### PR TITLE
Bazar field admin

### DIFF
--- a/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
+++ b/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
@@ -1179,7 +1179,9 @@ function textelong(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
             } elseif ($formatage == 'nohtml') {
                 $html .= htmlentities($valeurs_fiche[$identifiant], ENT_QUOTES, YW_CHARSET);
             } elseif ($formatage == 'html') {
-                $html .= str_replace('""','" "',$valeurs_fiche[$identifiant]);
+                // caution "" was replaced by '' otherwise in the case of a form inside a bazar entry, it's interpreted by
+                // wakka as a beginning of html code
+                $html .= str_replace('""','\'\'',$valeurs_fiche[$identifiant]);
             }
             $html .= '</span>' . "\n" . '</div> <!-- /.BAZ_rubrique -->' . "\n";
         }


### PR DESCRIPTION
Permet de paramétrer les droits en écriture sur les champs d'un formulaire bazar.

Il y a juste pour bf_titre que cela ne fonctionne pas (le formulaire ne se validait plus bien que je rajoute le champ avant l'insertion -> à investiguer davantage si on en a le besoin)
