### PR TITLE
Fix HTML5 tags

### DIFF
--- a/tools/templates/actions/panel.php
+++ b/tools/templates/actions/panel.php
@@ -17,8 +17,8 @@ if (empty($class)) {
     $class = 'panel-default';
 }
 
-// collapsed: initial state is collapsed, and the panel is collaspible
-// collaspsible: initial state is displayed, and the panel is collaspible
+// collapsed: initial state is collapsed, and the panel is collapsible
+// collapsible: initial state is displayed, and the panel is collapsible
 // empty: initial state is displayed, and the panel is not collapsible
 $type = $this->GetParameter('type');
 if (empty($type)) {
@@ -62,13 +62,12 @@ if ($GLOBALS['check_' . $pagetag]['panel']) {
     }
 
     $result = "<!-- start of panel -->"
-    . "<div class=\"panel $class\" $data>
-      <div class=\"panel-heading " . ($collapsed ? "collapsed" : "") ."\" role=\"tab\" id=\"$headingID\" role=\"button\"";
-    if (!empty($accordionID)) $result .= " data-parent=\"#$accordionID\"";
+        . "<div class=\"panel $class\" $data>
+      <div class=\"panel-heading " . ($collapsed ? "collapsed" : "") ."\" id=\"$headingID\"";
 
     if ($collapsible) {
-        $result .= " data-toggle=\"collapse\" href=\"#$collapseID\" aria-controls=\"$collapseID\"
-         aria-expanded='" . ($collapsed ? "true" : "false") . "'";
+        $result .= " role=\"tab\" data-toggle=\"collapse\"" . (!empty($accordionID) ? " data-parent=\"#$accordionID\"" : "")
+            . " href=\"#$collapseID\" aria-expanded=\"" . ($collapsed ? "false" : "true") . "\" aria-controls=\"$collapseID\"";
     }
     $result .= ">";
     $result .= "
@@ -76,8 +75,8 @@ if ($GLOBALS['check_' . $pagetag]['panel']) {
            $title
           </h4>
       </div>
-      <div id=\"$collapseID\" class=\"panel-collapse collapse " . ($collapsed ? "" : "in") ."\"
-        aria-expanded='" . ($collapsed ? "true" : "false") ."' role=\"tabpanel\" aria-labelledby=\"$headingID\">
+      <div id=\"$collapseID\" class=\"panel-collapse collapse " . ($collapsed ? "" : "in") . "\" role=\"tabpanel\""
+        . " aria-labelledby=\"$headingID\">
         <div class=\"panel-body\">";
 
     echo $result;


### PR DESCRIPTION
Suite de l'autre PR "Add the possibility to have default opened panel inside an accordion"

Cf commentaires de cette PR
J'en ai profité pour réajuster les balises, le soucis était surtout sur "aria-expanded" qui était renseigné avec le mauvais booléen.
Quand on passera à Bootstrap 4, mieux vaudra réécrire le panel-heading avec un <button> à l'intérieur.

Nécessite un dernier test et vous pouvez merger.
