### PR TITLE
Corrige lien inscription sur contrôle d'accès 

### DIFF
--- a/tools/login/actions/login.php
+++ b/tools/login/actions/login.php
@@ -55,8 +55,8 @@ include_once 'tools/login/libs/login.functions.php';
 
 // url d'inscription
 $signupurl = $this->GetParameter('signupurl');
-// si pas de pas d'url d'inscription renseignée, on utilise ParametresUtilisateur
-if (empty($signupurl) && $signupurl != "0") {
+// si pas d'url d'inscription renseignée, on utilise ParametresUtilisateur
+if (empty($signupurl) || $signupurl === "0") {
     $signupurl = $this->href("", "ParametresUtilisateur", "");
 } else {
     if ($this->IsWikiName($signupurl, WN_CAMEL_CASE_EVOLVED)) {


### PR DESCRIPTION
Si on empêche l'accès à une page wiki, le lien "S'inscrire" sur la page "Accès réservé" n'est pas le bon.
Problème identifié sur le wiki du GL Bergerac.
