### PR TITLE
Contact from

### DIFF
--- a/includes/email.inc.php
+++ b/includes/email.inc.php
@@ -51,17 +51,23 @@ function send_mail($mail_sender, $name_sender, $mail_receiver, $subject, $messag
         $mail->isSendmail();
     }
 
-    //Set who the message is to be sent from
-    if (empty($name_sender)) {
-        $name_sender = $mail_sender;
-    }
-    $mail->setFrom($mail_sender, $name_sender);
     //Set an alternative reply-to address
     if (!empty($GLOBALS['wiki']->config['contact_reply_to'])) {
         $mail->addReplyTo($GLOBALS['wiki']->config['contact_reply_to']);
     } else {
         $mail->addReplyTo($mail_sender, $name_sender);
     }
+    // Set always the same 'from' address (to avoid spam, it's a good practice to set the from field with an address from
+    // the same domain than the sending mail server)
+    if (!empty($GLOBALS['wiki']->config['contact_from'])) {
+        $mail_sender = $GLOBALS['wiki']->config['contact_from'];
+    }
+    //Set who the message is to be sent from
+    if (empty($name_sender)) {
+        $name_sender = $mail_sender;
+    }
+    $mail->setFrom($mail_sender, $name_sender);
+
     //Set who the message is to be sent to
     $mail->addAddress($mail_receiver, $mail_receiver);
     //Set the subject line

--- a/tools/bazar/libs/bazar.js
+++ b/tools/bazar/libs/bazar.js
@@ -410,23 +410,23 @@ $(document).ready(function () {
   });
 
   // cocher / decocher tous
-  var $checkboxselectall = $('.selectall');
-  $checkboxselectall.click(function (event) {
+  var checkboxselectall = $('.selectall');
+  checkboxselectall.click(function (event) {
     var $this = $(this);
     var target = $this.parents('.controls').find('.yeswiki-checkbox');
     if ($this.data('target')) {
-      $target = $($this.data('target'));
+      target = $($this.data('target'));
     }
 
     if (this.checked) { // check select status
-      $target.each(function () {
+      target.each(function () {
         $(this).find(':checkbox').prop('checked', true);
-        $checkboxselectall.prop('checked', true);
+        $(this).prop('checked', true);
       });
     } else {
-      $target.each(function () {
+      target.each(function () {
         $(this).find(':checkbox').prop('checked', false);
-        $checkboxselectall.prop('checked', false);
+        $(this).prop('checked', false);
       });
     }
   });

--- a/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
+++ b/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
@@ -2194,9 +2194,10 @@ function checkboxfiche(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
                 $GLOBALS['wiki']->AddJavascript($script);
                 $checkbox_html .= '<input type="text" name="'.$id.'" class="yeswiki-input-entries yeswiki-input-entries'.$id.'">';
             } else {
-                $checkbox_html.= '<input type="text" class="pull-left filter-entries" value="" placeholder="'.
+                $checkbox_filter = '<input type="text" class="pull-left filter-entries" value="" placeholder="'.
                     _t('BAZAR_FILTER').'"><label class="pull-right"><input type="checkbox" class="selectall" /> '.
-                    _t('BAZAR_CHECKALL') . '</label>' . "\n" . '<div class="clearfix"></div>' . "\n" .
+                    _t('BAZAR_CHECKALL') . '</label>' . "\n" . '<div class="clearfix"></div>' . "\n";
+                $checkbox_html.= (count($checkboxtab) > $GLOBALS['wiki']->config['BAZ_MAX_CHECKBOXLISTE_SANS_FILTRE'] ? $checkbox_filter : '') .
                     '<ul class="list-bazar-entries list-unstyled">';
                 foreach ($checkboxtab as $key => $label) {
                     $checkbox_html.= '<div class="yeswiki-checkbox checkbox">

--- a/tools/bazar/presentation/styles/bazar.css
+++ b/tools/bazar/presentation/styles/bazar.css
@@ -448,7 +448,7 @@ ul.list-sortables li, ul.valeur_formulaire li {list-style-type:none; padding:0; 
     column-count: 3;
 }
 .entries-list, .list-bazar-entries {
-	height:200px;
+	max-height: 200px;
 	overflow: auto;
 }
 .entries-list .yeswiki-checkbox {width:100% !important;}

--- a/tools/bazar/wiki.php
+++ b/tools/bazar/wiki.php
@@ -203,6 +203,8 @@ $wakkaConfig['BAZ_MODE_DIVISION'] = getConfigValue('BAZ_MODE_DIVISION', 'Jumping
 // Le nombre de page a afficher avant le 'next';
 $wakkaConfig['BAZ_DELTA'] = getConfigValue('BAZ_DELTA', 12, $wakkaConfig);
 
+// Le nombre maximum de fiches affichées par checkboxliste sans que les champs 'Filter' et 'Cocher tout' ne soient affichés
+$wakkaConfig['BAZ_MAX_CHECKBOXLISTE_SANS_FILTRE'] = getConfigValue('BAZ_MAX_CHECKBOXLISTE_SANS_FILTRE', 6, $wakkaConfig);
 
 //=========================== PARAMETRAGE GOOGLE MAP API ===========================
 // parametres pour la carto google


### PR DESCRIPTION
Permet la configuration d'un champ 'contact_from' dans le wakka.config.php qui fixe un champ 'from' pour tous les mails envoyés par bazar. Le champ 'reply-to' est alors ajouté avec l'adresse de l'utilisateur qui envoie le message.
Cela permet d'éviter que certains mails soient reconnus en tant que spam car les fournisseurs de mail s'attendent à ce que l'adresse du champ 'from' soient du même nom de domaine que le serveur dont provient le mail.
