### PR TITLE
Better summernote

### DIFF
--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -2930,9 +2930,8 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
             // write also a link to the user profile when the parameter ''bazar_user_entry_id' is defined in the config file
             // and an bazar entry corresponding to his username exists
             // TODO once the integration of login-sso is done, replace the $this->LoadPage with the function bazarUserEntryExists
-            if (!empty($GLOBALS['wiki']->config['sso_config']) && isset($GLOBALS['wiki']->config['sso_config']['bazar_user_entry_id']) &&
-                    $GLOBALS['wiki']->LoadPage($GLOBALS['wiki']->GetPageOwner($idfiche)))
-               $profilLink = true;
+            $profilLink = (!empty($GLOBALS['wiki']->config['sso_config']) && isset($GLOBALS['wiki']->config['sso_config']['bazar_user_entry_id']) &&
+                    $GLOBALS['wiki']->LoadPage($GLOBALS['wiki']->GetPageOwner($idfiche)));
 
             $fichebazar['infos'] .= ', ' . _t('BAZ_ECRITE') . ' ' . ($profilLink ?
                     $GLOBALS['wiki']->Format('[[' . $GLOBALS['wiki']->GetPageOwner($idfiche) . ' ' .

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -2920,9 +2920,8 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
         $fichebazar['infos'] .= '</div><!-- /.BAZ_actions_fiche -->'."\n";
 
         // Nom de la PageWiki de la fiche
-        $fichebazar['infos'] .= '<span class="BAZ_main_fiche_info">' . $GLOBALS['wiki']->Format('[['. $idfiche . ' ' . $idfiche . ']]')
-            . ' <span class="category">(' . $fichebazar['form']['bn_label_nature']
-            . ')</span>';
+        $fichebazar['infos'] .= '<span class="BAZ_main_fiche_info"><a href="' . $GLOBALS['wiki']->href('', $idfiche) . '">'
+            . $idfiche . '</a> <span class="category">(' . $fichebazar['form']['bn_label_nature'] . ')</span>';
 
         $owner = $GLOBALS['wiki']->GetPageOwner($idfiche);
         // Owner (if exist and does not looks like an Ip address)

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -2920,19 +2920,28 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
         $fichebazar['infos'] .= '</div><!-- /.BAZ_actions_fiche -->'."\n";
 
         // Nom de la PageWiki de la fiche
-        $fichebazar['infos'] .= $GLOBALS['wiki']->Format($idfiche)
-            .' <span class="category">('.$fichebazar['form']['bn_label_nature']
-            .')</span>';
+        $fichebazar['infos'] .= '<span class="BAZ_main_fiche_info">' . $GLOBALS['wiki']->Format('[['. $idfiche . ' ' . $idfiche . ']]')
+            . ' <span class="category">(' . $fichebazar['form']['bn_label_nature']
+            . ')</span>';
 
         $owner = $GLOBALS['wiki']->GetPageOwner($idfiche);
         // Owner (if exist and does not looks like an Ip address)
         if ($owner != '' && preg_replace('/([0-9]|\.)/', '', $owner) != '') {
-            $fichebazar['infos'] .= ', '._t('BAZ_ECRITE').' '.$GLOBALS['wiki']->GetPageOwner($idfiche);
+            // write also a link to the user profile when the parameter ''bazar_user_entry_id' is defined in the config file
+            // and an bazar entry corresponding to his username exists
+            // TODO once the integration of login-sso is done, replace the $this->LoadPage with the function bazarUserEntryExists
+            if (!empty($GLOBALS['wiki']->config['sso_config']) && isset($GLOBALS['wiki']->config['sso_config']['bazar_user_entry_id']) &&
+                    $GLOBALS['wiki']->LoadPage($GLOBALS['wiki']->GetPageOwner($idfiche)))
+               $profilLink = true;
+
+            $fichebazar['infos'] .= ', ' . _t('BAZ_ECRITE') . ' ' . ($profilLink ?
+                    $GLOBALS['wiki']->Format('[[' . $GLOBALS['wiki']->GetPageOwner($idfiche) . ' ' .
+                        $GLOBALS['wiki']->GetPageOwner($idfiche) . ']]') : $GLOBALS['wiki']->GetPageOwner($idfiche));
         }
 
         // Created at
         $fichebazar['infos'] .=
-            '<br><span class="date_creation">'._t('BAZ_DATE_CREATION').' '
+            '</span><br><span class="date_creation">'._t('BAZ_DATE_CREATION').' '
             .strftime('%d.%m.%Y &agrave; %H:%M', strtotime($fichebazar['values']['date_creation_fiche'])).
             '</span>';
         // Updated At (only if different from created at)

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -2695,7 +2695,7 @@ function show($val, $label = '', $class = 'field', $tag = 'p', $fiche = '')
             $form = array_shift($form);
             $html = $func($dummy, $form, 'html', $fiche);
             preg_match_all(
-                '/<span class="BAZ_texte">\s*(.*)\s*<\/span>/Uim',
+                '/<span class="BAZ_texte">\s*(.*)\s*<\/span>/is',
                 $html,
                 $matches
             );
@@ -2832,7 +2832,7 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
                             $fichebazar['values']
                         );
                         preg_match_all(
-                            '/<span class="BAZ_texte">\s*(.*)\s*<\/span>/Uim',
+                            '/<span class="BAZ_texte">\s*(.*)\s*<\/span>/is',
                             $html[$id],
                             $matches
                         );

--- a/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
+++ b/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
@@ -1044,11 +1044,19 @@ function textelong(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
                 [\'color\', [\'color\']],
                 [\'para\', [\'ul\', \'ol\', \'paragraph\']],
                 [\'insert\', [\'hr\', \'link\', \'table\', \'picture\', \'video\']],
-                [\'misc\', [\'fullscreen\', \'codeview\']]
+                //[\'misc\', [\'fullscreen\', \'codeview\']]
             ],
-            styleTags: [\'h1\', \'h2\', \'h3\', \'h4\', \'h5\', \'h6\', \'p\', \'blockquote\', \'pre\'],
+            isNotSplitEdgePoint : true,
+            styleTags: [\'h3\', \'h4\', \'h5\', \'h6\', \'p\', \'blockquote\', \'pre\'],
             oninit: function() {
               //$(\'button[data-original-title=Style]\').prepend("Style").find("i").remove();
+            },
+            callbacks: {
+                onPaste: function (e) {
+                    var bufferText = ((e.originalEvent || e).clipboardData || window.clipboardData).getData(\'Text\');
+                    e.preventDefault();
+                    document.execCommand(\'insertText\', false, bufferText);
+                }
             }
           });
         });';

--- a/tools/templates/actions/metarobots.php
+++ b/tools/templates/actions/metarobots.php
@@ -30,7 +30,9 @@ if ($this->GetMethod() != 'show') {
       .$this->config['wakka_name'].'" />'."\n";
     $title = htmlspecialchars(getTitleFromBody($this->page), ENT_COMPAT | ENT_HTML5);
     if ($title) {
-        echo '  <meta property="og:title" content="'.$title.'" />'."\n";
+        echo '  <meta property="og:title" content="' . $title . '" />'."\n";
+    } else {
+        echo '  <meta property="og:title" content="' . $GLOBALS['wiki']->config['wakka_name'] . '" />'."\n";
     }
     $desc = htmlspecialchars(getDescriptionFromBody($this->page), ENT_COMPAT | ENT_HTML5);
     if ($desc) {

--- a/tools/templates/actions/titrepage.php
+++ b/tools/templates/actions/titrepage.php
@@ -3,5 +3,10 @@ if (!defined("WIKINI_VERSION"))
 {
         die ("acc&egrave;s direct interdit");
 }
-echo $this->GetWakkaName()." : ".$this->GetPageTag();
+
+$title = htmlspecialchars(getTitleFromBody($this->page), ENT_COMPAT | ENT_HTML5);
+if ($title)
+    echo $title;
+else
+    echo $this->GetPageTag();
 ?>

--- a/tools/templates/libs/templates.functions.php
+++ b/tools/templates/libs/templates.functions.php
@@ -779,7 +779,6 @@ function getImageFromBody($page, $width, $height)
 
     return $image;
 }
-
 /**
  * Get the first title in page
  *
@@ -809,7 +808,7 @@ function getTitleFromBody($page)
         }
     }
 
-    return empty($title) ? $GLOBALS['wiki']->config['wakka_name'] : strip_tags($title);
+    return empty($title) ? '' : strip_tags($title);
 }
 
 /**


### PR DESCRIPTION
- mise à jour de la librairie avec la dernière version
- plus de h1/h2 dans les styles (dans le rendu de la fiche h1/h2 cassent la hiérarchie des champs)
- plus de bouton html et grand écran
- les copier/coller prennent dorénavant que le contenu (et non le formatage html)
- suppression de certaines balises <p><br></p> inutiles dans le contenu


+ sur le thème, à intégrer à margot :  rendu des boutons plus petits et sans gras

```
/* style for summernote text area | tools/bazar/libs/vendor/summernote/summernote.min.js */

.summernote button.note-btn {
    font-weight: normal;
    padding: 5px 10px;
    font-size: 15px;
}
```

Il reste une amélioration à faire mais je n'ai pas pris le temps de chercher où on pouvait insérer le code. Cela concerne lorsqu'on enregistre un contenu vide, summernote met un <p><br/></p>. J'ai cherché autour de ce soucis, et j'ai déjà pu déjà rajouté l'option `isNotSplitEdgePoint : true` car sinon il en rajoute un peu partout. Et pour le cas de la chaîne vide, le mieux il semblerait est de le gérer nous-même. C'est à dire qu'à la soumission du formulaire, il faudrait détecter qu'on est dans le cadre d'un textelong de type html et supprimer cette chaîne de caractère quand elle est seule.
