### PR TITLE
Remove searchResultstoArray

### DIFF
--- a/tools/bazar/actions/bazarcarto.php
+++ b/tools/bazar/actions/bazarcarto.php
@@ -21,15 +21,15 @@ if (!defined('WIKINI_VERSION')) {
 $GLOBALS['params'] = getAllParameters($this);
 // tableau des fiches correspondantes aux critères
 if (is_array($GLOBALS['params']['idtypeannonce'])) {
-    $results = array();
+    $fiches = array();
     foreach ($GLOBALS['params']['idtypeannonce'] as $formId) {
-        $results = array_merge(
-            $results,
+        $fiches = array_merge(
+            $fiches,
             $bazarFiche->search(['queries' => $GLOBALS['params']['query'], 'formsIds' => [$formId]])
         );
     }
 } else {
-    $results = $bazarFiche->search(['queries' => $GLOBALS['params']['query']]);
+    $fiches = $bazarFiche->search(['queries' => $GLOBALS['params']['query']]);
 }
 
 // a la place du choix par défaut, on affiche en carte
@@ -38,4 +38,4 @@ if ($GLOBALS['params']['template'] == $GLOBALS['wiki']->config['default_bazar_te
 }
 
 // affichage à l'écran
-echo displayResultList($results, $GLOBALS['params'], false);
+echo displayResultList($fiches, $GLOBALS['params'], false);

--- a/tools/bazar/actions/bazarliste.php
+++ b/tools/bazar/actions/bazarliste.php
@@ -15,20 +15,20 @@ $GLOBALS['params'] = getAllParameters($this);
 
 // Get results
 if (is_array($GLOBALS['params']['idtypeannonce'])) {
-    $results = array();
+    $fiches = array();
     foreach ($GLOBALS['params']['idtypeannonce'] as $formId) {
-        $results = array_merge(
-            $results,
+        $fiches = array_merge(
+            $fiches,
             $bazarFiche->search(['queries' => $GLOBALS['params']['query'], 'formsIds' => [$formId]])
         );
     }
 } else {
-    $results = $bazarFiche->search(['queries' => $GLOBALS['params']['query']]);
+    $fiches = $bazarFiche->search(['queries' => $GLOBALS['params']['query']]);
 }
 
 // Render the view
 if (getParameter_boolean($this, 'search', false)) {
   echo baz_rechercher($GLOBALS['params']['idtypeannonce'], $GLOBALS['params']['categorienature']);
 } else {
-  echo displayResultList($results, $GLOBALS['params'], false);
+  echo displayResultList($fiches, $GLOBALS['params'], false);
 }

--- a/tools/bazar/actions/bazarlistecategorie.php
+++ b/tools/bazar/actions/bazarlistecategorie.php
@@ -82,40 +82,31 @@ if (empty($list)) {
     } else {
         $tabquery = '';
     }
-    $tableau_resultat = $bazarFiche->search([ 'queries' => $tabquery, 'formsIds' => [$id_typeannonce] ]);
+    $tabfiches = $bazarFiche->search([ 'queries' => $tabquery, 'formsIds' => [$id_typeannonce] ]);
 
     $fiches['info_res'] = '';
     $fiches['pager_links'] = '';
     $fiches['fiches'] = array();
-    foreach ($tableau_resultat as $fiche) {
-        //json = norme d'ecriture utilisée pour les fiches bazar (en utf8)
-        $valeurs_fiche = json_decode($fiche['body'], true);
-        if (YW_CHARSET != 'UTF-8') {
-            $valeurs_fiche = array_map('utf8_decode', $valeurs_fiche);
-        }
+    foreach ($tabfiches as $fiche) {
         // pour les checkbox, on crée une fiche par case cochée pour apparaitre é différents endroits
-        $tabcheckbox = explode(',', $valeurs_fiche[$id]);
+        $tabcheckbox = explode(',', $fiche[$id]);
         foreach ($tabcheckbox as $value) {
             // on sauve les multiples valeurs pour les retablir é l'affichage
-            $multiplecheckbox[$valeurs_fiche['id_fiche']] = $valeurs_fiche[$id];
-            $valeurs_fiche[$id] = $value;
+            $multiplecheckbox[$fiche['id_fiche']] = $fiche[$id];
+            $fiche[$id] = $value;
 
             // permet de voir la fiche
-            $valeurs_fiche['html'] = baz_voir_fiche(0, $valeurs_fiche);
+            $fiche['html'] = baz_voir_fiche(0, $fiche);
             // lien de suppression visible pour le super admin
-            if (baz_a_le_droit('supp_fiche', $valeurs_fiche['createur'])) {
-                $valeurs_fiche['lien_suppression'] = '<a class="btn-delete-page-confirm" href="'.
-                    $this->href('deletepage', $valeurs_fiche['id_fiche']).'"></a>'."\n";
+            if (baz_a_le_droit('supp_fiche', $fiche['createur'])) {
+                $fiche['lien_suppression'] = '<a class="btn-delete-page-confirm" href="'.$this->href('deletepage', $fiche['id_fiche']).'"></a>'."\n";
             }
-            if (baz_a_le_droit('modif_fiche', $valeurs_fiche['createur'])) {
-                $valeurs_fiche['lien_edition'] = '<a class="BAZ_lien_modifier" href="'.
-                    $this->href('edit', $valeurs_fiche['id_fiche']).'"></a>'."\n";
+            if (baz_a_le_droit('modif_fiche', $fiche['createur'])) {
+                $fiche['lien_edition'] = '<a class="BAZ_lien_modifier" href="'.$this->href('edit', $fiche['id_fiche']).'"></a>'."\n";
             }
-            $valeurs_fiche['lien_voir_titre'] = '<a class="BAZ_lien_modifier" href="'.
-                $this->href('', $valeurs_fiche['id_fiche']) .'">'.$valeurs_fiche['bf_titre'].'</a>'."\n";
-            $valeurs_fiche['lien_voir'] = '<a class="BAZ_lien_modifier" href="'.
-                $this->href('', $valeurs_fiche['id_fiche']) .'"></a>'."\n";
-            $fiches['fiches'][] = $valeurs_fiche;
+            $fiche['lien_voir_titre'] = '<a class="BAZ_lien_modifier" href="'.$this->href('', $fiche['id_fiche']) .'">'.$fiche['bf_titre'].'</a>'."\n";
+            $fiche['lien_voir'] = '<a class="BAZ_lien_modifier" href="'.$this->href('', $fiche['id_fiche']) .'"></a>'."\n";
+            $fiches['fiches'][] = $fiche;
         }
     }
     // trie par liste choisie

--- a/tools/bazar/handlers/page/__widget.php
+++ b/tools/bazar/handlers/page/__widget.php
@@ -57,7 +57,7 @@ if (isset($_GET['id'])) {
             );
         }
     } else {
-        $bazarFiche->search(['queries' => $params['query'], 'formsIds' => [$params['idtypeannonce']], 'keywords' => $q]);
+        $results = $bazarFiche->search(['queries' => $params['query'], 'formsIds' => [$params['idtypeannonce']], 'keywords' => $q]);
     }
     //$params['groups'][0] = 'all';
     //$results = searchResultstoArray($results, $params);

--- a/tools/bazar/libs/BazarFiche.class.php
+++ b/tools/bazar/libs/BazarFiche.class.php
@@ -42,7 +42,7 @@ class BazarFiche
         }
 
         // TODO call this function only when necessary
-        $this->addDisplayData($data, $semantic);
+        $this->appendDisplayData($data, $semantic);
 
         return $data;
     }
@@ -542,10 +542,10 @@ class BazarFiche
     }
 
     /*
-     * Add data needed for display
+     * Append data needed for display
      * TODO move this to a class dedicated to display
      */
-    public function addDisplayData(&$fiche, $semantic = false, $correspondance = '')
+    public function appendDisplayData(&$fiche, $semantic = false, $correspondance = '')
     {
         // champs correspondants
         if (!empty($correspondance)) {

--- a/tools/bazar/libs/BazarFiche.class.php
+++ b/tools/bazar/libs/BazarFiche.class.php
@@ -545,7 +545,7 @@ class BazarFiche
      * Add data needed for display
      * TODO move this to a class dedicated to display
      */
-    protected function addDisplayData(&$fiche, $semantic = false, $correspondance = '')
+    public function addDisplayData(&$fiche, $semantic = false, $correspondance = '')
     {
         // champs correspondants
         if (!empty($correspondance)) {

--- a/tools/bazar/libs/bazar.api.php
+++ b/tools/bazar/libs/bazar.api.php
@@ -60,18 +60,19 @@ function getFiche($args) {
         } else {
             $semantic = strpos($_SERVER['HTTP_ACCEPT'], 'application/ld+json') !== false || $args[1] === 'json-ld';
 
-            $data = $GLOBALS['bazarFiche']->getList([ 'formsIds'=>$args[0], 'semantic'=>$semantic ]);
+            $data = $GLOBALS['bazarFiche']->search([ 'formsIds'=>$args[0] ]);
 
             // Put data inside LDP container
             if( $semantic ) {
                 $form = baz_valeurs_formulaire($args[0]);
 
                 $data = [
-                    '@context' => $data[0]['@context'],
+                    '@context' => (array) json_decode($form['bn_sem_context']) ?: $form['bn_sem_context'],
                     '@id' => $GLOBALS['wiki']->href('fiche/' . $args[0], 'api'),
                     '@type' => [ 'ldp:Container', 'ldp:BasicContainer' ],
                     'dcterms:title' => $form['bn_label_nature'],
-                    'ldp:contains' => array_map(function($resource) {
+                    'ldp:contains' => array_map(function($fiche) {
+                        $resource = $GLOBALS['bazarFiche']->convertToSemanticData($fiche['id_typeannonce'], $fiche, true);
                         unset($resource['@context']);
                         return $resource;
                     }, $data)

--- a/tools/bazar/libs/bazar.api.php
+++ b/tools/bazar/libs/bazar.api.php
@@ -75,7 +75,7 @@ function getFiche($args) {
                         $resource = $GLOBALS['bazarFiche']->convertToSemanticData($fiche['id_typeannonce'], $fiche, true);
                         unset($resource['@context']);
                         return $resource;
-                    }, $data)
+                    }, array_values($data))
                 ];
             }
 

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -3127,7 +3127,7 @@ function displayResultList($tableau_fiches, $params, $info_nb = true, $formtab =
 
     // Add display data to all fiches
     $fiches['fiches'] = array_map(function($fiche) use($params) {
-        $GLOBALS['bazarFiche']->addDisplayData($fiche, false, $params['correspondance']);
+        $GLOBALS['bazarFiche']->appendDisplayData($fiche, false, $params['correspondance']);
         return $fiche;
     }, $tableau_fiches);
 

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -2569,8 +2569,11 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
                     }
                 }
             }
-            // Map les données HTML sur les propriétés sémantiques
-            baz_append_semantic_data($html, $fichebazar['form']['bn_id_nature'], false, true);
+            try {
+                $html['semantic'] = $GLOBALS['bazarFiche']->convertToSemanticData($fichebazar['form']['bn_id_nature'], $html, true);
+            } catch(\Exception $e) {
+                // Do nothing if semantic type is not available
+            }
             $fiche['html'] = $html;
             $fiche['fiche'] = $fichebazar['values'];
             $fiche['form'] = $fichebazar['form'];
@@ -3107,62 +3110,6 @@ function scanAllFacettable($fiches, $params, $formtab = '', $onlyLists = false)
     return $facettevalue;
 }
 
-function searchResultstoArray($tableau_fiches, $params, $formtab = '')
-{
-    // tableau qui contiendra les fiches
-    $fiches['fiches'] = array();
-    $exturl = $GLOBALS['wiki']->GetParameter('url');
-    foreach ($tableau_fiches as $fiche) {
-        if (isset($fiche['body'])) {
-            $fiche = json_decode($fiche['body'], true);
-            if (YW_CHARSET != 'UTF-8') {
-                $fiche = array_map('utf8_decode', $fiche);
-            }
-        }
-        if (is_array($fiche)) {
-            // champs correspondants
-            if (!empty($params['correspondance'])) {
-                $tabcorrespondances = array();
-                $tabcorrespondances = getMultipleParameters($params['correspondance'], ',', '=');
-                if ($tabcorrespondances['fail'] != 1) {
-                    foreach ($tabcorrespondances as $key=>$data) {
-                        if (isset($key)) {
-                            if (isset($data) && isset($fiche[$data])) {
-                                $fiche[$key] = $fiche[$data];
-                            } else {
-                                $fiche[$key] = '';
-                            }
-                        } else {
-                            echo '<div class="alert alert-danger">action bazarliste : parametre correspondance mal rempli : il doit etre de la forme correspondance="identifiant_1=identifiant_2" ou correspondance="identifiant_1=identifiant_2, identifiant_3=identifiant_4"</div>';
-                        }
-                    }
-                } else {
-                    echo '<div class="alert alert-danger">action bazarliste : le paramètre correspondance est mal rempli.<br />Il doit être de la forme correspondance="identifiant_1=identifiant_2" ou correspondance="identifiant_1=identifiant_2, identifiant_3=identifiant_4"</div>';
-                }
-            }
-            $fiche['html_data'] = getHtmlDataAttributes($fiche, $formtab);
-            $fiche['datastr'] = $fiche['html_data'];
-
-            // les fiches concernent un wiki externe
-            if (isset($exturl)) {
-                $arr = explode('/wakka.php', $exturl, 2);
-                $exturl = $arr[0];
-                $fiche['url'] = $exturl.'/wakka.php?wiki='.$fiche['id_fiche'];
-            } else {
-                $fiche['url'] = $GLOBALS['wiki']->href('', $fiche['id_fiche']);
-            }
-            //$fiche['html'] = baz_voir_fiche($params['barregestion'], $fiche);
-
-            // ajout des données sémantiques, s'il y en a
-            baz_append_semantic_data($fiche, $fiche['id_typeannonce'], false);
-
-            // tableau qui contient le contenu de toutes les fiches
-            $fiches['fiches'][$fiche['id_fiche']] = $fiche;
-        }
-    }
-    return $fiches['fiches'];
-}
-
 /**
  * Affiche la liste des resultats d'une recherche.
  *
@@ -3177,7 +3124,13 @@ function displayResultList($tableau_fiches, $params, $info_nb = true, $formtab =
     }
     ++$GLOBALS['_BAZAR_']['nbbazarliste'];
     $params['nbbazarliste'] = $GLOBALS['_BAZAR_']['nbbazarliste'];
-    $fiches['fiches'] = searchResultstoArray($tableau_fiches, $params, $formtab);
+
+    // Add display data to all fiches
+    $fiches['fiches'] = array_map(function($fiche) use($params) {
+        $GLOBALS['bazarFiche']->addDisplayData($fiche, false, $params['correspondance']);
+        return $fiche;
+    }, $tableau_fiches);
+
     // tri des fiches
     if ($params['random']) {
         shuffle($fiches['fiches']);
@@ -3487,7 +3440,6 @@ function baz_afficher_flux_RSS()
         'keywords'=>$q
     ]);
 
-    $tableau_flux_rss = searchResultstoArray($tableau_flux_rss, array());
     $GLOBALS['ordre'] = 'desc';
     $GLOBALS['champ'] = 'date_creation_fiche';
     usort($tableau_flux_rss, 'champCompare');
@@ -4203,66 +4155,6 @@ function getMultipleParameters($param, $firstseparator = ',', $secondseparator =
         $tabparam['fail'] = 1;
     }
     return $tabparam;
-}
-
-function baz_append_semantic_data(&$fiche, $idformulaire, $err_if_not_semantic, $is_html_formatted = false)
-{
-    $form = baz_valeurs_formulaire($idformulaire);
-    if (!$form['bn_sem_type']) {
-        if ($err_if_not_semantic) {
-            exit(_t('BAZAR_SEMANTIC_TYPE_MISSING'));
-        } else {
-            return null;
-        }
-    }
-
-    // If context is a JSON decode it, otherwise use the string
-    $output['@context'] = (array) json_decode($form['bn_sem_context']) ?: $form['bn_sem_context'];
-
-    // If we have multiple types split by comma, generate an array, otherwise use a string
-    $output['@type'] = strpos($form['bn_sem_type'], ',')
-        ? array_map(function ($str) {
-            return trim($str);
-        }, explode(',', $form['bn_sem_type']))
-        : $form['bn_sem_type'];
-
-    // Add the ID of the Bazar object
-    $output['@id'] = $GLOBALS['wiki']->href('', $fiche['id_fiche']);
-
-    $fields_infos = bazPrepareFormData($form);
-    foreach ($fields_infos as $field_info) {
-        // If the file is not semantically defined, ignore it
-        if ($field_info['sem_type']) {
-            $value = $fiche[$field_info['id']];
-            if ($value) {
-                // We don't want this additional formatting if we are already dealing with HTML-formatted data
-                if (!$is_html_formatted) {
-                    // If this is a file or image, add the base URL
-                    if ($field_info['type'] === 'file') {
-                        $value = $GLOBALS['wiki']->getBaseUrl() . "/" . BAZ_CHEMIN_UPLOAD . $value;
-                    }
-
-                    // If this is a linked entity (listefiche), use the URL
-                    if (startsWith($field_info['id'], 'listefiche')) {
-                        $value = $GLOBALS['wiki']->href('', $value);
-                    }
-                }
-
-                if (is_array($field_info['sem_type'])) {
-                    // If we have multiple fields, duplicate the data
-                    foreach ($field_info['sem_type'] as $sem_type) {
-                        $output[$sem_type] = $value;
-                    }
-                } else {
-                    $output[$field_info['sem_type']] = $value;
-                }
-            }
-        }
-    }
-
-    $fiche['semantic'] = $output;
-
-    return $output;
 }
 
 /**

--- a/tools/bazar/libs/bazar.fonct.retrocompatibility.php
+++ b/tools/bazar/libs/bazar.fonct.retrocompatibility.php
@@ -64,7 +64,7 @@ function searchResultstoArray($pages, $params, $formtab = '')
 
     foreach ($pages as $page) {
         $fiche = $GLOBALS['bazarFiche']->decode($page['body']);
-        $GLOBALS['bazarFiche']->addDisplayData($fiche, false, $params['correspondance']);
+        $GLOBALS['bazarFiche']->appendDisplayData($fiche, false, $params['correspondance']);
         $fiches[$fiche['id_fiche']] = $fiche;
     }
 

--- a/tools/bazar/libs/bazar.fonct.retrocompatibility.php
+++ b/tools/bazar/libs/bazar.fonct.retrocompatibility.php
@@ -54,3 +54,16 @@ function validateForm($data)
         return array('result' => false, 'error' => $e->getMessage());
     }
 }
+
+function searchResultstoArray($pages, $params, $formtab = '')
+{
+    $fiches = array();
+
+    foreach ($pages as $page) {
+        $fiche = $GLOBALS['bazarFiche']->decode($page['body']);
+        $GLOBALS['bazarFiche']->addDisplayData($fiche, false, $params['correspondance']);
+        $fiches[$fiche['id_fiche']] = $fiche;
+    }
+
+    return $fiches;
+}

--- a/tools/bazar/libs/bazar.fonct.retrocompatibility.php
+++ b/tools/bazar/libs/bazar.fonct.retrocompatibility.php
@@ -36,13 +36,16 @@ function baz_requete_recherche_fiches(
 {
     if( $id==='' ) $id = [];
 
-    return $GLOBALS['bazarFiche']->search([
+    $fiches = $GLOBALS['bazarFiche']->search([
         'queries' => $tableau_criteres,
         'formsIds' => $id, // Types de fiches (par ID de formulaire)
         'user' => $personne, // N'affiche que les fiches d'un utilisateur
         'keywords' => $q, // Mots-clés pour la recherche fulltext
         'searchOperator' => $facettesearch // Opérateur à appliquer aux mots-clés
     ]);
+
+    // Re-encode fiche as Wiki page
+    return array_map(function ($fiche) { return ['body' => json_encode($fiche)]; }, $fiches);
 }
 
 function validateForm($data)


### PR DESCRIPTION
- `BazarFiche::search` retourne maintenant les résultats en JSON plutôt que les pages Wiki non-décodées
- `searchResultstoArray` est déprécié car il ne sert plus à rien (mis dans le fichier retrocompatibility)
- `baz_append_semantic_data` est remplacé par `BazarFiche::convertToSemanticData`