### PR TITLE
feat(links): add possibility to write tag links with ?param1=x&param2=y

### DIFF
--- a/formatters/wakka.php
+++ b/formatters/wakka.php
@@ -309,7 +309,7 @@ if (!class_exists('\YesWiki\WikiniFormatter')) {
                     // forced links
                     // \S : any character that is not a whitespace character
                     // \s : any whitespace character
-                    elseif (preg_match("/^\[\[(".WN_CAMEL_CASE_EVOLVED."|mailto:.*|https?:\/\/.*)(\s+(.+))?\]\]$/Uum", $thing, $matches)) {
+                    elseif (preg_match("/^\[\[(" . WN_CAMEL_CASE_EVOLVED_WITH_PARAMS . "|mailto:.*|https?:\/\/.*)(\s+(.+))?\]\]$/Uum", $thing, $matches)) {
                         if (isset($matches[3])) {
                             list(, $url, , $text) = $matches;
                         } else {

--- a/formatters/wakka.php
+++ b/formatters/wakka.php
@@ -309,7 +309,7 @@ if (!class_exists('\YesWiki\WikiniFormatter')) {
                     // forced links
                     // \S : any character that is not a whitespace character
                     // \s : any whitespace character
-                    elseif (preg_match("/^\[\[(" . WN_CAMEL_CASE_EVOLVED_WITH_PARAMS . "|mailto:.*|https?:\/\/.*)(\s+(.+))?\]\]$/Uum", $thing, $matches)) {
+                    elseif (preg_match("/^\[\[(" . WN_CAMEL_CASE_EVOLVED_WITH_SLASH_AND_PARAMS . "|mailto:.*|https?:\/\/.*)(\s+(.+))?\]\]$/Uum", $thing, $matches)) {
                         if (isset($matches[3])) {
                             list(, $url, , $text) = $matches;
                         } else {

--- a/formatters/wakka.php
+++ b/formatters/wakka.php
@@ -326,7 +326,12 @@ if (!class_exists('\YesWiki\WikiniFormatter')) {
                             // filter ]] because there are none here
                             // by construct)
                             $text = isset($text) ? preg_replace("/@@|££|\[\[/", "", $text) : '';
-                            return $result.$wiki->Link($url, "", $text, 1, true);
+
+                            $linkParts = $wiki->extractLinkParts($url);
+                            if ($linkParts) {
+                                return $result . $wiki->Link($linkParts['tag'], $linkParts['method'],
+                                        $linkParts['params'], $text, 1, true);
+                            }
                         } else { // if there is no URL, return at least the text
                             return htmlspecialchars($text, ENT_COMPAT, YW_CHARSET);
                         }

--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -468,10 +468,10 @@ class Wiki
                 // An inline image? (text!=tag and url ends by png,gif,jpeg)
                 return '<img src="' . htmlspecialchars($tag, ENT_COMPAT, YW_CHARSET)
                 .'" alt="'.htmlspecialchars($displayText, ENT_COMPAT, YW_CHARSET).'"/>';
-            } elseif (preg_match('/^'.WN_CAMEL_CASE_EVOLVED.'$/u', $tag)) {
+            } elseif (preg_match('/^' . WN_CAMEL_CASE_EVOLVED_WITH_PARAMS . '$/u', $tag)) {
                 if (! empty($track)) {
                     // it's a Wiki link!
-                    $this->TrackLinkTo($tag);
+                    $this->TrackLinkTo(explode('?', $tag)[0]);
                 }
             } elseif ($safeUrl = str_replace(
                 array('%3F', '%3A', '%26', '%3D', '%23'),
@@ -505,17 +505,17 @@ class Wiki
             }
         }
 
+        $linkParts = explode('?', $tag);
+        $tag = $linkParts[0];
+        $params = !empty($linkParts[1]) ? $linkParts[1] : '';
+
         if ($this->LoadPage($tag)) {
-            return '<a href="'.htmlspecialchars(
-                $this->href($method, $tag),
-                ENT_COMPAT,
-                YW_CHARSET
-            ).'">' . htmlspecialchars($displayText, ENT_COMPAT, YW_CHARSET) . '</a>';
+            return '<a href="'. $this->href($method, $tag, $params) . '">'
+                . htmlspecialchars($displayText, ENT_COMPAT, YW_CHARSET) . '</a>';
         } else {
             return '<span class="'.($forcedLink ? 'forced-link ' : '').'missingpage">'
             . htmlspecialchars($displayText, ENT_COMPAT, YW_CHARSET).'</span><a href="'
-            . htmlspecialchars($this->href("edit", $tag), ENT_COMPAT, YW_CHARSET)
-            . '">?</a>';
+            . $this->href("edit", $tag) . '">?</a>';
         }
     }
 

--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -403,8 +403,9 @@ class Wiki
         header("Location: $url");
         exit();
     }
+
     // returns just PageName[/method].
-    public function MiniHref($method = '', $tag = '')
+    public function MiniHref($method = null, $tag = null)
     {
         if (! $tag = trim($tag)) {
             $tag = $this->tag;
@@ -412,10 +413,11 @@ class Wiki
 
         return $tag . ($method ? '/' . $method : '');
     }
+
     // returns the full url to a page/method.
-    public function Href($method = '', $tag = '', $params = '', $htmlspchars = true)
+    public function Href($method = null, $tag = null, $params = null, $htmlspchars = true)
     {
-        if (!$tag = trim($tag)) {
+        if (! $tag = trim($tag)) {
             $tag = $this->tag;
         }
         $href = $this->config["base_url"] . $this->MiniHref($method, $tag);
@@ -441,7 +443,7 @@ class Wiki
         return $href;
     }
 
-    public function Link($tag, $method = "", $text = "", $track = 1, $forcedLink = false)
+    public function Link($tag, $method = null, $params = null, $text = null, $track = 1, $forcedLink = false)
     {
         $displayText = $text ? $text : $tag;
 
@@ -505,22 +507,15 @@ class Wiki
             }
         }
 
-        $linkParts = $this->extractLinkParts($tag);
-        if ($linkParts) {
-            // if the method is defined in $tag, it has the priority over the method given in $method
-            if ($linkParts['method']){
-                $method = $linkParts['method'];
-            }
-            if ((!empty($linkParts['method']) && $linkParts['method'] != 'show') || $this->LoadPage($linkParts['tag'])) {
-                // if the page refers to an handler url (contains /) or an existing page, display a 'show' link
-                return '<a href="' . $this->href($method, $linkParts['tag'], $linkParts['params']) . '">'
-                    . htmlspecialchars($displayText, ENT_COMPAT, YW_CHARSET) . '</a>';
-            } else {
-                // otherwise display an 'edit' link
-                return '<span class="' . ($forcedLink ? 'forced-link ' : '') . 'missingpage">'
-                    . htmlspecialchars($displayText, ENT_COMPAT, YW_CHARSET) . '</span><a href="'
-                    . $this->href("edit", $tag) . '">?</a>';
-            }
+       if ($method != 'show' || $this->LoadPage($tag)) {
+            // if the page refers to an handler url (contains /) or an existing page, display a 'show' link
+            return '<a href="' . $this->href($method, $tag, $params) . '">'
+                . htmlspecialchars($displayText, ENT_COMPAT, YW_CHARSET) . '</a>';
+        } else {
+            // otherwise display an 'edit' link
+            return '<span class="' . ($forcedLink ? 'forced-link ' : '') . 'missingpage">'
+                . htmlspecialchars($displayText, ENT_COMPAT, YW_CHARSET) . '</span><a href="'
+                . $this->href("edit", $tag) . '">?</a>';
         }
     }
 
@@ -528,19 +523,19 @@ class Wiki
      * Extract the different part of a link of the style MyTag/method?param1=value1&param2=value2...
      *
      * The resulting array has the tree keys : 'tag' (string), 'method' (string) and 'params' (arrays of key/value for
-     * each param). 'tag' can't have a empty value, but 'method' and 'params' can.
+     * each param). 'tag' can't have a null value, but 'method' can, and 'params' can also return an empty array.
      * If the link has a '/' and a '?' but no letter between (no method), the url is not recognized.
      * @param $link the link to parse
-     * @return array|null if the link is recognize return the result array, otherwise null
+     * @return array|null if the link is recognize return the result array, otherwise nullhref
      *
      */
     public function extractLinkParts($link): ?array
     {
         if (preg_match('/^(' . WN_CAMEL_CASE_EVOLVED . ')(?:\/(' . WN_CAMEL_CASE_EVOLVED . '))?(?:\?('
             . RFC3986_URI_CHARS . '))?$/', $link, $linkParts)){
-            $tag = !empty($linkParts[1]) ? $linkParts[1] : '';
-            $method = !empty($linkParts[2]) ? $linkParts[2] : '';
-            $paramsStr = !empty($linkParts[3]) ? $linkParts[3] : '';
+            $tag = !empty($linkParts[1]) ? $linkParts[1] : null;
+            $method = !empty($linkParts[2]) ? $linkParts[2] : null;
+            $paramsStr = !empty($linkParts[3]) ? $linkParts[3] : null;
             parse_str($paramsStr, $params);
             return [
                 'tag' => $tag,

--- a/includes/YesWikiController.php
+++ b/includes/YesWikiController.php
@@ -12,9 +12,10 @@ abstract class YesWikiController
 
     /**
      * Setter for the wiki property
+     * @param Wiki $wiki
      * @Required set the auto-injection
      */
-    public function setWikiObject(Wiki $wiki)
+    public function setWiki(Wiki $wiki): void
     {
         $this->wiki = $wiki;
     }

--- a/includes/YesWikiControllerResolver.php
+++ b/includes/YesWikiControllerResolver.php
@@ -28,7 +28,7 @@ class YesWikiControllerResolver extends ControllerResolver
     private function configureController($controller, string $class)
     {
         if ($controller instanceof YesWikiController) {
-            $controller->setWikiObject($this->wiki);
+            $controller->setWiki($this->wiki);
         }
 
         return $controller;

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -24,6 +24,9 @@ define("WN_CHAR2", "[A-Za-z0-9_-]"); // \xC0-\xD6\xD8-\xF6\xF8-\xFF]");
 define('WN_CAMEL_CASE', WN_UPPER . WN_LOWER . '+' . WN_UPPER_NUM . WN_CHAR . '*');
 //define('WN_CAMEL_CASE_EVOLVED', '\b[\p{Lu}]+[\p{L}-_0-9]*[\p{Lu}]+[\p{L}-_0-9]*');
 define('WN_CAMEL_CASE_EVOLVED', '[\p{L}\-_.0-9]+');
+define('RFC3986_URI_CHARS','[\p{L}0-9-._~:\/?#[\]@!$&\'()*+,;=%]*');
+// to check tag links with param which use camel case evolved characters
+define('WN_CAMEL_CASE_EVOLVED_WITH_PARAMS', WN_CAMEL_CASE_EVOLVED . '(?:\?' . RFC3986_URI_CHARS . ')?');
 /** the regexp that matches automatic wiki links in a text */
 define('WN_WIKI_LINK', WN_CAMEL_CASE); // this might evolve to handle the page groups and subpages syntax
 /** the regexp that checks if a word is a valid page tag */

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -24,9 +24,10 @@ define("WN_CHAR2", "[A-Za-z0-9_-]"); // \xC0-\xD6\xD8-\xF6\xF8-\xFF]");
 define('WN_CAMEL_CASE', WN_UPPER . WN_LOWER . '+' . WN_UPPER_NUM . WN_CHAR . '*');
 //define('WN_CAMEL_CASE_EVOLVED', '\b[\p{Lu}]+[\p{L}-_0-9]*[\p{Lu}]+[\p{L}-_0-9]*');
 define('WN_CAMEL_CASE_EVOLVED', '[\p{L}\-_.0-9]+');
+define('WN_CAMEL_CASE_EVOLVED_WITH_SLASH', '[\p{L}\-_.0-9\/]+');
 define('RFC3986_URI_CHARS','[\p{L}0-9-._~:\/?#[\]@!$&\'()*+,;=%]*');
 // to check tag links with param which use camel case evolved characters
-define('WN_CAMEL_CASE_EVOLVED_WITH_PARAMS', WN_CAMEL_CASE_EVOLVED . '(?:\?' . RFC3986_URI_CHARS . ')?');
+define('WN_CAMEL_CASE_EVOLVED_WITH_SLASH_AND_PARAMS', WN_CAMEL_CASE_EVOLVED_WITH_SLASH . '(?:\?' . RFC3986_URI_CHARS . ')?');
 /** the regexp that matches automatic wiki links in a text */
 define('WN_WIKI_LINK', WN_CAMEL_CASE); // this might evolve to handle the page groups and subpages syntax
 /** the regexp that checks if a word is a valid page tag */

--- a/tools/attach/libs/attach.lib.php
+++ b/tools/attach/libs/attach.lib.php
@@ -1017,11 +1017,11 @@ if (!class_exists('attach')) {
                 //Avertissement
                 $fmTitlePage .= '<div class="prev_alert">Les fichiers effac&eacute;s sur cette page le sont d&eacute;finitivement</div>';
                 //Pied du tableau
-                $url = $this->wiki->Link($this->wiki->tag, 'filemanager', 'Gestion des fichiers');
+                $url = $this->wiki->Link($this->wiki->tag, 'filemanager', null, 'Gestion des fichiers');
                 $fmFootTable = '	<tfoot>' . "\n" .
                     '		<tr>' . "\n" .
                     '			<td colspan="6">' . $url . '</td>' . "\n";
-                $url = $this->wiki->Link($this->wiki->tag, 'filemanager&do=emptytrash', 'Vider la corbeille');
+                $url = $this->wiki->Link($this->wiki->tag, 'filemanage', ['do' => 'emptytrash'], 'Vider la corbeille');
                 $fmFootTable .= '			<td>' . $url . '</td>' . "\n" .
                     '		</tr>' . "\n" .
                     '	</tfoot>' . "\n";

--- a/tools/bazar/services/FormManager.php
+++ b/tools/bazar/services/FormManager.php
@@ -78,7 +78,7 @@ class FormManager
         }
         // TODO verify this method : each form is written with the same key in the array
 
-        return count($this->cachedForms) > 0 ? $this->cachedForms : null;
+        return $this->cachedForms;
     }
 
     public function getMany($formsIds): array

--- a/tools/templates/actions/button.php
+++ b/tools/templates/actions/button.php
@@ -12,9 +12,11 @@ if ($link == "config/root_page") {
     $this->setParameter('link', $link);
 }
 
-if ($this->IsWikiName($link, WN_CAMEL_CASE_EVOLVED)) {
-    $linkTag = $link;
-    $link = $this->href('', $link);
+$linkParts = explode('?', $link);
+if ($this->IsWikiName($linkParts[0], WN_CAMEL_CASE_EVOLVED)) {
+    $linkTag = $linkParts[0];
+    $params = !empty($linkParts[1]) ? $linkParts[1] : '';
+    $link = $this->href('', $linkTag, $params);
 }
 
 // texte genere a l'interieur du bouton

--- a/tools/templates/actions/button.php
+++ b/tools/templates/actions/button.php
@@ -12,11 +12,9 @@ if ($link == "config/root_page") {
     $this->setParameter('link', $link);
 }
 
-$linkParts = explode('?', $link);
-if ($this->IsWikiName($linkParts[0], WN_CAMEL_CASE_EVOLVED)) {
-    $linkTag = $linkParts[0];
-    $params = !empty($linkParts[1]) ? $linkParts[1] : '';
-    $link = $this->href('', $linkTag, $params);
+$linkParts = $this->extractLinkParts($link);
+if ($linkParts){
+    $link = $this->href($linkParts['method'], $linkParts['tag'], $linkParts['params']);
 }
 
 // texte genere a l'interieur du bouton

--- a/tools/templates/actions/nav.php
+++ b/tools/templates/actions/nav.php
@@ -48,15 +48,17 @@ if (!empty($icons)) {
 
 $listlinks = '';
 foreach ($titles as $key => $title) {
-    $linkParts = explode('?', $links[$key]);
-    [$url, $params] = ['', ''];
-    if ($this->IsWikiName($linkParts[0], WN_CAMEL_CASE_EVOLVED)){
-        $params = !empty($linkParts[1]) ? $linkParts[1] : '';
-        $url = $this->href('', $linkParts[0], $params);
+    $linkParts = $this->extractLinkParts($links[$key]);
+    [$url, $method, $params] = ['', '', ''];
+    if ($linkParts){
+        $method = $linkParts['method'];
+        $params = $linkParts['params'];
+        $url = $this->href($method, $linkParts['tag'], $params);
     } else {
         $url = $links[$key];
     }
-    $listclass = ($url == $this->href('', $this->GetPageTag(), $params)) ? ' class="active"' : '';
+    // class="active" if the url have the same url than the current one (independently of the method and the params)
+    $listclass = ($url == $this->href($method, $this->GetPageTag(), $params)) ? ' class="active"' : '';
     $listlinks .= '<li' . $listclass . '><a href="'.$url.'">'
         . (isset($icons[$key]) ? $icons[$key] : '')
         . $title.'</a></li>'."\n";

--- a/tools/templates/actions/nav.php
+++ b/tools/templates/actions/nav.php
@@ -48,9 +48,18 @@ if (!empty($icons)) {
 
 $listlinks = '';
 foreach ($titles as $key => $title) {
-    $url = $this->IsWikiName($links[$key], WN_CAMEL_CASE_EVOLVED) ? $this->href('', $links[$key]) : $links[$key];
-    $listclass = ($url == $this->href('', $this->GetPageTag())) ? ' class="active"' : '';
-    $listlinks .= '<li'.$listclass.'><a href="'.$url.'">'.(isset($icons[$key]) ? $icons[$key] : '').$title.'</a></li>'."\n";
+    $linkParts = explode('?', $links[$key]);
+    [$url, $params] = ['', ''];
+    if ($this->IsWikiName($linkParts[0], WN_CAMEL_CASE_EVOLVED)){
+        $params = !empty($linkParts[1]) ? $linkParts[1] : '';
+        $url = $this->href('', $linkParts[0], $params);
+    } else {
+        $url = $links[$key];
+    }
+    $listclass = ($url == $this->href('', $this->GetPageTag(), $params)) ? ' class="active"' : '';
+    $listlinks .= '<li' . $listclass . '><a href="'.$url.'">'
+        . (isset($icons[$key]) ? $icons[$key] : '')
+        . $title.'</a></li>'."\n";
 }
 
 $navID = uniqid('nav_');

--- a/tools/templates/libs/templates.functions.php
+++ b/tools/templates/libs/templates.functions.php
@@ -151,26 +151,30 @@ function nomwikidouble($nomwiki, $nomswiki)
 //fonction pour remplacer les liens vers les NomWikis n'existant pas
 function replace_missingpage_links($output)
 {
-    $pattern = '/<span class="(forced-link )?missingpage">(.*)<\/span><a href="'.str_replace(
+    $pattern = '/<span class="(forced-link )?missingpage">(.*)<\/span><a href="' . str_replace(
         array('/', '?'),
         array('\/', '\?'),
         $GLOBALS['wiki']->config['base_url']
-    ).'(.*)\/edit">\?<\/a>/U';
+    ) . '(.*)\/edit">\?<\/a>/U';
     preg_match_all($pattern, $output, $matches, PREG_SET_ORDER);
 
     foreach ($matches as $values) {
         // on passe en parametres GET les valeurs du template de la page de provenance,
         // pour avoir le meme graphisme dans la page creee
-        $query_string = 'theme='.urlencode($GLOBALS['wiki']->config['favorite_theme']).
-                        '&amp;squelette='.urlencode($GLOBALS['wiki']->config['favorite_squelette']).
-                        '&amp;style='.urlencode($GLOBALS['wiki']->config['favorite_style']).
-                        '&amp;bgimg='.urlencode($GLOBALS['wiki']->config['favorite_background_image']).
-                        (($values[2] != $values[3]) ? '&amp;body='.urlencode($values[2]) : '').
-                        '&amp;newpage=1';
-        $replacement = '<a class="yeswiki-editable" title="'._t('TEMPLATE_EDIT_THIS_PAGE').'" href="'
-            .$GLOBALS['wiki']->href("edit", $values[3], $query_string)
-            .'">'
-            .$values[2].' <i class="fa fa-pencil-alt icon-edit"></i></a>';
+        $query_string = (!empty($GLOBALS['wiki']->config['favorite_theme']) ?
+                'theme=' . urlencode($GLOBALS['wiki']->config['favorite_theme']) : '')
+            . (!empty($GLOBALS['wiki']->config['favorite_squelette']) ?
+                '&amp;squelette=' . urlencode($GLOBALS['wiki']->config['favorite_squelette']) : '')
+            . (!empty($GLOBALS['wiki']->config['favorite_style']) ?
+                '&amp;style=' . urlencode($GLOBALS['wiki']->config['favorite_style']) : '')
+            . (!empty($GLOBALS['wiki']->config['favorite_background_image']) ?
+                '&amp;bgimg=' . urlencode($GLOBALS['wiki']->config['favorite_background_image']) : '')
+            . (($values[2] != $values[3]) ?
+                '&amp;body=' . urlencode($values[2]) : '') . '&amp;newpage=1';
+        $replacement = '<a class="yeswiki-editable" title="' . _t('TEMPLATE_EDIT_THIS_PAGE') . '" href="'
+            . $GLOBALS['wiki']->href("edit", $values[3], $query_string)
+            . '">'
+            . $values[2] . ' <i class="fa fa-pencil-alt icon-edit"></i></a>';
         $output = str_replace_once($values[0], $replacement, $output);
     }
 


### PR DESCRIPTION
works for [[TaG text]], {{nav links="... and {{button link="...

exemple : [[ExerciceQuEstCeQuUnNous?parcours=Les360DeLaGouvernancePartagee&module=2CultiverLeNous Exercice]]

j'en avais besoin pour l'action onglet de l'extension lms, et ça faisait un moment que je m'étais dis que cela manquait.