### PR TITLE
fix form builder and date display

### DIFF
--- a/tools/bazar/presentation/javascripts/form-edit-template.js
+++ b/tools/bazar/presentation/javascripts/form-edit-template.js
@@ -178,7 +178,7 @@ var typeUserAttrs = {
     },
     send_form_content_to_this_email: {
       label: "Envoyer le contenu du formulaire à cet email",
-      options: { "": "Non", "1": "Oui" }
+      options: { "1": "Oui", " ": "Non" }
     },
     // searchable: searchableConf, -> 10/19 Florian say that this conf is not working for now
     read: readConf,
@@ -192,7 +192,7 @@ var typeUserAttrs = {
   date: {
     today_button: {
       label: "Initialiser à Aujourd'hui",
-      options: { "": "Non", "today": "Oui" }
+      options: { " ": "Non", "today": "Oui" }
     },
     read: readConf,
     write: writeconf,

--- a/tools/bazar/presentation/styles/bazar.css
+++ b/tools/bazar/presentation/styles/bazar.css
@@ -457,15 +457,31 @@ ul.list-sortables li, ul.valeur_formulaire li {list-style-type:none; padding:0; 
   min-height: auto;
 }
 
-.bazar-date  {width: 150px !important;}
+/* BAZAR DATE FIELD */
+.bazar-date, .bazar-date.form-control {
+  width: 133px ;
+}
+.form-group.date .controls {
+  display: flex;  
+}
+@media (max-width: 600px) {
+  .form-group.date .controls {
+    flex-wrap: wrap;
+  }
+  .form-group.date .select-time {
+    width: 100%;
+    margin: 1rem 0 0 0;
+  }
+}
+.select-hour, .select-minutes {
+  width: 76px !important;
+}
 input::-webkit-calendar-picker-indicator{
-    display: none;
+  display: none;
 }
 input[type="date"]::-webkit-input-placeholder{
-    visibility: hidden !important;
+  visibility: hidden !important;
 }
-.select-allday {width: 180px !important;}
-.select-hour, .select-minutes {width: 76px !important;}
 
 /*!
  * Datepicker for Bootstrap v1.7.1 (https://github.com/uxsolutions/bootstrap-datepicker)


### PR DESCRIPTION
For form builder, solve trouble of standard options for champs_mail and date : this is not "" but " "
For champs_mail, standard behaviour "do not send e-mail"
For display of date, responsive behaviour.

