### PR TITLE
fix btn bazar form builder

### DIFF
--- a/tools/bazar/presentation/styles/form-edit-template.css
+++ b/tools/bazar/presentation/styles/form-edit-template.css
@@ -112,3 +112,18 @@
 }
 
 xmp { overflow: auto; }
+
+/* Redefine .fa class when icon- class exists, because redefined by form-builder.min.js*/
+.fa[class*=" icon-"]::before, .fa[class^="icon-"]::before {
+  font-family: inherit;
+  font-weight: inherit;
+  font-style: inherit;
+  margin: 0;
+  font-variant: inherit;
+  line-height: inherit;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  width: inherit;
+  text-transform: inherit;
+}
+	


### PR DESCRIPTION
lors de la modification d'un formulaire bazar, certains bouton comme fa-cog roue crantée ne s'affichent pas
Proposition de modifier le css pour cloisonner la portée de la class icon uniquement dans le formulaire