### PR TITLE
fix-btn-bazar-form-builder

### DIFF
--- a/tools/bazar/presentation/styles/form-edit-template.css
+++ b/tools/bazar/presentation/styles/form-edit-template.css
@@ -112,3 +112,38 @@
 }
 
 xmp { overflow: auto; }
+/* Apply icon- class only for form, defined in form-builder-min*/
+[class*=" icon-"]::before, [class^="icon-"]::before {
+    font-family: initial;
+    font-style: initial;
+    font-weight: initial;
+    speak: initial;
+    display: initial;
+    text-decoration: initial;
+    width: initial;
+    margin-right: initial;
+    text-align: initial;
+    font-variant: initial;
+    text-transform: initial;
+    line-height: initial;
+    margin-left: initial;
+    -webkit-font-smoothing: initial;
+    -moz-osx-font-smoothing: initial;
+}
+#formulaire [class*=" icon-"]::before, #formulaire [class^="icon-"]::before {
+    font-family: form-builder-font;
+    font-style: normal;
+    font-weight: 400;
+    speak: none;
+    display: inline-block;
+    text-decoration: inherit;
+    width: 1em;
+    margin-right: .2em;
+    text-align: center;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1em;
+    margin-left: .2em;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}


### PR DESCRIPTION
lors de la modification d'un formulaire bazar, certains bouton comme fa-cog roue crantée ne s'affichent pas
Proposition de modifier le css pour cloisonner la portée de la class icon uniquement dans le formulaire
