### PR TITLE
fix renew pwd

### DIFF
--- a/includes/User.class.php
+++ b/includes/User.class.php
@@ -432,8 +432,10 @@ class User
     {
         // Generate the password recovery key
         $key = md5($this->properties['name'] . '_' . $this->properties['email'] . rand(0, 10000) . date('Y-m-d H:i:s') . PW_SALT);
+        // Erase the previous triples in the trible table
+        $this->wiki->services->get(TripleStore::class)->delete($this->properties['name'],$this->keyVocabulary,null,'','') ;
         // Store the (name, vocabulary, key) triple in triples table
-        $res = $this->wiki->InsertTriple($this->properties['name'], $this->keyVocabulary, $key, '', '');
+        $res = $this->wiki->services->get(TripleStore::class)->create($this->properties['name'], $this->keyVocabulary, $key, '', '');
 
         // Generate the recovery email
         $passwordLink = $this->wiki->Href() . '&a=recover&email=' . $key . '&u=' . urlencode(base64_encode($this->properties['name']));
@@ -504,16 +506,8 @@ class User
     public function checkEmailKey($hash, $user)
     {
         // Pas de detournement possible car utilisation de _vocabulary/key ....
-        $results = $this->wiki->services->get(TripleStore::class)->getAll($user, 'http://outils-reseaux.org/_vocabulary/key','','');
-        $result = false ;
-        foreach ($results as $res) {
-            if ($res['value'] == $hash || $result) {
-                $result = true;
-            } else {
-                $result = false;
-            }
-        }
-        return $result;
+        $result = $this->wiki->services->get(TripleStore::class)->exist($user, 'http://outils-reseaux.org/_vocabulary/key',$hash,'','');
+        return ($result !== 0) ;
     }
     /* End of Password recovery process (AKA reset password)   */
 

--- a/includes/User.class.php
+++ b/includes/User.class.php
@@ -1,5 +1,6 @@
 <?php
 namespace YesWiki;
+use YesWiki\Core\Service\TripleStore;
 
 class User
 {
@@ -503,11 +504,14 @@ class User
     public function checkEmailKey($hash, $user)
     {
         // Pas de detournement possible car utilisation de _vocabulary/key ....
-        $res = $this->wiki->GetTripleValue($user, 'http://outils-reseaux.org/_vocabulary/key', '', '');
-        if ($res == $hash) {
-            $result = true;
-        } else {
-            $result = false;
+        $results = $this->wiki->services->get(TripleStore::class)->getAll($user, 'http://outils-reseaux.org/_vocabulary/key','','');
+        $result = false ;
+        foreach ($results as $res) {
+            if ($res['value'] == $hash || $result) {
+                $result = true;
+            } else {
+                $result = false;
+            }
         }
         return $result;
     }

--- a/tools/login/actions/lostpassword.php
+++ b/tools/login/actions/lostpassword.php
@@ -57,13 +57,13 @@ if (isset($_POST['subStep']) && !isset($_GET['a'])) { // Sub step
         } // End switch
 } elseif (isset($_GET['a']) && $_GET['a'] == 'recover' && $_GET['email'] != '') {
     $step = 'invalidKey';
-    $result = $this->user->checkEmailKey($_GET['email'], base64_decode($_GET['u']));
+    $result = $this->user->checkEmailKey($_GET['email'], urldecode(base64_decode($_GET['u'])));
     if ($result == false) {
         $error = true;
         $step = 'invalidKey';
     } else {
         $error = false;
-        $this->user->loadByNameFromDB(base64_decode($_GET['u']));
+        $this->user->loadByNameFromDB(urldecode(base64_decode($_GET['u'])));
         $step = 'recoverForm';
     }
 }


### PR DESCRIPTION
Je propose ce correctif pour le renouvèlement des mots de passe.
Vu que ça touche à la sécurité.

Je cherche un relecteur.
Je commence avec @mrflos mais si tu n'as pas le temps, je te laisse transmettre la revue à qui tu veux.


Contexte : si quelqu'un demande un renouvellement de mot de passe alors qu'il l'a déjà fait, la nouvelle clé ne va pas correspondre à la précédente. Or jusque là, seule la précédente était utilisée pour comparaison.