### PR TITLE
Not rendering empty fields

### DIFF
--- a/tools/bazar/fields/EmailField.php
+++ b/tools/bazar/fields/EmailField.php
@@ -37,13 +37,16 @@ class EmailField extends BazarField
 
     public function renderStatic($entry)
     {
+        $value = $this->getValue($entry);
+        if( !$value ) return null;
+        
         // TODO add JS libraries with Twig
         if( $this->showContactForm ) {
             $GLOBALS['wiki']->addJavascriptFile('tools/contact/libs/contact.js');
         }
 
         return $this->render('@bazar/fields/email.twig', [
-            'value' => $this->getValue($entry),
+            'value' => $value,
             'showContactForm' => $this->showContactForm,
             'contactFormUrl' => $this->showContactForm ? $GLOBALS['wiki']->href('mail', $GLOBALS['wiki']->GetPageTag(), 'field='.$this->propertyName) : null
         ]);

--- a/tools/bazar/fields/LabelField.php
+++ b/tools/bazar/fields/LabelField.php
@@ -33,6 +33,6 @@ class LabelField extends BazarField
 
     public function renderStatic($entry)
     {
-        return $this->viewText . "\n";
+        return empty($this->viewText) ? $this->viewText . "\n" : null ;
     }
 }

--- a/tools/bazar/fields/RadioListField.php
+++ b/tools/bazar/fields/RadioListField.php
@@ -29,6 +29,7 @@ class RadioListField extends EnumField
     public function renderStatic($entry)
     {
         $value = $entry !== '' ? $this->options[$this->getValue($entry)] : '';
+        if( empty($value) ) return null;
         return $this->render('@bazar/fields/radio.twig', [
             'value' => $value
         ]);

--- a/tools/bazar/fields/SelectEntryField.php
+++ b/tools/bazar/fields/SelectEntryField.php
@@ -40,6 +40,7 @@ class SelectEntryField extends EnumField
     public function renderStatic($entry)
     {
         $value = $this->getValue($entry);
+        if( !$value ) return null;
 
         if( $this->displayMethod === 'fiche' ) {
             if( $this->isDistantJson ) {

--- a/tools/bazar/fields/SelectListField.php
+++ b/tools/bazar/fields/SelectListField.php
@@ -26,8 +26,10 @@ class SelectListField extends EnumField
 
     public function renderStatic($entry)
     {
+        $value = $this->getValue($entry)
+        if( !$value ) return null;
         return $this->render('@bazar/fields/select.twig', [
-            'value' => $this->options[$this->getValue($entry)]
+            'value' => $this->options[$value]
         ]);
     }
 }

--- a/tools/bazar/fields/SelectListField.php
+++ b/tools/bazar/fields/SelectListField.php
@@ -26,7 +26,7 @@ class SelectListField extends EnumField
 
     public function renderStatic($entry)
     {
-        $value = $this->getValue($entry)
+        $value = $this->getValue($entry) ;
         if( !$value ) return null;
         return $this->render('@bazar/fields/select.twig', [
             'value' => $this->options[$value]

--- a/tools/bazar/fields/TagsField.php
+++ b/tools/bazar/fields/TagsField.php
@@ -100,10 +100,12 @@ class TagsField extends BazarField
             $tags = array_map(function($tag) {
                 return '<a class="tag-label label label-info" href="' . $GLOBALS['wiki']->href('listpages', $GLOBALS['wiki']->GetPageTag(), 'tags=' . urlencode(trim($tag))) . '" title="' . _t('TAGS_SEE_ALL_PAGES_WITH_THIS_TAGS') . '">' . $tag . '</a>';
             }, $tags);
-        }
 
-        return $this->render('@bazar/fields/tags.twig', [
-            'value' => join(' ', $tags) ?? ''
-        ]);
+            return $this->render('@bazar/fields/tags.twig', [
+                'value' => join(' ', $tags) ?? ''
+            ]);
+        } else {
+            return null ;
+        }
     }
 }

--- a/tools/bazar/fields/TagsField.php
+++ b/tools/bazar/fields/TagsField.php
@@ -95,7 +95,7 @@ class TagsField extends BazarField
 
         $tags = explode(',', $value);
 
-        if (count($tags) > 0) {
+        if (count($tags) > 0 && !empty($tags[0])) {
             sort($tags);
             $tags = array_map(function($tag) {
                 return '<a class="tag-label label label-info" href="' . $GLOBALS['wiki']->href('listpages', $GLOBALS['wiki']->GetPageTag(), 'tags=' . urlencode(trim($tag))) . '" title="' . _t('TAGS_SEE_ALL_PAGES_WITH_THIS_TAGS') . '">' . $tag . '</a>';

--- a/tools/bazar/fields/TextField.php
+++ b/tools/bazar/fields/TextField.php
@@ -43,8 +43,11 @@ class TextField extends BazarField
 
     public function renderStatic($entry)
     {
+        $value = $this->getValue($entry);
+        if( !$value ) return null;
+        
         return $this->render("@bazar/fields/text.twig", [
-            'value' => $this->getValue($entry)
+            'value' => $value
         ]);
     }
 }

--- a/tools/bazar/fields/TextareaField.php
+++ b/tools/bazar/fields/TextareaField.php
@@ -105,7 +105,8 @@ class TextareaField extends BazarField
     public function renderStatic($entry)
     {
         $value = $this->getValue($entry);
-
+        if( !$value ) return null;
+        
         switch($this->syntax){
             case self::SYNTAX_WIKI:
                 // Do the page change in any case (useful for attach or grid)


### PR DESCRIPTION
Je propose, par rétrocompatibilité, de ne pas afficher les champs vides.
Qu'en pensez-vous ?
Une fois la PR validée par chacun je ferai la fusion en rebase + no fast forwarding pour permettre une belle lecture de l'arbre des commit