### PR TITLE
fix-several-checkbox-same-form

### DIFF
--- a/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
+++ b/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
@@ -2340,7 +2340,7 @@ function checkboxfiche(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
                                         <input type="checkbox" id="' . $id . '_' . $key . '" value="1" name="' .
                                         $id.'['.$key.']"';
                     if ($def != '' && in_array($key, $def)) {
-                        $checkbox_html.= ' checked="checked"';
+                        $checkbox_html.= ' checked';
                     }
                     $checkbox_html.= ' class="element_checkbox">'.$label.'
                     </label></div>';

--- a/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
+++ b/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
@@ -2336,8 +2336,8 @@ function checkboxfiche(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
                     '<ul class="list-bazar-entries list-unstyled">';
                 foreach ($checkboxtab as $key => $label) {
                     $checkbox_html.= '<div class="yeswiki-checkbox checkbox">
-                                        <label for="ckbx_'.$key.'">
-                                        <input type="checkbox" id="ckbx_' . $key . '" value="1" name="' .
+                                        <label for="' . $id . '_'.$key.'">
+                                        <input type="checkbox" id="' . $id . '_' . $key . '" value="1" name="' .
                                         $id.'['.$key.']"';
                     if ($def != '' && in_array($key, $def)) {
                         $checkbox_html.= ' checked="checked"';


### PR DESCRIPTION
permettre d'avoir un identifiant unique pour chaque input de type checkbox et éviter les conflits comme énoncé dans #479 

@srosset81 je te propose de valider si tu penses que ça n'a pas d'effet de bord et si tu l'as pris en compte dans le refacto.
Je ferai alors le merge.