### PR TITLE
fix remove all checkbox

### DIFF
--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -1356,10 +1356,20 @@ function baz_requete_bazar_fiche($valpost)
         unset($valpost['sendmail']);
     }
 
-    //pour les checkbox, on met les resultats sur une ligne
+    //pour les checkbox et checkboxfiches, on met les resultats sur une ligne
     foreach ($valpost as $cle => $val) {
         if (is_array($val)) {
-            $valpost[$cle] = implode(',', array_keys($val));
+            foreach ($val as $key => $value) {
+                if ($value == 0 && $key == "END_INDEX NO_CHANGE_IT"){
+                    unset($val[$key]) ;
+                }
+            }
+            
+            if (empty(array_keys($val))) {
+                unset($valpost[$cle]) ;
+            } else {
+                $valpost[$cle] = implode(',', array_keys($val)) ;
+            }
         }
     }
 

--- a/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
+++ b/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
@@ -2359,16 +2359,16 @@ function checkboxfiche(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
 
         return $checkbox_html;
     } elseif ($mode == 'requete') {
-        if (isset($valeurs_fiche[$id]) && ($valeurs_fiche[$id] != 0)) {
-            return array($id => $valeurs_fiche[$id]);
-        } 
+        if (isset($valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]]) && ($valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]] != 0)) {
+            return array($tableau_template[0].$tableau_template[1].$tableau_template[6] => $valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]]);
+        }
     } elseif ($mode == 'html') {
         $html = '';
-        if (isset($valeurs_fiche[$id]) && $valeurs_fiche[$id] != '') {
-            $html.= '<div class="BAZ_rubrique" data-id="' . $id.'">' . "\n" . '<span class="BAZ_label">' . $tableau_template[2] . '</span>' . "\n";
+        if (isset($valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]]) && $valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]] != '') {
+            $html.= '<div class="BAZ_rubrique" data-id="' . $tableau_template[0].$tableau_template[1].$tableau_template[6].'">' . "\n" . '<span class="BAZ_label">' . $tableau_template[2] . '</span>' . "\n";
             $html.= '<span class="BAZ_texte">' . "\n";
-            $tab_fiche = explode(',', $valeurs_fiche[$id]);
-            
+            $tab_fiche = explode(',', $valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]]);
+
             foreach ($tab_fiche as $idfiche) {
                 $html .= '<ul>';
                 if (isset($tableau_template[3]) and $tableau_template[3] == 'fiche') {

--- a/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
+++ b/tools/bazar/libs/formulaire/formulaire.fonct.inc.php
@@ -330,6 +330,7 @@ function checkbox(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
                       .'</div>'."\n";
                 }
 
+                $checkbox_html .= '<input class="" name="'.$id.'[END_INDEX NO_CHANGE_IT]'.'" value="0" checked id="'.$id.'_hidden'.'" type="hidden">' ;
                 $checkbox_html .= '</div>
 </div>
 </div>';
@@ -339,7 +340,7 @@ function checkbox(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
     } elseif ($mode == 'requete') {
         $key = $tableau_template[0].$tableau_template[1].$tableau_template[6];
         return array_key_exists($key, $valeurs_fiche) ?
-            array($key => $valeurs_fiche[$key]) : array($key => null);
+            array($key => $valeurs_fiche[$key]) : null;
     } elseif ($mode == 'html') {
         $html = '';
         if (isset($valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]]) && $valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]] != '') {
@@ -2343,6 +2344,7 @@ function checkboxfiche(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
                     $checkbox_html.= ' class="element_checkbox">'.$label.'
                     </label></div>';
                 }
+                $checkbox_html.= '<input name="'.$id.'[END_INDEX NO_CHANGE_IT]'.'" value="0" checked id="'.$id.'_hidden'.'" type="hidden">' ;
                 $checkbox_html.= "\n".'</ul>'."\n";
                 // javascript additions
                 $GLOBALS['wiki']->AddJavascriptFile('tools/bazar/libs/vendor/jquery.fastLiveFilter.js');
@@ -2357,16 +2359,16 @@ function checkboxfiche(&$formtemplate, $tableau_template, $mode, $valeurs_fiche)
 
         return $checkbox_html;
     } elseif ($mode == 'requete') {
-        if (isset($valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]]) && ($valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]] != 0)) {
-            return array($tableau_template[0].$tableau_template[1].$tableau_template[6] => $valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]]);
-        }
+        if (isset($valeurs_fiche[$id]) && ($valeurs_fiche[$id] != 0)) {
+            return array($id => $valeurs_fiche[$id]);
+        } 
     } elseif ($mode == 'html') {
         $html = '';
-        if (isset($valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]]) && $valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]] != '') {
-            $html.= '<div class="BAZ_rubrique" data-id="' . $tableau_template[0].$tableau_template[1].$tableau_template[6].'">' . "\n" . '<span class="BAZ_label">' . $tableau_template[2] . '</span>' . "\n";
+        if (isset($valeurs_fiche[$id]) && $valeurs_fiche[$id] != '') {
+            $html.= '<div class="BAZ_rubrique" data-id="' . $id.'">' . "\n" . '<span class="BAZ_label">' . $tableau_template[2] . '</span>' . "\n";
             $html.= '<span class="BAZ_texte">' . "\n";
-            $tab_fiche = explode(',', $valeurs_fiche[$tableau_template[0].$tableau_template[1].$tableau_template[6]]);
-
+            $tab_fiche = explode(',', $valeurs_fiche[$id]);
+            
             foreach ($tab_fiche as $idfiche) {
                 $html .= '<ul>';
                 if (isset($tableau_template[3]) and $tableau_template[3] == 'fiche') {


### PR DESCRIPTION
la PR précédente #548 ne modifiait pas le bon endroit.
Merci à @srosset81 de m'avoir incité à trouver une solution qui ne modifie pas le FicheManager.
La voici.

Intention : permettre de détection une lite de cases à cocher sans aucune case cochée et donc vider les valeurs de la fiche qui correspondent

Ceci ne change rien à #135 qui peut être close a priori car normalement ça fonctionne.

Mon intention ici:
- corriger un bug (bénévolat)
- je n'ai pas le temps de faire de l'amélioration de code pour cette correction de bug
- pour les remarques d'amélioration de code, je suis persuadé qu'elles sont pertinentes mais je préfère qu'elles soient émises sur une Issue dédiée de façon à ne pas retarder la sortie de ce correction
(sauf si bien sûr ces remarques sont d'ordre à bloquer cette PR)