### PR TITLE
Template litle fixes

### DIFF
--- a/tools/aceditor/presentation/javascripts/aceditor.js
+++ b/tools/aceditor/presentation/javascripts/aceditor.js
@@ -364,4 +364,3 @@ $('#body').aceditor({savebtn : true, class: "big"});
 
 // For comments and Bazar's textarea
 $('.wiki-textarea, .commentform textarea').aceditor();
-// $('textarea.nohtml').aceditor({syntax:'html'});

--- a/tools/aceditor/presentation/javascripts/aceditor.js
+++ b/tools/aceditor/presentation/javascripts/aceditor.js
@@ -364,4 +364,4 @@ $('#body').aceditor({savebtn : true, class: "big"});
 
 // For comments and Bazar's textarea
 $('.wiki-textarea, .commentform textarea').aceditor();
-$('textarea.nohtml').aceditor({syntax:'html'});
+// $('textarea.nohtml').aceditor({syntax:'html'});

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -2598,7 +2598,7 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
     // Try rendering a custom template
     try {
         $custom_template = baz_get_custom_template($fichebazar['values']);
-        $res .= $templateEngine->render("custom/templates/bazar/$custom_template", $customTemplateValues);
+        $res .= $templateEngine->render("@bazar/$custom_template", $customTemplateValues);
     } catch (\YesWiki\Core\Service\TemplateNotFound $e) {
         $customTemplateFound = false;
     }
@@ -2613,7 +2613,7 @@ function baz_voir_fiche($danslappli, $idfiche, $form = '')
         }
     }        
     
-    // If not foud, use default templating
+    // If not found, use default templating
     if (!$customTemplateFound) {
         for ($i = 0; $i < count($fichebazar['form']['template']); ++$i) {
             if (isset($fichebazar['form']['template'][$i][11]) &&

--- a/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
+++ b/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
@@ -1102,8 +1102,6 @@ function textelong(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
         return "";
     } elseif (empty($formatage) || $formatage == 'wiki') {
         $formatage = 'wiki-textarea';
-    } elseif ($formatage == 'texte') {
-        $formatage = 'nohtml';
     } elseif ($formatage == 'html' && $mode == 'saisie') {
         $langpref = strtolower($GLOBALS['prefered_language']).'-'.strtoupper($GLOBALS['prefered_language']);
         $langfile = 'tools/bazar/libs/vendor/summernote/lang/summernote-'.$langpref.'.js';

--- a/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
+++ b/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
@@ -1102,8 +1102,8 @@ function textelong(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
         return "";
     } elseif (empty($formatage) || $formatage == 'wiki') {
         $formatage = 'wiki-textarea';
-    } elseif ($formatage == 'nohtml' && $mode == 'saisie') {
-        $formatage = 'texte';
+    } elseif ($formatage == 'texte' && $mode == 'saisie') {
+        $formatage = 'nohtml';
     } elseif ($formatage == 'html' && $mode == 'saisie') {
         $langpref = strtolower($GLOBALS['prefered_language']).'-'.strtoupper($GLOBALS['prefered_language']);
         $langfile = 'tools/bazar/libs/vendor/summernote/lang/summernote-'.$langpref.'.js';

--- a/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
+++ b/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
@@ -1102,7 +1102,7 @@ function textelong(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
         return "";
     } elseif (empty($formatage) || $formatage == 'wiki') {
         $formatage = 'wiki-textarea';
-    } elseif ($formatage == 'texte' && $mode == 'saisie') {
+    } elseif ($formatage == 'texte') {
         $formatage = 'nohtml';
     } elseif ($formatage == 'html' && $mode == 'saisie') {
         $langpref = strtolower($GLOBALS['prefered_language']).'-'.strtoupper($GLOBALS['prefered_language']);
@@ -1206,7 +1206,7 @@ function textelong(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
 
                 $GLOBALS['wiki']->tag = $oldpage;
                 $GLOBALS['wiki']->page = $oldpagearray;
-            } elseif ($formatage == 'nohtml' || $formatage == 'texte'  ) {
+            } elseif ($formatage == 'nohtml') {
                 $html .= htmlentities($valeurs_fiche[$identifiant], ENT_QUOTES, YW_CHARSET);
             } elseif ($formatage == 'html') {
                 // caution "" was replaced by '' otherwise in the case of a form inside a bazar entry, it's interpreted by

--- a/tools/bazar/presentation/javascripts/form-edit-template.js
+++ b/tools/bazar/presentation/javascripts/form-edit-template.js
@@ -275,7 +275,7 @@ var typeUserAttrs = {
       options: {
         wiki: "Wiki",
         html: "Editeur Wysiwyg",
-        nohtml: "Html non interprété",
+        nohtml: "Texte non interprété",
       },
     },
     hint: { label: "Texte d'aide" },


### PR DESCRIPTION
fix loading templatePath with - or _
+ fix detail message of TemplateNotFound
+ code formatting in PSR1/2

Je ne pouvais pas charger de templates dans le module login-sso  à cause du - (j'ai mis le _ en plus au cas même si on l'utilise pas).
J'avais aussi des warnings car il y avait un cas qui n'était pas pris en compte pour lever l'exception TemplateNotFound

Il me reste encore une soucis avec les templates de fiche : bazar ne semble charger que les templates de fiche qui sont dans `custom/templates/bazar` : cf [ici](https://github.com/YesWiki/yeswiki/blob/16065a686d2ff184d63cac471159df8fbbf7b93d/tools/bazar/libs/bazar.fonct.php#L2601). Mais si j'ai bien compris, il devrait aussi charger les templates dans `/tools/$ext/templates/bazar`, non ?


