### PR TITLE
Lecteur vidéo intégré pour les fichiers mp4, webm et flv

### DIFF
--- a/tools/attach/actions/attach.class.php
+++ b/tools/attach/actions/attach.class.php
@@ -78,6 +78,10 @@ if (!class_exists('attach')) {
                 $this->attachConfig["ext_audio"] = "mp3";
             }
 
+            if (empty($this->attachConfig["ext_video"])) {
+                $this->attachConfig["ext_video"] = "mp4|webm|ogg";
+            }
+
             if (empty($this->attachConfig["ext_wma"])) {
                 $this->attachConfig["ext_wma"] = "wma";
             }
@@ -241,7 +245,7 @@ if (!class_exists('attach')) {
             //decompose le nom du fichier en nom+extension
             if (preg_match('`^(.*)\.(.*)$`', str_replace(' ', '_', $this->file), $match)) {
                 list(, $file['name'], $file['ext']) = $match;
-                if (!$this->isPicture() && !$this->isAudio() && !$this->isFreeMindMindMap() && !$this->isWma() && !$this->isFlashvideo()) {
+                if (!$this->isPicture() && !$this->isAudio() && !$this->isVideo() && !$this->isFreeMindMindMap() && !$this->isWma() && !$this->isFlashvideo()) {
                     $file['ext'] .= '_';
                 }
             } else {
@@ -298,6 +302,13 @@ if (!class_exists('attach')) {
         public function isAudio()
         {
             return preg_match("/.(" . $this->attachConfig["ext_audio"] . ")$/i", $this->file) == 1;
+        }
+        /**
+         * Test si le fichier est un fichier vidéo
+         */
+        public function isVideo()
+        {
+            return preg_match("/.(" . $this->attachConfig["ext_video"] . ")$/i", $this->file) == 1;
         }
         /**
          * Test si le fichier est un fichier freemind mind map
@@ -549,10 +560,21 @@ if (!class_exists('attach')) {
             echo '<a href="' . $url . '">' . ($this->desc ? $this->desc : $this->file) . "</a>";
             $this->showUpdateLink();
         }
+        // Affiche le fichier liee comme un fichier video
+        public function showAsVideo($fullFilename)
+        {
+            $output = $this->wiki->format(
+                '{{player url="'.$this->wiki->getBaseUrl().'/'.$fullFilename.'" type="video" '.
+                'height="'.(!empty($height) ? $height : '300px').'" '.
+                'width="'.(!empty($width) ? $width : '400px').'"}}'
+            );
+            echo $output;
+            $this->showUpdateLink();
+        }
         // Affiche le fichier liee comme un fichier audio
         public function showAsAudio($fullFilename)
         {
-            $output = $this->wiki->format('{{player url="'.$this->wiki->getBaseUrl().'/'.$fullFilename.'"}}');
+            $output = $this->wiki->format('{{player url="'.$this->wiki->getBaseUrl().'/'.$fullFilename.'" type="audio"}}');
             echo $output;
             $this->showUpdateLink();
         }
@@ -572,18 +594,6 @@ if (!class_exists('attach')) {
         // Affiche le fichier liee comme un fichier mind map  freemind
         public function showAsWma($fullFilename)
         {
-        }
-
-        // Affiche le fichier liee comme une video flash
-        public function showAsFlashvideo($fullFilename)
-        {
-            $output = $this->wiki->format(
-                '{{player url="'.$this->wiki->getBaseUrl().'/'.$fullFilename.'" '.
-                'height="'.(!empty($height) ? $height : '300px').'" '.
-                'width="'.(!empty($width) ? $width : '400px').'"}}'
-            );
-            echo $output;
-            $this->showUpdateLink();
         }
 
         // End Paste
@@ -624,12 +634,12 @@ if (!class_exists('attach')) {
             //le fichier existe : affichage en fonction du type
             if ($this->isPicture()) {
                 $this->showAsImage($fullFilename);
+            } elseif ($this->isVideo() || $this->isFlashvideo()) {
+                $this->showAsVideo($fullFilename);
             } elseif ($this->isAudio()) {
                 $this->showAsAudio($fullFilename);
             } elseif ($this->isFreeMindMindMap()) {
                 $this->showAsFreeMindMindMap($fullFilename);
-            } elseif ($this->isFlashvideo()) {
-                $this->showAsFlashvideo($fullFilename);
             } elseif ($this->isWma()) {
                 $this->showAsWma($fullFilename);
             } else {

--- a/tools/attach/actions/attach.class.php
+++ b/tools/attach/actions/attach.class.php
@@ -71,11 +71,11 @@ if (!class_exists('attach')) {
             }
 
             if (empty($this->attachConfig["ext_images"])) {
-                $this->attachConfig["ext_images"] = "gif|jpeg|png|jpg|svg";
+                $this->attachConfig["ext_images"] = "gif|jpeg|png|jpg|svg|webp";
             }
 
             if (empty($this->attachConfig["ext_audio"])) {
-                $this->attachConfig["ext_audio"] = "mp3";
+                $this->attachConfig["ext_audio"] = "mp3|aac";
             }
 
             if (empty($this->attachConfig["ext_video"])) {

--- a/tools/attach/actions/player.php
+++ b/tools/attach/actions/player.php
@@ -31,6 +31,8 @@ if (!defined("WIKINI_VERSION")) {
 }
 
 $url = $this->GetParameter('url');
+$type = $this->getParameter('type');
+
 if (!empty($url)) {
     $height = $this->GetParameter('height');
     if (empty($height)) $height = "300px";
@@ -39,7 +41,7 @@ if (!empty($url)) {
     if (empty($width)) $width = "400px";
 
     $extension = strtolower(substr(strrchr($url, '.'), 1));
-    if ($extension=="mp3" || $extension=="m4a") {
+    if ($type=="audio" || $extension=="mp3" || $extension=="m4a") {
         if (!isset($GLOBALS['jplayer'])) {
             $GLOBALS['jplayer'] = 1;
             $this->AddJavascriptFile('tools/attach/libs/vendor/jplayer/jquery.jplayer.min.js');
@@ -89,7 +91,7 @@ if (!empty($url)) {
 });'."\n";
         $this->AddJavascript($script);
 
-        $output = '
+        $output = '<div id="jp_wrapper_'.$GLOBALS['jplayer'].'" class="jp-wrapper" role="application" aria-label="audio player">
             <div id="jquery_jplayer_'.$GLOBALS['jplayer'].'" class="jp-jplayer"></div>
             <div id="jp_container_'.$GLOBALS['jplayer'].'" class="jp-audio">
                 <div class="btn-group btn-group-sm no-dblclick">
@@ -106,12 +108,94 @@ if (!empty($url)) {
                     </span>
                     <a href="#" class="jp-unmute btn btn-default btn-small"><i class="fa fa-volume-off icon-volume-off"></i></a>
                     <a href="#" class="jp-mute btn btn-default btn-small" style="display: none;"><i class="fa fa-volume-up icon-volume-up"></i></a>
-                    <a href="'.$url.'" title="'._t('ATTACH_DOWNLOAD_THE_FILE').' : '.($url).'" class="btn btn-default btn-small"><i class="fa fa-download-alt icon-download-alt"></i></a>
+                    <a href="'.$url.'" rel="download" title="'._t('ATTACH_DOWNLOAD_THE_FILE').' : '.($url).'" class="btn btn-default btn-small"><i class="fa fa-download-alt icon-download-alt"></i></a>
                 </div>
-            </div>';
+            </div>
+          </div>';
         echo $output;
-    } elseif ($extension=="webm" || $extension=="mp4" || $extension=="ogg" || $extension=="flv") {
-        //todo jplayer video
+    } elseif ($type=="video" || $extension=="webm" || $extension=="mp4" || $extension=="ogg" || $extension=="flv") {
+        if (!isset($GLOBALS['jplayer'])) {
+            $GLOBALS['jplayer'] = 1;
+            $this->AddJavascriptFile('tools/attach/libs/vendor/jplayer/jquery.jplayer.min.js');
+        }
+        else {
+            $GLOBALS['jplayer']++;
+        }
+        switch ($extension) {
+          case 'flv': $playbackFormat = 'flv'; break;
+          case 'ogg': $playbackFormat = 'ogv'; break;
+          case 'webmv': $playbackFormat = 'webmv'; break;
+          case 'mp4':
+          default:
+            $playbackFormat = 'm4v';
+          break;
+        }
+
+        $script = '$(document).ready(function(){
+    // Local copy of jQuery selectors, for performance.
+    var	my_jPlayer = $("#jquery_jplayer_'.$GLOBALS['jplayer'].'"),
+        my_playbtn = $("#jp_container_'.$GLOBALS['jplayer'].' .jp-play"),
+        my_pausebtn = $("#jp_container_'.$GLOBALS['jplayer'].' .jp-pause"),
+        my_extraPlayInfo = $("#jp_container_'.$GLOBALS['jplayer'].' .extra-play-info");
+
+    // Change the time format
+    $.jPlayer.timeFormat.padMin = true;
+    $.jPlayer.timeFormat.padSec = true;
+    $.jPlayer.timeFormat.sepMin = ":";
+    $.jPlayer.timeFormat.sepSec = "";
+
+    $("#jquery_jplayer_'.$GLOBALS['jplayer'].'").jPlayer({
+        ready: function () {
+            $(this).jPlayer("setMedia", {
+                '.$playbackFormat.':"'.$url.'#t=0.1"
+            });
+        },
+        cssSelectorAncestor: "#jp_container_'.$GLOBALS['jplayer'].'",
+        swfPath: "tools/attach/libs/vendor/jplayer",
+        timeupdate: function(event) {
+            my_extraPlayInfo.css({width : parseInt(event.jPlayer.status.currentPercentAbsolute, 10) + "%"});
+        },
+        play: function(event) {
+            my_playbtn.before(my_pausebtn);
+            my_pausebtn.show();
+        },
+        pause: function(event) {
+            my_pausebtn.before(my_playbtn);
+            my_playbtn.show();
+        },
+        ended: function(event) {
+            my_pausebtn.before(my_playbtn);
+            my_playbtn.show();
+        },
+        supplied: "'.$playbackFormat.'",
+        preload: "auto",
+        wmode: "window"
+    });
+});'."\n";
+        $this->AddJavascript($script);
+
+        $output = '<div id="jp_wrapper_'.$GLOBALS['jplayer'].'" class="jp-wrapper" role="application" aria-label="media player">
+            <div id="jquery_jplayer_'.$GLOBALS['jplayer'].'" class="jp-jplayer"></div>
+            <div id="jp_container_'.$GLOBALS['jplayer'].'" class="jp-video">
+                <div class="btn-group btn-group-sm no-dblclick">
+                    <a href="#" class="jp-play btn btn-default btn-primary btn-small"><i class="fa fa-play icon-play icon-white"></i></a>
+                    <a href="#" class="jp-pause btn btn-default btn-primary btn-small" style="display:none"><i class="fa fa-pause icon-pause icon-white"></i></a>
+                    <a href="#" class="jp-stop btn btn-default btn-small"><i class="fa fa-stop icon-stop"></i></a>
+                    <span class="btn btn-default btn-small" style="width:140px; position:relative;">
+                        <span style="width:100%; text-align:center; z-index:2; position:absolute; left:0;">
+                            <span class="jp-current-time">00:00</span> / <span class="jp-duration">00:00</span>
+                        </span>
+                        <div class="progress" style="margin-top:-1px;margin-bottom:-1px;">
+                            <div class="bar extra-play-info" style="width: 0%;background: rgba(0, 0, 0, .2);height: 100%;"></div>
+                        </div>
+                    </span>
+                    <a href="#" class="jp-unmute btn btn-default btn-small"><i class="fa fa-volume-off icon-volume-off"></i></a>
+                    <a href="#" class="jp-mute btn btn-default btn-small" style="display: none;"><i class="fa fa-volume-up icon-volume-up"></i></a>
+                    <a href="'.$url.'" rel="download" title="'._t('ATTACH_DOWNLOAD_THE_FILE').' : '.($url).'" class="btn btn-default btn-small"><i class="fa fa-download-alt icon-download-alt"></i></a>
+                </div>
+            </div>
+          </div>';
+        echo $output;
     } elseif ($extension=="mm") {
         $output = '<embed id="visorFreeMind" height="'.$height.'" align="middle" width="'.$width.'" flashvars="openUrl=_blank&initLoadFile='.$url.'&startCollapsedToLevel=5" quality="high" bgcolor="#ffffff" src="tools/attach/players/visorFreemind.swf" type="application/x-shockwave-flash"/>';
         $output .="[<a href=\"$url\" title=\""._t('ATTACH_DOWNLOAD_THE_FILE')."\">mm</a>]";


### PR DESCRIPTION
## Description of pull request / Description de la demande d'ajout

J'ai fait 2 choses :

- ajout de la détection des formats vidéo dans le handler `{{ attach }}`
- ajout d'un player vidéo dans le handler `{{ player }}` — l'attribut `type` permettrait d'ailleurs de différencier un `.ogg` qui est audio, ou vidéo, en affichant le player adéquat

Le rendu actuel est un peu nul car il n'y a pas de poster qui s'affiche.

![image](https://user-images.githubusercontent.com/138627/92009274-8ef3ec00-ed48-11ea-965b-1224e321dd35.png)

Je ne connais pas trop jPlayer, il faudrait "juste" afficher la vidéo au lieu du poster en réglant la valeur de `width`/`height` sur l'objet `<video>`, ça ferait le taf.

![image](https://user-images.githubusercontent.com/138627/92009479-dd08ef80-ed48-11ea-8b35-12d274d40bac.png)


Ensuite y'aura plus qu'à améliorer l'affichage de la barre — elle ne suit pas la longueur de la vidéo ; c'est la limite d'utiliser un `.btn-group` de Bootstrap tel quel dans ce cas.

fixes #484