### PR TITLE
Fix rss display

### DIFF
--- a/tools/bazar/actions/linkrss__.php
+++ b/tools/bazar/actions/linkrss__.php
@@ -7,13 +7,15 @@ if (!defined("WIKINI_VERSION")) {
 $liste = '';
 $resultat = baz_valeurs_formulaire() ;
 
-if (is_array($resultat) && count($resultat)>0) {
-    foreach ($resultat as $form) {
-        $liste .= '  <link rel="alternate" type="application/rss+xml" '
-          .'title="'.htmlspecialchars($form['bn_label_nature']).'" '
-          .'href="'.$this->href('rss', $this->getPageTag(), 'id_typeannonce='.$form['bn_id_nature']).'">'."\n";
-    }
-}
+if ($this->CheckModuleACL('rss', 'handler')) {
+	if (is_array($resultat) && count($resultat)>0) {
+		foreach ($resultat as $form) {
+			$liste .= '  <link rel="alternate" type="application/rss+xml" '
+			  .'title="'.htmlspecialchars($form['bn_label_nature']).'" '
+			  .'href="'.$this->href('rss', $this->getPageTag(), 'id='.$form['bn_id_nature']).'">'."\n";
+		}
+	}
 
-echo '  <link rel="alternate" type="application/rss+xml" title="'.htmlspecialchars(_t('BAZ_FLUX_RSS_GENERAL')).'" '
-  .'href="'.$this->href('rss').'">'."\n".$liste;
+	echo '  <link rel="alternate" type="application/rss+xml" title="'.htmlspecialchars(_t('BAZ_FLUX_RSS_GENERAL')).'" '
+	  .'href="'.$this->href('rss').'">'."\n".$liste;
+}

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -3382,6 +3382,9 @@ function baz_afficher_flux_RSS()
     if (isset($_GET['id'])) {
         $id = $_GET['id'];
         $urlrss .= '&amp;id='.$id;
+    } elseif (isset($_GET['id_typeannonce'])) {
+        $id = $_GET['id_typeannonce'];
+        $urlrss .= '&amp;id='.$id;
     } else {
         $id = '';
     }

--- a/tools/templates/actions/linkrss.php
+++ b/tools/templates/actions/linkrss.php
@@ -3,7 +3,17 @@ if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
 }
 
-echo "\n".
-'  <!-- RSS links -->'."\n".
-'  <link rel="alternate" type="application/rss+xml" title="'._t('TEMPLATE_RSS_LAST_CHANGES').'" href="'.$this->href('xml', 'DerniersChangementsRSS').'" />'."\n".
-'  <link rel="alternate" type="application/rss+xml" title="'._t('TEMPLATE_RSS_LAST_COMMENTS').'" href="'.$this->href('xml', 'DerniersCommentairesRSS').'" />'."\n";
+$displayLastChanges = $this->HasAccess('read', 'DerniersChangementsRSS') ;
+$displayLastComments = $this->HasAccess('read', 'DerniersCommentairesRSS') ;
+
+if ($displayLastChanges || $displayLastComments) {
+	echo "\n".
+	'  <!-- RSS links -->'."\n" ;
+}
+if ($displayLastChanges) {
+	echo '  <link rel="alternate" type="application/rss+xml" title="'._t('TEMPLATE_RSS_LAST_CHANGES').'" href="'.$this->href('xml', 'DerniersChangementsRSS').'" />'."\n";
+}
+if ($displayLastComments) {
+	echo '  <link rel="alternate" type="application/rss+xml" title="'._t('TEMPLATE_RSS_LAST_COMMENTS').'" href="'.$this->href('xml', 'DerniersCommentairesRSS').'" />'."\n";
+}
+?>

--- a/tools/templates/actions/linkrss.php
+++ b/tools/templates/actions/linkrss.php
@@ -3,8 +3,8 @@ if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
 }
 
-$displayLastChanges = $this->HasAccess('read', 'DerniersChangementsRSS') ;
-$displayLastComments = $this->HasAccess('read', 'DerniersCommentairesRSS') ;
+$displayLastChanges = $this->HasAccess('read', 'DerniersChangementsRSS') && !(empty($this->LoadPage('DerniersChangementsRSS')['tag'])) ;
+$displayLastComments = $this->HasAccess('read', 'DerniersCommentairesRSS') && !(empty($this->LoadPage('DerniersCommentairesRSS')['tag'])) ;
 
 if ($displayLastChanges || $displayLastComments) {
 	echo "\n".


### PR DESCRIPTION
- Lorsqu'on bloque le handler RSS pour éviter des fuites de donner personnelles, il existe toujours la liste des flux RSS dans les en-têtes HTML.
Ce fix permet de retirer la liste des flux RSS vers les formulaires dans ce cas.

- Correction de l'en-tête RSS pour utiliser id au lieu de id_typeannonce.
- Ajout dans bazar fonc de la retrocompatibilité avec id_typeannonce.
- Ce fix retire l'affichage des en-têtes DerniersChangements si l'utilisateur courant n'a pas les accès aux pages en questions.

