### PR TITLE
Amélioration de la suppression de pages/fiches

### DIFF
--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -386,19 +386,6 @@ class Wiki
         return $url;
     }
 
-    /**
-     * Return the absolute url of the current page. Specify the http or https protocol according to which is activated,
-     * and a specific port if used.
-     * @return string the absolute url
-     */
-    public function getAbsoluteUrl()
-    {
-        return 'http'
-            . ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? 's' : '')
-            . '://'
-            . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
-    }
-
     public function Redirect($url)
     {
         header("Location: $url");

--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -386,6 +386,19 @@ class Wiki
         return $url;
     }
 
+    /**
+     * Return the absolute url of the current page. Specify the http or https protocol according to which is activated,
+     * and a specific port if used.
+     * @return string the absolute url
+     */
+    public function getAbsoluteUrl()
+    {
+        return 'http'
+            . ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? 's' : '')
+            . '://'
+            . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
+    }
+
     public function Redirect($url)
     {
         header("Location: $url");

--- a/includes/urlutils.inc.php
+++ b/includes/urlutils.inc.php
@@ -29,43 +29,6 @@ function getAbsoluteUrl()
 }
 
 /**
- * Computes the absolute path contained in an URL. For example in
- * http://hostname/path/to/site/file.php?param=value
- * the absolute path is '/path/to/site/'.
- * @param string $url The url from which extract the absolute path.
- * You might give partial URLs, for example just "/path/to/site/file.php".
- * If no argument is given, $_SERVER['REQUEST_URI'] will be used.
- * @return string The absolute path extracted from $url
- */
-function getURLAbsolutePath($url = null)
-{
-    if (!$url) {
-        $url = $_SERVER['REQUEST_URI'];
-    }
-
-    $pieces = @parse_url($url);
-    if ($pieces === false) {
-        return false;
-    }
-
-    if (empty($pieces['path'])) {
-        return '/';
-    }
-
-    $path = $pieces['path'];
-    $path_len = strlen($path);
-
-    if ($path[$path_len - 1] == '/') {
-        return $path;
-    }
-
-    $expl = explode('/', $path); // here $expl[0] should be the empty string
-    $expl[count($expl) - 1] = ''; // this makes the path /look/like/this/
-
-    return implode('/', $expl);
-}
-
-/**
  * Computes the base url of the wiki, used as default configuration value.
  * This function works with https sites two.
  * @param boolean $rewrite_mode Indicates whether the rewrite mode is activated

--- a/includes/urlutils.inc.php
+++ b/includes/urlutils.inc.php
@@ -19,6 +19,16 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
 /**
+ * Return the absolute url of the current page. Specify the http or https protocol according to which is activated,
+ * and a specific port if used.
+ * @return string the absolute url
+ */
+function getAbsoluteUrl()
+{
+    return $GLOBALS['wiki']->getBaseUrl() . $_SERVER['REQUEST_URI'];
+}
+
+/**
  * Computes the absolute path contained in an URL. For example in
  * http://hostname/path/to/site/file.php?param=value
  * the absolute path is '/path/to/site/'.

--- a/tools/bazar/actions/bazarlistecategorie.php
+++ b/tools/bazar/actions/bazarlistecategorie.php
@@ -100,7 +100,8 @@ if (empty($list)) {
             $fiche['html'] = baz_voir_fiche(0, $fiche);
             // lien de suppression visible pour le super admin
             if (baz_a_le_droit('supp_fiche', $fiche['createur'])) {
-                $fiche['lien_suppression'] = '<a class="btn-delete-page-confirm" href="'.$this->href('deletepage', $fiche['id_fiche']).'"></a>'."\n";
+                $fiche['lien_suppression'] = '<a class="btn-delete-page-confirm" href="'
+                    . $this->href('deletepage', $fiche['id_fiche'], 'incoming=' . urlencode($this->getAbsolutePath())).'"></a>'."\n";
             }
             if (baz_a_le_droit('modif_fiche', $fiche['createur'])) {
                 $fiche['lien_edition'] = '<a class="BAZ_lien_modifier" href="'.$this->href('edit', $fiche['id_fiche']).'"></a>'."\n";

--- a/tools/bazar/actions/bazarlistecategorie.php
+++ b/tools/bazar/actions/bazarlistecategorie.php
@@ -100,7 +100,7 @@ if (empty($list)) {
             $fiche['html'] = baz_voir_fiche(0, $fiche);
             // lien de suppression visible pour le super admin
             if (baz_a_le_droit('supp_fiche', $fiche['createur'])) {
-                $fiche['lien_suppression'] = '<a class="btn-delete-page-confirm" href="'
+                $fiche['lien_suppression'] = '<a class="modalbox" href="'
                     . $this->href('deletepage', $fiche['id_fiche'], 'incoming=' . urlencode($this->getAbsolutePath())).'"></a>'."\n";
             }
             if (baz_a_le_droit('modif_fiche', $fiche['createur'])) {

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -2668,7 +2668,7 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
             $fichebazar['infos'] .=
             ' <a class="btn btn-xs btn-mini btn-danger modalbox" href="'
             . $GLOBALS['wiki']->href('deletepage', $idfiche, 'incomingurl='
-                . urlencode($GLOBALS['wiki']->getAbsoluteUrl()))
+                . urlencode(getAbsoluteUrl()))
             . '" data-confirm-text="'
             . _t('BAZ_CONFIRM_SUPPRIMER_FICHE').'">'
             . '<i class="fa fa-trash icon-trash icon-white"></i> '

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -2667,7 +2667,9 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
         if ($GLOBALS['wiki']->UserIsAdmin() or $GLOBALS['wiki']->UserIsOwner()) {
             $fichebazar['infos'] .=
             ' <a class="btn btn-xs btn-mini btn-danger btn-delete-page-confirm" href="'
-            . $GLOBALS['wiki']->href('deletepage', $idfiche).'" data-confirm-text="'
+            . $GLOBALS['wiki']->href('deletepage', $idfiche, 'incomingurl='
+                . urlencode($GLOBALS['wiki']->getAbsoluteUrl()))
+            . '" data-confirm-text="'
             . _t('BAZ_CONFIRM_SUPPRIMER_FICHE').'">'
             . '<i class="fa fa-trash icon-trash icon-white"></i> '
             . '<span>' . _t('BAZ_SUPPRIMER').'</span></a>'."\n";

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -2666,7 +2666,7 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
         // lien supprimer la fiche
         if ($GLOBALS['wiki']->UserIsAdmin() or $GLOBALS['wiki']->UserIsOwner()) {
             $fichebazar['infos'] .=
-            ' <a class="btn btn-xs btn-mini btn-danger btn-delete-page-confirm" href="'
+            ' <a class="btn btn-xs btn-mini btn-danger modalbox" href="'
             . $GLOBALS['wiki']->href('deletepage', $idfiche, 'incomingurl='
                 . urlencode($GLOBALS['wiki']->getAbsoluteUrl()))
             . '" data-confirm-text="'

--- a/tools/bazar/libs/bazar.js
+++ b/tools/bazar/libs/bazar.js
@@ -64,16 +64,6 @@ $(document).ready(function () {
     return false;
   });
 
-  // confirm delete of entry
-  $('.btn-delete-page-confirm').click(function(e) {
-    if (confirm($(this).data('confirm-text'))) {
-      $(this).attr('href',  $(this).attr('href')+'&confirme=oui');
-      return true;
-    } else {
-      return false;
-    }
-  });
-
   //permet de gerer des affichages conditionnels, en fonction de balises div
   function handleConditionnalListChoice() {
     var id = $(this).attr('id');

--- a/tools/bazar/presentation/templates/material-card.tpl.html
+++ b/tools/bazar/presentation/templates/material-card.tpl.html
@@ -120,7 +120,7 @@ if ( count($fiches)>0 ) : ?>
               <a href="<?php echo $GLOBALS['wiki']->href('edit', $fiche['id_fiche']); ?>" class="fa fa-fw fa-pencil-square-o"></a>
               <?php endif; ?>
               <?php if ($GLOBALS['wiki']->UserIsAdmin() || $GLOBALS['wiki']->UserIsOwner()) : ?>
-              <a href="<?php echo $GLOBALS['wiki']->href('deletepage', $fiche['id_fiche']); ?>" class="fa fa-fw fa-trash btn-delete-page-confirm"></a>
+              <a href="<?php echo $GLOBALS['wiki']->href('deletepage', $fiche['id_fiche']); ?>" class="fa fa-fw fa-trash modalbox"></a>
               <?php endif; ?>
             </div>
           </div>

--- a/tools/tags/presentation/templates/pages_accordion.tpl.html
+++ b/tools/tags/presentation/templates/pages_accordion.tpl.html
@@ -17,7 +17,8 @@
             <a href="<?php echo $GLOBALS['wiki']->href('edit', $tag); ?>" class="btn btn-default"><i class="icon-pencil"></i></a>
             <?php endif; ?>
             <?php if ($GLOBALS['wiki']->UserIsAdmin() || $GLOBALS['wiki']->UserIsOwner()) : ?>
-            <a href="<?php echo $GLOBALS['wiki']->href('deletepage', $tag); ?>" class="btn btn-danger"><i class="icon-trash icon-white"></i></a>
+            <a href="<?php echo $GLOBALS['wiki']->href('deletepage', $tag, 'incomingurl='
+                . urlencode($GLOBALS['wiki']->getAbsoluteUrl())); ?>" class="btn btn-danger modalbox"><i class="icon-trash icon-white"></i></a>
             <?php endif; ?>
           </div>
           <div class="clearfix"></div>

--- a/tools/tags/presentation/templates/pages_accordion.tpl.html
+++ b/tools/tags/presentation/templates/pages_accordion.tpl.html
@@ -18,7 +18,7 @@
             <?php endif; ?>
             <?php if ($GLOBALS['wiki']->UserIsAdmin() || $GLOBALS['wiki']->UserIsOwner()) : ?>
             <a href="<?php echo $GLOBALS['wiki']->href('deletepage', $tag, 'incomingurl='
-                . urlencode($GLOBALS['wiki']->getAbsoluteUrl())); ?>" class="btn btn-danger modalbox"><i class="icon-trash icon-white"></i></a>
+                . urlencode(getAbsoluteUrl())); ?>" class="btn btn-danger modalbox"><i class="icon-trash icon-white"></i></a>
             <?php endif; ?>
           </div>
           <div class="clearfix"></div>


### PR DESCRIPTION
On en a parlé pendant le sprint : suite à une suppression d'un fiche bazar, on retombe systématiquement sur une page qui affiche le message d'erreur, ce qui rend compliqué la suppression de plusieurs fiches.

Ce que j'ai corrigé :

  - suite à la suppression d'une fiche, on retourne sur la page appelante et le message de confirmation s'effectue dans une popup
   - de la même manière, on retourne vers l'accueil si on supprime une page (à la place de rester sur la page qui n'existe plus)
   - la boîte de dialogue de suppression d'une fiche bazar faisait vieillote, j'ai mis celle la même qui est utilisé pour les pages (thème margot)