### PR TITLE
[include] fix the bug of tag name after an include

### DIFF
--- a/tools/attach/actions/__include.php
+++ b/tools/attach/actions/__include.php
@@ -4,7 +4,7 @@
 	        die ("acc&egrave;s direct interdit");
 	}
 
-	$oldpage = $this->GetPageTag();
+	$oldpage = $this->page['tag'];
 	$this->tag = trim($this->GetParameter('page'));
 	$this->page = $this->LoadPage($this->tag);
 ?>


### PR DESCRIPTION
c'était bien un soucis d'include comme tu le préssentais @mrflos
le soucis apparaîssait seulement quand un template liste plusieurs fiches du même type
