### PR TITLE
Title fix

### DIFF
--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -2930,9 +2930,8 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
             // write also a link to the user profile when the parameter ''bazar_user_entry_id' is defined in the config file
             // and an bazar entry corresponding to his username exists
             // TODO once the integration of login-sso is done, replace the $this->LoadPage with the function bazarUserEntryExists
-            if (!empty($GLOBALS['wiki']->config['sso_config']) && isset($GLOBALS['wiki']->config['sso_config']['bazar_user_entry_id']) &&
-                    $GLOBALS['wiki']->LoadPage($GLOBALS['wiki']->GetPageOwner($idfiche)))
-               $profilLink = true;
+            $profilLink = (!empty($GLOBALS['wiki']->config['sso_config']) && isset($GLOBALS['wiki']->config['sso_config']['bazar_user_entry_id']) &&
+                    $GLOBALS['wiki']->LoadPage($GLOBALS['wiki']->GetPageOwner($idfiche)));
 
             $fichebazar['infos'] .= ', ' . _t('BAZ_ECRITE') . ' ' . ($profilLink ?
                     $GLOBALS['wiki']->Format('[[' . $GLOBALS['wiki']->GetPageOwner($idfiche) . ' ' .

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -2920,9 +2920,8 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
         $fichebazar['infos'] .= '</div><!-- /.BAZ_actions_fiche -->'."\n";
 
         // Nom de la PageWiki de la fiche
-        $fichebazar['infos'] .= '<span class="BAZ_main_fiche_info">' . $GLOBALS['wiki']->Format('[['. $idfiche . ' ' . $idfiche . ']]')
-            . ' <span class="category">(' . $fichebazar['form']['bn_label_nature']
-            . ')</span>';
+        $fichebazar['infos'] .= '<span class="BAZ_main_fiche_info"><a href="' . $GLOBALS['wiki']->href('', $idfiche) . '">'
+            . $idfiche . '</a> <span class="category">(' . $fichebazar['form']['bn_label_nature'] . ')</span>';
 
         $owner = $GLOBALS['wiki']->GetPageOwner($idfiche);
         // Owner (if exist and does not looks like an Ip address)

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -2920,19 +2920,28 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
         $fichebazar['infos'] .= '</div><!-- /.BAZ_actions_fiche -->'."\n";
 
         // Nom de la PageWiki de la fiche
-        $fichebazar['infos'] .= $GLOBALS['wiki']->Format($idfiche)
-            .' <span class="category">('.$fichebazar['form']['bn_label_nature']
-            .')</span>';
+        $fichebazar['infos'] .= '<span class="BAZ_main_fiche_info">' . $GLOBALS['wiki']->Format('[['. $idfiche . ' ' . $idfiche . ']]')
+            . ' <span class="category">(' . $fichebazar['form']['bn_label_nature']
+            . ')</span>';
 
         $owner = $GLOBALS['wiki']->GetPageOwner($idfiche);
         // Owner (if exist and does not looks like an Ip address)
         if ($owner != '' && preg_replace('/([0-9]|\.)/', '', $owner) != '') {
-            $fichebazar['infos'] .= ', '._t('BAZ_ECRITE').' '.$GLOBALS['wiki']->GetPageOwner($idfiche);
+            // write also a link to the user profile when the parameter ''bazar_user_entry_id' is defined in the config file
+            // and an bazar entry corresponding to his username exists
+            // TODO once the integration of login-sso is done, replace the $this->LoadPage with the function bazarUserEntryExists
+            if (!empty($GLOBALS['wiki']->config['sso_config']) && isset($GLOBALS['wiki']->config['sso_config']['bazar_user_entry_id']) &&
+                    $GLOBALS['wiki']->LoadPage($GLOBALS['wiki']->GetPageOwner($idfiche)))
+               $profilLink = true;
+
+            $fichebazar['infos'] .= ', ' . _t('BAZ_ECRITE') . ' ' . ($profilLink ?
+                    $GLOBALS['wiki']->Format('[[' . $GLOBALS['wiki']->GetPageOwner($idfiche) . ' ' .
+                        $GLOBALS['wiki']->GetPageOwner($idfiche) . ']]') : $GLOBALS['wiki']->GetPageOwner($idfiche));
         }
 
         // Created at
         $fichebazar['infos'] .=
-            '<br><span class="date_creation">'._t('BAZ_DATE_CREATION').' '
+            '</span><br><span class="date_creation">'._t('BAZ_DATE_CREATION').' '
             .strftime('%d.%m.%Y &agrave; %H:%M', strtotime($fichebazar['values']['date_creation_fiche'])).
             '</span>';
         // Updated At (only if different from created at)

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -2695,7 +2695,7 @@ function show($val, $label = '', $class = 'field', $tag = 'p', $fiche = '')
             $form = array_shift($form);
             $html = $func($dummy, $form, 'html', $fiche);
             preg_match_all(
-                '/<span class="BAZ_texte">\s*(.*)\s*<\/span>/Uim',
+                '/<span class="BAZ_texte">\s*(.*)\s*<\/span>/is',
                 $html,
                 $matches
             );
@@ -2832,7 +2832,7 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
                             $fichebazar['values']
                         );
                         preg_match_all(
-                            '/<span class="BAZ_texte">\s*(.*)\s*<\/span>/Uim',
+                            '/<span class="BAZ_texte">\s*(.*)\s*<\/span>/is',
                             $html[$id],
                             $matches
                         );

--- a/tools/templates/actions/metarobots.php
+++ b/tools/templates/actions/metarobots.php
@@ -30,7 +30,9 @@ if ($this->GetMethod() != 'show') {
       .$this->config['wakka_name'].'" />'."\n";
     $title = htmlspecialchars(getTitleFromBody($this->page), ENT_COMPAT | ENT_HTML5);
     if ($title) {
-        echo '  <meta property="og:title" content="'.$title.'" />'."\n";
+        echo '  <meta property="og:title" content="' . $title . '" />'."\n";
+    } else {
+        echo '  <meta property="og:title" content="' . $GLOBALS['wiki']->config['wakka_name'] . '" />'."\n";
     }
     $desc = htmlspecialchars(getDescriptionFromBody($this->page), ENT_COMPAT | ENT_HTML5);
     if ($desc) {

--- a/tools/templates/actions/titrepage.php
+++ b/tools/templates/actions/titrepage.php
@@ -3,5 +3,10 @@ if (!defined("WIKINI_VERSION"))
 {
         die ("acc&egrave;s direct interdit");
 }
-echo $this->GetWakkaName()." : ".$this->GetPageTag();
+
+$title = htmlspecialchars(getTitleFromBody($this->page), ENT_COMPAT | ENT_HTML5);
+if ($title)
+    echo $title;
+else
+    echo $this->GetPageTag();
 ?>

--- a/tools/templates/libs/templates.functions.php
+++ b/tools/templates/libs/templates.functions.php
@@ -779,7 +779,6 @@ function getImageFromBody($page, $width, $height)
 
     return $image;
 }
-
 /**
  * Get the first title in page
  *
@@ -809,7 +808,7 @@ function getTitleFromBody($page)
         }
     }
 
-    return empty($title) ? $GLOBALS['wiki']->config['wakka_name'] : strip_tags($title);
+    return empty($title) ? '' : strip_tags($title);
 }
 
 /**


### PR DESCRIPTION
Fix : the action titrepage returns the title with getTitleFromBody instead of the page name

Pour que ce soit pris en compte par le thème, il faut remplacer {{currentpage}} par {{titrepage}} dans 1col.tpl.html, 2cols-left.tpl.html, 2cols-right.tpl.html.

Je peux commiter ces modif dans le thème margot.