### PR TITLE
modif sur formatter/wakka.php : syntaxe obsolète pour instanciation de classe.

### DIFF
--- a/formatters/wakka.php
+++ b/formatters/wakka.php
@@ -553,7 +553,9 @@ if (!class_exists('WikiniFormatter'))
 } // if !class_exists
 
 
-$form = & WikiniFormatter :: getInstance($this);
+//$form = & WikiniFormatter :: getInstance($this);
+$form = new WikiniFormatter($this);
+//$form->getInstance($this);
 echo $form->format($text);
 
 ?>


### PR DESCRIPTION
modif sur formatter/wakka.php : syntaxe obsolète pour instanciation de classe.
