### PR TITLE
Are you YesWikiBazarTemplate ?

### DIFF
--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -30,6 +30,7 @@ require_once 'includes/YesWikiPerformable.php';
 require_once 'includes/objects/YesWikiAction.php';
 require_once 'includes/objects/YesWikiHandler.php';
 require_once 'includes/objects/YesWikiFormatter.php';
+require_once 'includes/objects/YesWikiBazarTemplate.php';
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;

--- a/includes/YesWikiPerformable.php
+++ b/includes/YesWikiPerformable.php
@@ -15,6 +15,8 @@ abstract class YesWikiPerformable
     public $arguments = [];
     public $output;
 
+    private $twig;
+
     /**
      * Creates a YesWikiAction object associated with the given wiki object.
      */

--- a/includes/objects/YesWikiBazarTemplate.php
+++ b/includes/objects/YesWikiBazarTemplate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace YesWiki\Core;
+
+abstract class YesWikiBazarTemplate extends YesWikiPerformable
+{
+    protected $twigTemplate;
+
+    public function __construct(&$wiki, &$arguments, $twigTemplate)
+    {
+        parent::__construct($wiki);
+        $this->arguments = &$arguments;
+        $this->twigTemplate = $twigTemplate;
+    }
+
+    abstract public function prepare();
+
+    public function run()
+    {
+        $this->prepare();
+
+        return $this->render($this->twigTemplate, $this->arguments);
+    }
+}

--- a/includes/squelettephp.class.php
+++ b/includes/squelettephp.class.php
@@ -32,8 +32,6 @@ class SquelettePhp
     }
 
     /**
-     */
-    /**
      * Add several or one value to template
      *
      * @param mixed $name variable name, or array name=>value

--- a/tools/helloworld/templates/bazar/Form1Template.php
+++ b/tools/helloworld/templates/bazar/Form1Template.php
@@ -1,0 +1,25 @@
+<?php
+use YesWiki\Core\YesWikiBazarTemplate;
+
+class Form1Template extends YesWikiBazarTemplate
+{
+    public function prepare()
+    {
+        // you can prepare your data model here by using services
+
+        // in this example, we shuffle the fields and keep the indexes to access to field metadatas (label, ...)
+        $keys = array_keys($this->arguments['html']);
+
+        $indexes = range(0, count($keys) - 1);
+        shuffle($indexes);
+
+        $this->arguments['shuffled'] = [];
+        foreach ($indexes as $i){
+            $this->arguments['shuffled'][] = [
+                'key' => $keys[$i],
+                'index' => $i,
+                'value' => $this->arguments['html'][$keys[$i]]
+            ];
+        }
+    }
+}

--- a/tools/helloworld/templates/bazar/ShuffledListTemplate.php
+++ b/tools/helloworld/templates/bazar/ShuffledListTemplate.php
@@ -1,0 +1,12 @@
+<?php
+use YesWiki\Core\YesWikiBazarTemplate;
+
+class ShuffledListTemplate extends YesWikiBazarTemplate
+{
+    public function prepare()
+    {
+        // you can prepare your data model here by using services
+
+        shuffle($this->arguments['fiches']);
+    }
+}

--- a/tools/helloworld/templates/bazar/form1.twig
+++ b/tools/helloworld/templates/bazar/form1.twig
@@ -1,0 +1,13 @@
+<h4 class="hello-title">These entry fields are shuffled</h4>
+<p><em>You can refresh the view to shuffle it again...</em></p>
+
+{% for field in shuffled %}
+    <div class="BAZ_rubrique" {% if field['key'] is not empty %}data-id="{{ field['key'] }}"{% endif %}>
+        <span class="BAZ_label">
+            {{ form['prepared'][field['index']].label }}
+        </span>
+        <span class="BAZ_texte">
+            {{ field['value']|raw }}
+        </span>
+    </div>
+{% endfor %}

--- a/tools/helloworld/templates/bazar/shuffledlist.twig
+++ b/tools/helloworld/templates/bazar/shuffledlist.twig
@@ -1,0 +1,7 @@
+<h2 class="hello-title">My list is now shuffled</h2>
+<p><em>You can refresh the view to shuffle it again...</em></p>
+<ul>
+        {% for fiche in fiches %}
+                <li>{{ fiche['bf_titre'] }}</li>
+        {% endfor %}
+</ul>

--- a/tools/helloworld/templates/bazar/simplelist.twig
+++ b/tools/helloworld/templates/bazar/simplelist.twig
@@ -1,0 +1,6 @@
+<h2 class="hello-title">My first bazar template</h2>
+<ul>
+    {% for fiche in fiches %}
+        <li>{{ fiche['bf_titre'] }}</li>
+    {% endfor %}
+</ul>


### PR DESCRIPTION
Suite à notre réunion d'hier, j'ai voulu au début juste regarder un peu et vous envoyez là où j'en étais mais sorry j'y suis pas arrivé ! 
En effet, en ouvrant quelques templates existants dans `tools/bazar/presentation/templates/`, j'ai tout de suite vu que ça serait impossible de réécrire ces templates juste avec une vue twig (regardez le [template damier](https://github.com/YesWiki/yeswiki/blob/af7b97a647f3cee4c3d75f1bb59a81b46d0a230f/tools/bazar/presentation/templates/damier.tpl.html) par ex.) ... du coup, j'ai continué quelques heures ce que j'avais commencé pour pouvoir vous montrer le fonctionnement avec de vrais exemples.

Actuellement, un bazar template est soit :
  - un fichier de la forme fiche-X.tpl.html qui assure le rendu des fiches du formulaire d'id X
  - un fichier en .tpl.html qui est utilisé par {{bazarliste template="montemplate"}} pour faire le rendu d'un ensemble de de fiche, pas forcément de même type, et sous différentes formes : liste, tableaux, galerie photo, carto, etc.
  
J'ai d'abord fait en sorte qu'on puisse utiliser les twig plutôt que nos vieux .tpl.html. Pour des rendus simples, cela peut suffire mais dès qu'on a besoin de transformer un peu les données, ou qu'on veut afficher afficher des informations suivant des informations qui proviennent de fiches auxquelles on se réfère, on a besoin de "préparer" les données avant de les afficher via twig. 

Pour cela, je propose un système qui se calque sur la logique actuelle de nos Performables (actions/handlers/formatters), et qui permet de lancer du code au sein de la fonction prepare() d'une sous-classe de YesWikiBazarTemplate. Ensuite, cette même classe appelle la vue twig associée (fichier ayant le même nom en minuscule sans le 'Template' à la fin et dans le même répertoire).

Vous pouvez tester les deux templates de type liste en ajoutant ce code :
```
{{bazarliste id="1" template="simplelist.twig"}}
{{bazarliste id="1" template="ShuffledListTemplate.php"}}
```
Vous pouvez remplacer 1 par l'ID du formulaire que vous voulez.

Ensuite pour l'exemple de type fiche, il faut que vous ayez un formulaire avec l'ID 1 de déclaré et des fiches de ce formulaire. Vous pouvez renommer les fichiers `tools/helloworld/templates/bazar/form1.twig` et `tools/helloworld/templates/bazar/Form1Template.php` avec l'ID que vous voulez.



 
  
  