### PR TITLE
fix acls at fiche creation

### DIFF
--- a/includes/services/PageManager.php
+++ b/includes/services/PageManager.php
@@ -198,14 +198,20 @@ class PageManager
         if ($rights) {
             // is page new?
             if (!$oldPage = $this->getOne($tag)) {
+				
+				// LoadACL (if defined by acls)
+				$defaultWrite = $this->wiki->LoadAcl($tag, 'write', true)['list'] ;
+				$defaultRead = $this->wiki->LoadAcl($tag, 'read', true)['list'];
+				$defaultComment = $this->wiki->LoadAcl($tag, 'comment', true)['list'] ;
+				
                 // create default write acl. store empty write ACL for comments.
-                $this->wiki->SaveAcl($tag, 'write', ($comment_on ? $user : $this->params->get('default_write_acl')));
+                $this->wiki->SaveAcl($tag, 'write', ($comment_on ? $user : $defaultWrite));
 
                 // create default read acl
-                $this->wiki->SaveAcl($tag, 'read', $this->params->get('default_read_acl'));
+                $this->wiki->SaveAcl($tag, 'read', $defaultRead);
 
                 // create default comment acl.
-                $this->wiki->SaveAcl($tag, 'comment', ($comment_on ? '' : $this->params->get('default_comment_acl')));
+                $this->wiki->SaveAcl($tag, 'comment', ($comment_on ? '' : $defaultComment));
 
                 // current user is owner; if user is logged in! otherwise, no owner.
                 if ($this->wiki->GetUser()) {

--- a/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
+++ b/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
@@ -1723,16 +1723,17 @@ function acls(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
         if ($comment == 'user' or $comment == '#') {
             $comment = $valeurs_fiche['nomwiki'];
         }
-        // hack pour que SavePage ne re-ecrit pas les droits avec les valeurs par défaut
-        $GLOBALS['wiki']->pageCache[$valeurs_fiche['id_fiche']]['body'] = $valeurs_fiche;
-        $GLOBALS['wiki']->pageCache[$valeurs_fiche['id_fiche']]['tag'] = $valeurs_fiche['id_fiche'];
-        $GLOBALS['wiki']->pageCache[$valeurs_fiche['id_fiche']]['owner'] = (isset($valeurs_fiche['nomwiki']) ? $valeurs_fiche['nomwiki'] : $valeurs_fiche['createur']);
-        $GLOBALS['wiki']->pageCache[$valeurs_fiche['id_fiche']]['comment_on'] = '';
-
+        
         // on sauve les acls
-        $GLOBALS['wiki']->SaveAcl($valeurs_fiche['id_fiche'], 'read', $read);
-        $GLOBALS['wiki']->SaveAcl($valeurs_fiche['id_fiche'], 'write', $write);
-        $GLOBALS['wiki']->SaveAcl($valeurs_fiche['id_fiche'], 'comment', $comment);
+		if (empty($GLOBALS['wiki']->LoadAcl($valeurs_fiche['id_fiche'], 'read', false)['list'])){
+            $GLOBALS['wiki']->SaveAcl($valeurs_fiche['id_fiche'], 'read', $read);
+        }
+        if (empty($GLOBALS['wiki']->LoadAcl($valeurs_fiche['id_fiche'], 'write', false)['list'])){
+            $GLOBALS['wiki']->SaveAcl($valeurs_fiche['id_fiche'], 'write', $write);
+        }
+        if (empty($GLOBALS['wiki']->LoadAcl($valeurs_fiche['id_fiche'], 'comment', false)['list'])){
+            $GLOBALS['wiki']->SaveAcl($valeurs_fiche['id_fiche'], 'comment', $comment);
+        }
     }
 }
 


### PR DESCRIPTION
Avant : 
- la création d'un fiche dans un formulaire ne tient pas compte des paramètres du champ acls
- la modification d'une fiche change les acl pour correspondre aux acls du champ acls même si on les a changé à la main.

Après: 
- la création d'un fiche dans un formulaire tient compte des paramètres du champ acls
- la modification d'une fiche ne change pas les acl pour correspondre aux acls du champ acls et conserve les acls changéses à la main

NB : j'ai encore utilisé LoadPage, ... désolé je n'arrive pas correctement à maîtriser les nouvelles fonctions. Ça va venir.