### PR TITLE
Add the possibility to have default opened panel inside an accordion

### DIFF
--- a/tools/templates/actions/panel.php
+++ b/tools/templates/actions/panel.php
@@ -17,9 +17,9 @@ if (empty($class)) {
     $class = 'panel-default';
 }
 
-// collapsed: initial state is collasped, and the panel is collaspible
+// collapsed: initial state is collapsed, and the panel is collaspible
 // collaspsible: initial state is displayed, and the panel is collaspible
-// empty: initial state is displayed, and the panel is not collapsable
+// empty: initial state is displayed, and the panel is not collapsible
 $type = $this->GetParameter('type');
 if (empty($type)) {
     $type = '';
@@ -42,8 +42,14 @@ if ($GLOBALS['check_' . $pagetag]['panel']) {
     $collapseID = uniqid('collapse');
     if (isset($GLOBALS['check_'.$pagetag]['accordion_uniqueID'])) {
         $accordionID = $GLOBALS['check_'.$pagetag]['accordion_uniqueID'];
+        $collapsible = ($type == "collapsible");
+        if ($collapsible && !isset($GLOBALS['check_'.$pagetag]['accordion_collapsible'])){
+            $collapsed = false;
+            $GLOBALS['check_'.$pagetag]['accordion_collapsible'] = true;
+        } else {
+            $collapsed = true;
+        }
         $collapsible = true;
-        $collapsed = true;
     } else {
         $accordionID = '';
     }
@@ -62,7 +68,7 @@ if ($GLOBALS['check_' . $pagetag]['panel']) {
 
     if ($collapsible) {
         $result .= " data-toggle=\"collapse\" href=\"#$collapseID\" aria-controls=\"$collapseID\"
-         aria-expanded='" . ($collasped ? "true" : "false") . "'";
+         aria-expanded='" . ($collapsed ? "true" : "false") . "'";
     }
     $result .= ">";
     $result .= "


### PR DESCRIPTION
Quand les panels sont dans un accordion, on est obligé d'avoir tous les panels fermés par défaut.
J'avais besoin de pouvoir avoir un panel ouvert par défaut, je me suis permis de rajouter cette possibilité.
Il est maintenant possible de spécifier un type=collapsible sur le panel qu'on veut voir ouvrir par défaut. Si plusieurs type=collapsible sont définis au sein d'un même accordion, seul le premier sera ouvert par défaut (pour garantir le comportement d'un accordion même en cas d'erreur dans l'écriture des actions).