### PR TITLE
Disable wiki links option

### DIFF
--- a/formatters/wakka.php
+++ b/formatters/wakka.php
@@ -350,7 +350,7 @@ if (!class_exists('\YesWiki\WikiniFormatter')) {
                         return $wiki->Link($thing);
                     }
                     // wiki links!
-                    elseif (preg_match('`^' . WN_WIKI_LINK . '`u', $thing)) {
+                    elseif (!$wiki->GetConfigValue('disable_wiki_links', false) && preg_match('`^' . WN_WIKI_LINK . '`u', $thing)) {
                         return $wiki->Link($thing);
                     }
                     // separators

--- a/includes/YesWikiInit.php
+++ b/includes/YesWikiInit.php
@@ -165,6 +165,7 @@ class Init
             'default_comment_acl' => '@admins',
             'preview_before_save' => 0,
             'allow_raw_html' => false,
+            'disable_wiki_links' => false,
             'timezone'=>'GMT' // Only used if not set in wakka.config.php nor in php.ini
         );
         unset($_rewrite_mode);


### PR DESCRIPTION
Ajoute une nouvelle option `disable_wiki_links` qui ne transforme pas en lien les WikiLinks.

`false` par défaut.