### PR TITLE
Modified section in order to cope with CSS grid and flex

### DIFF
--- a/docs/actions/section.yaml
+++ b/docs/actions/section.yaml
@@ -23,7 +23,7 @@ actions:
         label: Visible par 
         options:
           '': Tout le monde
-          '+': Utilisateur connecté
+          '+': Utilisateurs connectés
           '%': Propriétaire de la page
           '@admins': Admins seulement
       class:
@@ -84,6 +84,10 @@ actions:
               wow wobble: Essuie glace
               wow jello: Danse
               wow heartBeat: Bat
+      style:
+        label: Style (CSS)
+        type: text
+        hint: Si vous connaissez la syntaxe CSS et souhaitez modifier l'affichage ou le comportement de cette section
 #      data:
 #        label: Data wow
 #        type: text

--- a/tools/templates/actions/end.php
+++ b/tools/templates/actions/end.php
@@ -34,7 +34,7 @@ if (empty($elem)) {
                 echo "\n</div> <!-- end of col -->\n";
                 break;
             case 'section':
-                echo "\n</div>\n</section> <!-- end of section -->\n";
+                echo "\n</section> <!-- end of section -->\n";
                 break;
             case 'label':
                 echo "</span>";


### PR DESCRIPTION
###Modification du comportement de l'action {{section}}

##Description de la demande d'ajout

Aujourd'hui, avant PR, pour illustration : 
- `{{section class="maClasse" }}Du texte {{end elem="section"}}` 
  donne
  `<section class="maClasse"><div class="container">Du texte </div></section>`
- `{{section class="maClasse" nocontainer="1" }}Du texte {{end elem="section"}}` 
  donne
  `<section class="maClasse"><div >Du texte </div></section>`
- `{{section class="maClasse" id="monId" file="image.jpg" bgcolor="purple" height="200" }}Du texte {{end elem="section"}}` 
  donne
  `<section class="background-image maClasse" id="monId" style="background: purple; height: 200px; background-image:url('url.du.fichier/monImage_genre.jpg');"><div class="container">Du texte </div></section>`

L'élément div placé à l'intérieur de l'élément section empêche d'utiliser simplement (c'est à dire par un utilisateur non développeur) des outils comme les grid ou les flex CSS. Ceux-ci nécessitent un élément parent dont la classe va influer sur le positionnement des enfants.

**Ce qui a été fait :**
- suppression de l'insertion de la balise d'ouverture de l'élément `<div>` par `{{section}}`
- suppression de l'insertion de la balise de fermeture de l'élément `</div>` par `{{end elem="section"}}`
- prise en compte de la classe container au niveau de l'élément `<section>` (au lieu de `<div>` précédemment) ;
- prise en compte d'un attribut style de l'action, dont la valeur sera ajoutée à la fin de l'attribut style tel que précédemment construit pour l'élément section.

Maintenant,
`{{section class="maClasse" id="monId" file="image.jpg" bgcolor="purple" height="200" style="font-weight: bold;"}}Du texte {{end elem="section"}}` 
  donne
  `<section class="background-image container maClasse" id="monId" style="background: purple; height: 200px; background-image:url('url.du.fichier/monImage_genre.jpg'); font-weight: bold;">Du texte </section>`

**Compatibilité descendante**
Si quelqu'un a utilisé la classe container avec des CSS avec `div.container` plutôt que `.container`, alors il y a un problème. Avec @gatienbataille , nous nous sommes dit qu'une fois le code présent dans une release de doryphore, Gatien poserait une question qui illustre le problème sur le forum et que j'y répondrais afin de documenter le sujet.