### PR TITLE
extraction of tag list fix + ok with '

### DIFF
--- a/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
+++ b/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
@@ -497,6 +497,14 @@ function listedatefin(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
  * @param    mixed   valeur par défaut du champs
  * @return   void
  */
+/** tags() - Ajoute un élément de type mot clés (tags)
+ *
+ * @param    mixed   L'objet QuickForm du formulaire
+ * @param    mixed   Le tableau des valeurs des différentes option pour l'élément texte
+ * @param    string  Type d'action pour le formulaire : saisie, modification, vue,... saisie par défaut
+ * @param    mixed   valeur par défaut du champs
+ * @return   void
+ */
 function tags(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
 {
     if ($mode == 'saisie') {
@@ -504,7 +512,7 @@ function tags(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
 
         //gestion des mots cles deja entres
         if (isset($valeurs_fiche[$tableau_template[1]])) {
-            $tags = explode(",", mysqli_real_escape_string($GLOBALS['wiki']->dblink, $valeurs_fiche[$tableau_template[1]]));
+            $tags = explode(",", str_replace('\'','&#39;', $valeurs_fiche[$tableau_template[1]]));
             if (is_array($tags)) {
                 sort($tags);
                 foreach ($tags as $tag) {
@@ -518,7 +526,8 @@ function tags(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
         $tab_tous_les_tags = $GLOBALS['wiki']->GetAllTags();
         if (is_array($tab_tous_les_tags)) {
             foreach ($tab_tous_les_tags as $tab_les_tags) {
-                $response[] = _convert($tab_les_tags['value'], 'ISO-8859-15');
+                // TODO why ISO-8859-15 ? fix the encoding ???
+                $response[] = _convert(str_replace('\'','&#39;', $tab_les_tags['value']), 'ISO-8859-15');
             }
         }
         sort($response);
@@ -577,7 +586,7 @@ function tags(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
         }
 
         //on decoupe les tags pour les mettre dans un tableau
-        $tags = explode(",", mysqli_real_escape_string($GLOBALS['wiki']->dblink, $valeurs_fiche[$tableau_template[1]]));
+        $tags = explode(",", $valeurs_fiche[$tableau_template[1]]);
 
         //on ajoute les tags postés
         foreach ($tags as $tag) {


### PR DESCRIPTION
Sans ces modifs, j'avais de soucis à l'affichage du champ d'édition du tag :
![image](https://user-images.githubusercontent.com/8435038/93768122-3d3cd400-fc19-11ea-9c83-85e1865cc046.png)

J'ai rajouté également la prise en compte du ' qui coupait systématiquement la chaîne de caractère utilisé pour le tag.

