### PR TITLE
Fix export import csv + acl

### DIFF
--- a/includes/services/PageManager.php
+++ b/includes/services/PageManager.php
@@ -198,14 +198,20 @@ class PageManager
         if ($rights) {
             // is page new?
             if (!$oldPage = $this->getOne($tag)) {
+				
+				// LoadACL (if defined by acls)
+				$defaultWrite = $this->wiki->LoadAcl($tag, 'write', true)['list'] ;
+				$defaultRead = $this->wiki->LoadAcl($tag, 'read', true)['list'];
+				$defaultComment = $this->wiki->LoadAcl($tag, 'comment', true)['list'] ;
+				
                 // create default write acl. store empty write ACL for comments.
-                $this->wiki->SaveAcl($tag, 'write', ($comment_on ? $user : $this->params->get('default_write_acl')));
+                $this->wiki->SaveAcl($tag, 'write', ($comment_on ? $user : $defaultWrite));
 
                 // create default read acl
-                $this->wiki->SaveAcl($tag, 'read', $this->params->get('default_read_acl'));
+                $this->wiki->SaveAcl($tag, 'read', $defaultRead);
 
                 // create default comment acl.
-                $this->wiki->SaveAcl($tag, 'comment', ($comment_on ? '' : $this->params->get('default_comment_acl')));
+                $this->wiki->SaveAcl($tag, 'comment', ($comment_on ? '' : $defaultComment));
 
                 // current user is owner; if user is logged in! otherwise, no owner.
                 if ($this->wiki->GetUser()) {

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -849,23 +849,51 @@ function baz_afficher_formulaire_export()
                 if ($tabindex[0] == 'radio' || $tabindex[0] == 'liste' || $tabindex[0] == 'checkbox'
                     || $tabindex[0] == 'listefiche' || $tabindex[0] ==
                     'checkboxfiche') {
-                    // ???  FIXME ?
-                    $toto = 'dummy';
-                    $html = $tabindex[0](
-                        $toto,
-                        array(
-                            0 => $tabindex[0],
-                            1 => $tabindex[1],
-                            2 => '',
-                            6 => $tabindex[2],
-                        ),
-                        'html',
-                        array($index => isset($fiche[$index]) ?
-                            $fiche[$index] : '', )
-                    );
-                    $tabhtml = explode('</span>', $html);
-                    $fiche[$index] = isset($tabhtml[1]) ?
-                    html_entity_decode(trim(strip_tags($tabhtml[1]))) : '';
+                        
+                    // liste ou fiche
+                    if ($tabindex[0] == 'radio' || $tabindex[0] == 'liste' || $tabindex[0] == 'checkbox') {
+                        
+                        $values_liste = baz_valeurs_liste($tabindex[1]);
+
+                        $tabresult = isset($fiche[$index]) ? explode(',', $fiche[$index]) : null ;
+                        if (is_array($tabresult)) {
+                            $labels_result = '';
+                            foreach ($tabresult as $id) {
+                                $res_value = $values_liste["label"][$id] ;
+                                if (isset($res_value)) {
+                                    if (strpos($res_value,',') !== false) {
+                                        $res_value = '"' .$res_value . '"' ;
+                                    }
+                                    if ($labels_result == '') {
+                                        $labels_result = $res_value;
+                                    } else {
+                                        $labels_result.= ', ' . $res_value;
+                                    }
+                                }
+                            }
+                            $fiche[$index] = $labels_result ;
+                        }
+                    } else {
+                        $tabresult = isset($fiche[$index]) ? explode(',', $fiche[$index]) : null ;
+                        if (is_array($tabresult)) {
+                            $labels_result = '';
+                            foreach ($tabresult as $id) {
+                                $val_fiche = $GLOBALS['wiki']->services->get(FicheManager::class)->getOne($id);
+                                if (is_array($val_fiche)) {
+                                    $res_value = $val_fiche['bf_titre'] ;
+                                    if (strpos($res_value,',') !== false) {
+                                        $res_value = '"' .$res_value . '"' ;
+                                    }
+                                    if ($labels_result == '') {
+                                        $labels_result = $res_value;
+                                    } else {
+                                        $labels_result.= ', ' . $res_value;
+                                    }
+                                }
+                            }
+                            $fiche[$index] = $labels_result ;
+                        }
+                    }
                 }
 
                 // si la valeur existe, on l'affiche
@@ -877,6 +905,8 @@ function baz_afficher_formulaire_export()
                     if ($tabindex[0] == 'image' || $tabindex[0] == 'fichier') {
                         $fiche[$index] = $GLOBALS['wiki']->getBaseUrl() . '/' . BAZ_CHEMIN_UPLOAD . $fiche[$index];
                     }
+                    $fiche[$index] = str_replace("\n", "\\n", $fiche[$index]);
+                    $fiche[$index] = str_replace("\r", "\\r", $fiche[$index]);
                     $tab_csv[] = html_entity_decode(
                         '"'.str_replace('"', '""', $fiche[$index]).'"'
                     );
@@ -901,7 +931,7 @@ function baz_afficher_formulaire_export()
 
         //on cree le lien vers ce fichier
         $output .=
-        '<a href="#" onclick="downloadCSV($(\'.precsv\').text(), \'export-bazar-'.$id.'.csv\');return false;" class="btn btn-neutral link-csv-file">'.
+        '<a href="#" onclick="downloadCSV($(\'.precsv\').html(), \'export-bazar-'.$id.'.csv\');return false;" class="btn btn-neutral link-csv-file">'.
         '<i class="fa fa-download"></i>'.
         _t('BAZ_TELECHARGER_FICHIER_EXPORT_CSV').'</a>'."\n";
     } else {

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -938,9 +938,10 @@ function baz_afficher_formulaire_export()
                             foreach ($tabresult as $id) {
                                 $res_value = $values_liste["label"][$id] ;
                                 if (isset($res_value)) {
-                                    if (strpos($res_value,',') !== false && $tabindex[0] == 'checkbox') {
-                                        //  for checkbox if value contains ',' add '"' before and after
-                                        $res_value = '"' . $res_value . '"' ;
+                                    if ((strpos($res_value,',') !== false || substr($res_value,0,1) == '"' )
+                                            && $tabindex[0] == 'checkbox') {
+                                        //  for checkbox if value contains ',' or begin with '"' add '"' before and after
+                                        $res_value = (strpos($res_value,'",') === false) ? '"' . $res_value . '"' : $id ;
                                     }
                                     if ($labels_result == '') {
                                         $labels_result = $res_value;

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -296,11 +296,17 @@ function baz_afficher_formulaire_import()
                                             $type_champ[$c] == 'radio') &&
                                             !empty($data[$c])) {
                                             if ($type_champ[$c] == 'liste' || $type_champ[$c] == 'radio') {
+                                                
+                                                //remove '"'
+                                                $data[$c] = trim($data[$c],'"') ;
+                                            
                                                 $idval = array_search(
                                                     $data[$c],
                                                     $alllists[strtolower($idliste_champ[$nom_champ[$c]])]['label']
                                                 );
-                                                if ((! $idval) && (is_numeric($data[$c]))) {
+                                                if ((! $idval) && (is_numeric($data[$c]) || 
+                                                        array_key_exists($data[$c],
+                                                        $alllists[strtolower($idliste_champ[$nom_champ[$c]])]['label']))) {
                                                     $idval = $data[$c] ;
                                                 }
                                             } elseif ($type_champ[$c] ==
@@ -316,7 +322,11 @@ function baz_afficher_formulaire_import()
                                                     if (is_numeric($value)) {
                                                         $tab_id[] = $value ;
                                                     } else {
-                                                        $tab_id[] = array_search($value, $refList);
+                                                        $res = array_search($value, $refList);
+                                                        if ($res === false && array_key_exists($value, $refList)) {
+                                                            $res = $value;
+                                                        }
+                                                        $tab_id[] = $res ;
                                                     }
                                                 }
                                                 $idval = implode(',', $tab_id);
@@ -344,6 +354,11 @@ function baz_afficher_formulaire_import()
                                                     $value,
                                                     $allentries[$id]
                                                 );
+                                                if ($idval === false && array_key_exists(
+                                                        $value,
+                                                        $allentries[$id])) {
+                                                    $idval = $value;
+                                                }
                                                 $tab_id[] = $idval;
                                             }
                                             $idval = implode(',', $tab_id);
@@ -862,7 +877,8 @@ function baz_afficher_formulaire_export()
                                 $res_value = $values_liste["label"][$id] ;
                                 if (isset($res_value)) {
                                     if (strpos($res_value,',') !== false) {
-                                        $res_value = '"' .$res_value . '"' ;
+                                        // if contains ',' add '"' for liste and radio or give id for checkbox
+                                        $res_value = ($tabindex[0] == 'checkbox') ? $id : '"' .$res_value . '"' ;
                                     }
                                     if ($labels_result == '') {
                                         $labels_result = $res_value;
@@ -882,7 +898,8 @@ function baz_afficher_formulaire_export()
                                 if (is_array($val_fiche)) {
                                     $res_value = $val_fiche['bf_titre'] ;
                                     if (strpos($res_value,',') !== false) {
-                                        $res_value = '"' .$res_value . '"' ;
+                                        // to manage name with coma, gives id
+                                        $res_value =  $id  ;
                                     }
                                     if ($labels_result == '') {
                                         $labels_result = $res_value;
@@ -905,8 +922,6 @@ function baz_afficher_formulaire_export()
                     if ($tabindex[0] == 'image' || $tabindex[0] == 'fichier') {
                         $fiche[$index] = $GLOBALS['wiki']->getBaseUrl() . '/' . BAZ_CHEMIN_UPLOAD . $fiche[$index];
                     }
-                    $fiche[$index] = str_replace("\n", "\\n", $fiche[$index]);
-                    $fiche[$index] = str_replace("\r", "\\r", $fiche[$index]);
                     $tab_csv[] = html_entity_decode(
                         '"'.str_replace('"', '""', $fiche[$index]).'"'
                     );

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -620,7 +620,7 @@ function baz_afficher_formulaire_import()
                 $csv = '';
                 foreach ($tableau as $ligne) {
                     if ($ligne[0] != 'labelhtml') {
-                        if ($ligne[0] == 'liste' || $ligne[0] == 'checkbox' ||
+                        if ($ligne[0] == 'liste' || $ligne[0] == 'checkbox' || $ligne[0] == 'radio' ||
                             $ligne[0] == 'listefiche' || $ligne[0] ==
                             'checkboxfiche') {
                             $csv .= _convert(

--- a/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
+++ b/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
@@ -1723,16 +1723,17 @@ function acls(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
         if ($comment == 'user' or $comment == '#') {
             $comment = $valeurs_fiche['nomwiki'];
         }
-        // hack pour que SavePage ne re-ecrit pas les droits avec les valeurs par défaut
-        $GLOBALS['wiki']->pageCache[$valeurs_fiche['id_fiche']]['body'] = $valeurs_fiche;
-        $GLOBALS['wiki']->pageCache[$valeurs_fiche['id_fiche']]['tag'] = $valeurs_fiche['id_fiche'];
-        $GLOBALS['wiki']->pageCache[$valeurs_fiche['id_fiche']]['owner'] = (isset($valeurs_fiche['nomwiki']) ? $valeurs_fiche['nomwiki'] : $valeurs_fiche['createur']);
-        $GLOBALS['wiki']->pageCache[$valeurs_fiche['id_fiche']]['comment_on'] = '';
-
+        
         // on sauve les acls
-        $GLOBALS['wiki']->SaveAcl($valeurs_fiche['id_fiche'], 'read', $read);
-        $GLOBALS['wiki']->SaveAcl($valeurs_fiche['id_fiche'], 'write', $write);
-        $GLOBALS['wiki']->SaveAcl($valeurs_fiche['id_fiche'], 'comment', $comment);
+		if (empty($GLOBALS['wiki']->LoadAcl($valeurs_fiche['id_fiche'], 'read', false)['list'])){
+            $GLOBALS['wiki']->SaveAcl($valeurs_fiche['id_fiche'], 'read', $read);
+        }
+        if (empty($GLOBALS['wiki']->LoadAcl($valeurs_fiche['id_fiche'], 'write', false)['list'])){
+            $GLOBALS['wiki']->SaveAcl($valeurs_fiche['id_fiche'], 'write', $write);
+        }
+        if (empty($GLOBALS['wiki']->LoadAcl($valeurs_fiche['id_fiche'], 'comment', false)['list'])){
+            $GLOBALS['wiki']->SaveAcl($valeurs_fiche['id_fiche'], 'comment', $comment);
+        }
     }
 }
 


### PR DESCRIPTION
merge #535 fix acl
+

- prise en compte des clés des listes lors des imports csv pour checkbox, radio, list
- prise en compte des id_fiches pour les import csv checkboxfiche listefiche
- export des noms de fiches et de listes en récupérant directement les noms (au lieu de travailler du html)
- export des noms contenant des "," en ajoutant des guillemets pour éviter les confusions (ou sinon id_fiches pour permettre l'import)
