### PR TITLE
possibility to add several files for javascripts and css custom files

### DIFF
--- a/docs/custom-folder.md
+++ b/docs/custom-folder.md
@@ -23,11 +23,11 @@ Available variables inside the template are
 
 ## Custom Javascript
 
-Puts your javascript code in `custom/javascripts/custom.js`
+All the javascript files in the `custom/javascripts/` directory are included.
 
 ## Custom Css
 
-Puts your Css code in `custom/styles/custom.css`
+All the css files in the `custom/styles/` directory are included.
 
 ## Custom Squelette
 

--- a/tools/templates/actions/linkjavascript.php
+++ b/tools/templates/actions/linkjavascript.php
@@ -53,7 +53,7 @@ if (!$bootstrapjs) {
 // on trie les javascripts du theme par ordre alphabéthique et on les insere
 if (isset($scripts) && is_array($scripts)) {
     asort($scripts);
-    foreach ($scripts as $key => $val) {
+    foreach ($scripts as $val) {
         $this->addJavascriptFile($val);
     }
 }
@@ -63,8 +63,13 @@ if (!$yeswikijs) {
     $this->addJavascriptFile('tools/templates/libs/yeswiki-base.js');
 }
 
-if (file_exists('custom/javascripts/custom.js')) {
-    $this->addJavascriptFile('custom/javascripts/custom.js');
+// add javascript files which are included in the custom javascript directory
+$customJsPath = 'custom/javascripts';
+$customJsDir = is_dir($customJsPath) ? opendir($customJsPath) : false;
+while ($customJsDir && ($file = readdir($customJsDir)) !== false) {
+    if (substr($file, -3, 3) == '.js') {
+        $this->addJavascriptFile($customJsPath . '/' . $file);
+    }
 }
 
 // si quelque chose est passée dans la variable globale pour le javascript, on l'intègre

--- a/tools/templates/actions/linkstyle.php
+++ b/tools/templates/actions/linkstyle.php
@@ -57,8 +57,13 @@ if ($pageCss && !empty($pageCss['body'])) {
     $styles .= '  <link rel="stylesheet" href="' . $this->href('css', 'PageCss') .'" />'."\n";
 }
 
-if (file_exists('custom/styles/custom.css')) {
-    $styles .= '  <link rel="stylesheet" href="'.$this->getBaseUrl().'/custom/styles/custom.css" />' . "\n";
+// add css files which are included in the custom styles directory
+$customCssPath = 'custom/styles';
+$customCssDir = is_dir($customCssPath) ? opendir($customCssPath) : false;
+while ($customCssDir && ($file = readdir($customCssDir)) !== false) {
+    if (substr($file, -4, 4) == '.css') {
+        $styles .= '  <link rel="stylesheet" href="' . $this->getBaseUrl() . '/' . $customCssPath . '/' . $file .'" />' . "\n";
+    }
 }
 
 // on ajoute aux css le background personnalise


### PR DESCRIPTION
J'en avais parlé à @seballot il y a une dizaine de jours, et j'avais écris ce petit fix pour ne pas que seuls `custom/javascripts/custom.css` et `custom/styles/custom.css` ne soient inclus. Tous les fichiers de ces deux répertoires sont maintenant inclus.
L'intérêt est de pouvoir les nommer comme on veut et d'en mettre plusieurs si besoin.

J'étais parti de la branche de Seb custom-templates et je l'avais nommé [more-custom-templates](https://github.com/YesWiki/yeswiki/tree/more-custom-templates). Je n'ai pas proposé de suite la PR car je voulais d'abord faire améliorer rapidement le fonctionnement des templates dans les extensions, mais vu le boulot déjà entrepris, plus besoin :)

Si je fais une PR sur more-custom-templates, il me met en conflit puisqu'il essaye de repasser tous les commits d'avant de Sebastian (je me dis que c'est certainement lié au fait que Flo a fait un gros squeeze). Du coup, j'ai fais un cherry picking du bon commit sur cette branche.
