### PR TITLE
improve checkACL for section visibility

### DIFF
--- a/tools/templates/actions/section.php
+++ b/tools/templates/actions/section.php
@@ -81,7 +81,7 @@ if ($GLOBALS['check_' . $pagetag]['section']) {
 
     // specify the role to be checked ( *, +, %, @admins)
     $role = $this->GetParameter('visibility');
-    $visible = !$role || ($GLOBALS['wiki']->CheckACL($role));
+    $visible = !$role || ($GLOBALS['wiki']->CheckACL($role,null,false));
     
     echo '<!-- start of section -->
     <section' . (!empty($id) ? ' id="'.$id .'"' : '') . ' class="'. ($backgroundimg ? 'background-image' : '') . ($visible ? '' : ' remove-this-div-on-page-load ') . (!empty($class) ? ' ' . $class : '') . '" style="'


### PR DESCRIPTION
J'ai une proposition concernant l'usage de visibility pour l'action section

**Cas d'usage** :
- Code
```{{section visibility="!+"}}```
...
```{{end elem="section"}}```
- intention : n'afficher le contenu que pour les gens non connecté.
- comportement 

|Rôle|Avant correctif|Après|
|:-:|:-:|:-:|
|Non connecté|Affiché|Affiché|
|Connecté|Non affiché|Non affiché|
|`@admins`|**Affiché**|Non affiché|

Proposition : ne pas surpasser le test par les droits `@admins`

Qu'en dites-vous ?