### PR TITLE
fix display action builder component default

### DIFF
--- a/docs/actions/pdf.yaml
+++ b/docs/actions/pdf.yaml
@@ -1,5 +1,6 @@
 label: _t(AB_attach_pdf_label)
 previewHeight: 300px
+onlyEdit: true
 actions:
   pdf:
     label: _t(AB_attach_pdf_label)

--- a/docs/actions/video.yaml
+++ b/docs/actions/video.yaml
@@ -24,7 +24,8 @@ actions:
       id:
         label: _t(AB_attach_video_id_label)
         type: text
-        required: true      
+        required: true  
+        default: 1f5bfc59-998b-41b3-9be3-e8084ad1a2a1
       ratio:
         label: _t(AB_attach_video_ratio_label)
         type: list

--- a/tools/aceditor/presentation/javascripts/actions-builder.js
+++ b/tools/aceditor/presentation/javascripts/actions-builder.js
@@ -187,7 +187,7 @@ window.myapp = new Vue({
       for(let key in this.values) {
         let config = this.selectedActionAllConfigs[key]
         let value = this.values[key]
-        if (result.hasOwnProperty(key) || value === undefined || config && value === config.default 
+        if (result.hasOwnProperty(key) || value === undefined 
             || typeof value == "object" || config && !this.display(config) ) 
           continue
         result[key] = value


### PR DESCRIPTION
Pour répondre aux questions de @furax37 
- video par défaut pour éviter les alertes de {{video}}
- affichage des valeurs par défaut dans le code à copier

en plus, passage de l'action {{pdf}} en onlyEdit car {{attach}} permet déjà de gérer l'affichage des pdf
