### PR TITLE
Bug action logout avec reverseProxy

### DIFF
--- a/tools/login/actions/login.php
+++ b/tools/login/actions/login.php
@@ -70,7 +70,9 @@ $profileurl = $this->GetParameter('profileurl');
 // sauvegarde de l'url d'ou on vient
 $incomingurl = $this->GetParameter('incomingurl');
 if (empty($incomingurl)) {
-    $incomingurl = 'http'.((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? 's' : '') . '://' . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
+    //$incomingurl = 'http'.((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? 's' : '') . '://' . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
+    global $wiki;
+    $incomingurl = $wiki->getBaseUrl() . $_SERVER['REQUEST_URI'] ;
 }
 
 $userpage = $this->GetParameter("userpage");

--- a/tools/login/actions/login.php
+++ b/tools/login/actions/login.php
@@ -70,9 +70,7 @@ $profileurl = $this->GetParameter('profileurl');
 // sauvegarde de l'url d'ou on vient
 $incomingurl = $this->GetParameter('incomingurl');
 if (empty($incomingurl)) {
-    //$incomingurl = 'http'.((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? 's' : '') . '://' . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
-    global $wiki;
-    $incomingurl = $wiki->getBaseUrl() . $_SERVER['REQUEST_URI'] ;
+    $incomingurl = $this->getBaseUrl() . $_SERVER['REQUEST_URI'] ;
 }
 
 $userpage = $this->GetParameter("userpage");


### PR DESCRIPTION
Dans une configuration où le serveur avec php est derrière un proxy l'url pour login/logout était fausse, elle était construite à partir du HTTP_HOST qui est faux dans le cas d'un reverseProxy.