### PR TITLE
Add anchors management for yeswiki links and simplify

### DIFF
--- a/actions/recentchanges.php
+++ b/actions/recentchanges.php
@@ -70,7 +70,7 @@ if ($pages = $this->LoadRecentlyChanged($max, $dateMin)) {
     if ($this->GetParameter('max')) {
         foreach ($pages as $i => $page) {
             // echo entry
-            echo '<small><a href="' . $this->href('revisions', $page['tag']) . '">'.$svgIcon.'</a>&nbsp;'.$page['time'].'</small> ', $this->ComposeLinkToPage($page['tag'], '', '', 0),' <small>par ', $this->Format($page['user']), "</small><br>\n";
+            echo '<small><a href="' . $this->href('revisions', $page['tag']) . '">'.$svgIcon.'</a>&nbsp;'.$page['time'].'</small> ', $this->ComposeLinkToPage($page['tag'], '', '', null, 0),' <small>par ', $this->Format($page['user']), "</small><br>\n";
         }
     } else {
         $curday = '';
@@ -85,7 +85,7 @@ if ($pages = $this->LoadRecentlyChanged($max, $dateMin)) {
                 $curday = $day;
             }
             // echo entry
-            echo '<small><a href="' . $this->href('revisions', $page['tag']) . '">'.$svgIcon.'</a>&nbsp;'.$time.'</small> ', $this->ComposeLinkToPage($page['tag'], '', '', 0),' <small>par ', $this->Format($page['user']), "</small><br>\n";
+            echo '<small><a href="' . $this->href('revisions', $page['tag']) . '">'.$svgIcon.'</a>&nbsp;'.$time.'</small> ', $this->ComposeLinkToPage($page['tag'], '', '', null, 0),' <small>par ', $this->Format($page['user']), "</small><br>\n";
         }
     }
 }

--- a/actions/userstable.php
+++ b/actions/userstable.php
@@ -101,7 +101,7 @@ foreach ($last_users as $user) {
         echo '<a href="'.$this->href('', 'ParametresUtilisateur').'" class="btn btn-sm btn-primary" role="button">'._t('USER_MODIFY').'</a>';
     } else { // not the current user, then can be modified
         if ($isAdmin) {
-            echo '<a href="'.$this->href('', 'ParametresUtilisateur', 'user='.$user['name'], false).'&from='.$this->tag.'" class="btn btn-sm btn-warning " role="button">'._t('USER_MODIFY').'</a>';
+            echo '<a href="'.$this->href('', 'ParametresUtilisateur', 'user='.$user['name'], null, false).'&from='.$this->tag.'" class="btn btn-sm btn-warning " role="button">'._t('USER_MODIFY').'</a>';
         }
     }
     echo '</td>';

--- a/formatters/wakka.php
+++ b/formatters/wakka.php
@@ -328,16 +328,16 @@ if (!class_exists('\YesWiki\WikiniFormatter')) {
                             
                             $linkParts = $wiki->extractLinkParts($url);
                             if ($linkParts) {
-                                return $result . $wiki->Link(
-                                    $linkParts['tag'],
-                                    $linkParts['method'],
-                                    $linkParts['params'],
-                                    $text,
-                                    1,
-                                    true
-                                );
+                                return $result . $wiki->Link($linkParts['tag'],
+                                        $linkParts['method'],
+                                        $linkParts['params'],
+                                        $linkParts['anchor'],
+                                        $text,
+                                        1,
+                                        true
+                                    );
                             } else {
-                                return '<a href="'.$wiki->generateLink($url).'">'.$text.'</a>';
+                                return '<a href="' . $url . '">' . $text . '</a>';
                             }
                         } else { // if there is no URL, return at least the text
                             return htmlspecialchars($text, ENT_COMPAT, YW_CHARSET);

--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -422,6 +422,7 @@ class Wiki
         }
         $href = $this->config["base_url"] . $this->MiniHref($method, $tag, $anchor);
         if ($params) {
+            $ampChar = $htmlspchars ? '&amp;' : '&';
             if (is_array($params)) {
                 $paramsArray = [];
                 foreach ($params as $key => $value) {
@@ -432,12 +433,12 @@ class Wiki
                     }
                 };
                 if (count($paramsArray)>0) {
-                    $params = implode("&", $paramsArray);
+                    $params = implode($ampChar, $paramsArray);
                 } else {
                     $params = '';
                 }
             }
-            $href .= ($this->config['rewrite_mode'] ? '?' : ($htmlspchars ? '&amp;' : '&')) . $params;
+            $href .= ($this->config['rewrite_mode'] ? '?' : $ampChar) . $params;
         }
         if (isset($_GET['lang']) && $_GET['lang']!='') {
             $href .= '&lang='.$GLOBALS['prefered_language'];

--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -527,8 +527,11 @@ class Wiki
      * @param string $link the link to parse
      * @return string final form of the link
      */
-    public function generateLink($link)
+    public function generateLink($link) : ?string
     {
+        if (empty($link)) {
+            return null;
+        }
         $linkParts = $this->extractLinkParts($link);
         if ($linkParts){
             return $this->href(
@@ -560,7 +563,7 @@ class Wiki
         if (empty($link)) {
             return null;
         }
-        elseif (preg_match(WN_YESWIKI_EVOLVED_LINK, $link, $linkParts)) {
+        if (preg_match(WN_YESWIKI_EVOLVED_LINK, $link, $linkParts)) {
             $tag = !empty($linkParts[1]) ? $linkParts[1] : null;
             $anchor = !empty($linkParts[2]) ? $linkParts[2] : null;
             $method = !empty($linkParts[3]) ? $linkParts[3] : null;

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -24,10 +24,11 @@ define("WN_CHAR2", "[A-Za-z0-9_-]"); // \xC0-\xD6\xD8-\xF6\xF8-\xFF]");
 define('WN_CAMEL_CASE', WN_UPPER . WN_LOWER . '+' . WN_UPPER_NUM . WN_CHAR . '*');
 //define('WN_CAMEL_CASE_EVOLVED', '\b[\p{Lu}]+[\p{L}-_0-9]*[\p{Lu}]+[\p{L}-_0-9]*');
 define('WN_CAMEL_CASE_EVOLVED', '[\p{L}\-_.0-9]+');
-define('WN_CAMEL_CASE_EVOLVED_WITH_SLASH', '[\p{L}\-_.0-9\/]+');
+define('WN_CAMEL_CASE_EVOLVED_OR_EMPTY', '[\p{L}\-_.0-9]*');
 define('RFC3986_URI_CHARS', '[\p{L}0-9-._~:\/?#[\]@!$&\'()*+,;=%]*');
 // to check tag links with param which use camel case evolved characters
-define('WN_CAMEL_CASE_EVOLVED_WITH_SLASH_AND_PARAMS', WN_CAMEL_CASE_EVOLVED_WITH_SLASH . '(?:[?&]' . RFC3986_URI_CHARS . ')?');
+define('WN_YESWIKI_EVOLVED_LINK', '/^(' . WN_CAMEL_CASE_EVOLVED_OR_EMPTY . ')(?:#(' . RFC3986_URI_CHARS . '))?' .
+    '(?:\/(' . WN_CAMEL_CASE_EVOLVED . '))?(?:&(' . RFC3986_URI_CHARS . '))?$/');
 /** the regexp that matches automatic wiki links in a text */
 define('WN_WIKI_LINK', WN_CAMEL_CASE); // this might evolve to handle the page groups and subpages syntax
 /** the regexp that checks if a word is a valid page tag */

--- a/includes/services/TemplateEngine.php
+++ b/includes/services/TemplateEngine.php
@@ -62,7 +62,7 @@ class TemplateEngine
         });
         $this->addTwigHelper('url', function ($options) {
             $options = array_merge(['tag' => '', 'handler' => '', 'params' => []], $options);
-            return $this->wiki->Href($options['handler'], $options['tag'], $options['params'], false);
+            return $this->wiki->Href($options['handler'], $options['tag'], $options['params'], null, false);
         });
         $this->addTwigHelper('include_javascript', function ($file, $first = false) {
             $this->wiki->AddJavascriptFile($file, $first);

--- a/tools/attach/libs/attach.lib.php
+++ b/tools/attach/libs/attach.lib.php
@@ -1017,11 +1017,11 @@ if (!class_exists('attach')) {
                 //Avertissement
                 $fmTitlePage .= '<div class="prev_alert">Les fichiers effac&eacute;s sur cette page le sont d&eacute;finitivement</div>';
                 //Pied du tableau
-                $url = $this->wiki->Link($this->wiki->tag, 'filemanager', null, 'Gestion des fichiers');
+                $url = $this->wiki->Link($this->wiki->tag, 'filemanager', null, null, 'Gestion des fichiers');
                 $fmFootTable = '	<tfoot>' . "\n" .
                     '		<tr>' . "\n" .
                     '			<td colspan="6">' . $url . '</td>' . "\n";
-                $url = $this->wiki->Link($this->wiki->tag, 'filemanage', ['do' => 'emptytrash'], 'Vider la corbeille');
+                $url = $this->wiki->Link($this->wiki->tag, 'filemanage', ['do' => 'emptytrash'], null, 'Vider la corbeille');
                 $fmFootTable .= '			<td>' . $url . '</td>' . "\n" .
                     '		</tr>' . "\n" .
                     '	</tfoot>' . "\n";

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -32,7 +32,7 @@ class EntryController extends YesWikiController
         if( isset($_POST['bf_titre']) ) {
             $entry = $this->entryManager->create($formId, $_POST);
             if (empty($redirectUrl)) {
-                $redirectUrl = $this->wiki->Href('', '', ['vue' => 'consulter', 'action' => 'voir_fiche', 'id_fiche' => $entry['id_fiche']], false);
+                $redirectUrl = $this->wiki->Href('', '', ['vue' => 'consulter', 'action' => 'voir_fiche', 'id_fiche' => $entry['id_fiche']], null, false);
             }
             header('Location: ' . $redirectUrl);
             exit;
@@ -54,7 +54,7 @@ class EntryController extends YesWikiController
         if( isset($_POST['bf_titre']) ) {
             $entry = $this->entryManager->update($entryId, $_POST);
             if (empty($redirectUrl)) {
-                $redirectUrl = $this->wiki->Href(testUrlInIframe(), '', ['vue' => 'consulter', 'action' => 'voir_fiche', 'id_fiche' => $entry['id_fiche'], 'message' => 'modif_ok'], false);
+                $redirectUrl = $this->wiki->Href(testUrlInIframe(), '', ['vue' => 'consulter', 'action' => 'voir_fiche', 'id_fiche' => $entry['id_fiche'], 'message' => 'modif_ok'], null, false);
             }
             header('Location: ' . $redirectUrl);
             exit;

--- a/tools/bazar/controllers/FormController.php
+++ b/tools/bazar/controllers/FormController.php
@@ -34,7 +34,7 @@ class FormController extends YesWikiController
                 }
             }
 
-            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_FORM_IMPORT_SUCCESSFULL'], false));
+            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_FORM_IMPORT_SUCCESSFULL'], null, false));
         }
 
         $values = [];
@@ -60,7 +60,7 @@ class FormController extends YesWikiController
         if( isset($_POST['valider']) ) {
             $this->formManager->create($_POST);
 
-            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_NOUVEAU_FORMULAIRE_ENREGISTRE'], false));
+            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_NOUVEAU_FORMULAIRE_ENREGISTRE'], null, false));
         }
 
         return $this->render("@bazar/forms/forms_form.twig", [
@@ -73,7 +73,7 @@ class FormController extends YesWikiController
         if( isset($_POST['valider']) ) {
             $this->formManager->update($_POST);
 
-            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_FORMULAIRE_MODIFIE'], false));
+            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_FORMULAIRE_MODIFIE'], null, false));
         }
 
         return $this->render("@bazar/forms/forms_form.twig", [
@@ -86,13 +86,13 @@ class FormController extends YesWikiController
     {
         $this->formManager->delete($id);
 
-        return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_FORMULAIRE_ET_FICHES_SUPPRIMES'], false));
+        return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_FORMULAIRE_ET_FICHES_SUPPRIMES'], null, false));
     }
 
     public function empty($id)
     {
         $this->formManager->clear($id);
 
-        return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_FORMULAIRE_VIDE'], false));
+        return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_FORMULAIRE_VIDE'], null, false));
     }
 }

--- a/tools/bazar/controllers/ListController.php
+++ b/tools/bazar/controllers/ListController.php
@@ -53,7 +53,7 @@ class ListController extends YesWikiController
             $this->listManager->create($_POST['titre_liste'], $values);
 
             $this->wiki->Redirect(
-                $this->wiki->Href('', '', [BAZ_VARIABLE_VOIR => BAZ_VOIR_LISTES], false)
+                $this->wiki->Href('', '', [BAZ_VARIABLE_VOIR => BAZ_VOIR_LISTES], null, false)
             );
         }
 
@@ -79,7 +79,7 @@ class ListController extends YesWikiController
                 $this->listManager->update($id, $_POST['titre_liste'], $values);
 
                 $this->wiki->Redirect(
-                    $this->wiki->Href('', '', [BAZ_VARIABLE_VOIR => BAZ_VOIR_LISTES], false)
+                    $this->wiki->Href('', '', [BAZ_VARIABLE_VOIR => BAZ_VOIR_LISTES], null, false)
                 );
             } else {
                 throw new \Exception('Not allowed');
@@ -102,7 +102,7 @@ class ListController extends YesWikiController
         }
 
         $this->wiki->Redirect(
-            $this->wiki->href('', '', [BAZ_VARIABLE_VOIR => BAZ_VOIR_LISTES], false)
+            $this->wiki->href('', '', [BAZ_VARIABLE_VOIR => BAZ_VOIR_LISTES], null, false)
         );
     }
 }

--- a/tools/bazar/fields/FileField.php
+++ b/tools/bazar/fields/FileField.php
@@ -35,7 +35,7 @@ class FileField extends BazarField
                 return $this->render('@bazar/inputs/file.twig', [
                     'value' => $value,
                     'fileUrl' => BAZ_CHEMIN_UPLOAD . $value,
-                    'deleteUrl' => $GLOBALS['wiki']->href('edit', $GLOBALS['wiki']->GetPageTag(), 'delete_file=' . $value, false)
+                    'deleteUrl' => $GLOBALS['wiki']->href('edit', $GLOBALS['wiki']->GetPageTag(), 'delete_file=' . $value, null, false)
                 ]);
             }
         }

--- a/tools/bazar/fields/ImageField.php
+++ b/tools/bazar/fields/ImageField.php
@@ -164,7 +164,7 @@ class ImageField extends FileField
                 return $this->render('@bazar/inputs/image.twig', [
                     'value' => $value,
                     'downloadUrl' => BAZ_CHEMIN_UPLOAD . $value,
-                    'deleteUrl' => $GLOBALS['wiki']->href('edit', $GLOBALS['wiki']->GetPageTag(), 'suppr_image=' . $value, false),
+                    'deleteUrl' => $GLOBALS['wiki']->href('edit', $GLOBALS['wiki']->GetPageTag(), 'suppr_image=' . $value, null, false),
                     'image' => afficher_image(
                         $this->name,
                         $value,

--- a/tools/bazar/presentation/templates/gogomap.tpl.html
+++ b/tools/bazar/presentation/templates/gogomap.tpl.html
@@ -43,7 +43,7 @@
   // All param attached in bazarlist action
   var param = <?php echo json_encode($param) ?>;
   // Url to get the wiki categories
-  var categoriesUrl = "<?php echo $GLOBALS['wiki']->href('json', 'BazaR', 'demand=lists', false) ?>";
+  var categoriesUrl = "<?php echo $GLOBALS['wiki']->href('json', 'BazaR', 'demand=lists', null, false) ?>";
 
   var gogoConf = {};
   var confReady = false; // sometime we need to download distant configuration

--- a/tools/bazar/presentation/templates/widget.tpl.html
+++ b/tools/bazar/presentation/templates/widget.tpl.html
@@ -2,7 +2,7 @@
   data-formid="<?php echo $_GET['id']; ?>"
   data-templatemodel="<?php echo $params['template']; ?>"
   data-providermodel="<?php echo $params['provider']; ?>"
-  data-iframeUrl="<?php echo $GLOBALS['wiki']->href('iframe', '', $urlparams, false); ?>"
+  data-iframeUrl="<?php echo $GLOBALS['wiki']->href('iframe', '', $urlparams, null, false); ?>"
   data-checkedFacette="<?php echo '[]'; ?>"
   data-markerfieldmodel="<?php echo _t('BAZ_CHOISIR'); ?>"
   data-colorfieldmodel="<?php echo _t('BAZ_CHOISIR'); ?>"

--- a/tools/login/actions/usersettings.php
+++ b/tools/login/actions/usersettings.php
@@ -63,7 +63,7 @@ if ($action == 'logout') { // User wants to log out
             if ($userLoggedIn) { // In case it's the usther trying to update oneself
                 $this->Redirect($this->href());
             } else { // That's the admin acting, we need to pass the user on
-                $this->Redirect($this->href('', '', 'user='.$_GET['user'].'&from='.$referrer, false));
+                $this->Redirect($this->href('', '', 'user='.$_GET['user'].'&from='.$referrer,null, false));
             }
         } else { // Unable to update
             $this->session->setMessage($this->user->error);
@@ -104,7 +104,7 @@ if ($action == 'logout') { // User wants to log out
     } ?></h2>
 <?php
 if ($adminIsActing) {
-        $href = $this->href('', '', 'user='.$this->user->getProperty('name').'&from='.$referrer, false);
+        $href = $this->href('', '', 'user='.$this->user->getProperty('name').'&from='.$referrer, null, false);
     } else {
         $href = $this->href();
     } ?>
@@ -144,7 +144,7 @@ if ($adminIsActing) {
 <?php
             if ($adminIsActing) { // Admin is acting
 ?>
-<form action="<?php echo $this->href('', '', 'user='.$this->user->getProperty('name').'&from='.$referrer, false); ?>" method="post" class="form-horizontal">
+<form action="<?php echo $this->href('', '', 'user='.$this->user->getProperty('name').'&from='.$referrer, null, false); ?>" method="post" class="form-horizontal">
 	<input type="hidden" name="usersettings_action" value="deleteByAdmin" />
 	<input class="btn btn-danger" type="submit" value="<?php echo _t('USER_DELETE');?>" />
 <?php echo $this->FormClose();

--- a/tools/tags/actions/nuagetag.php
+++ b/tools/tags/actions/nuagetag.php
@@ -71,7 +71,7 @@ if (is_array($tab_tous_les_tags)) {
             } else {
                 $texte_page= _t('TAGS_ONE_PAGE');
             }
-            $texte_liste  = '<li class="tag-list">'."\n".'<a class="tag-link size'.ceil($nb_pages/$mult).'" id="j'.$i.'" data-title="'.htmlspecialchars('<button class="btn-close-popover pull-right close" type="button">&times;</button>'.$texte_page.' '._t('TAGS_CONTAINING_TAG').' : <a href="'.$this->href('listpages', $this->GetPageTag(), 'tags='.$tag_precedent, ENT_QUOTES, $this->config['charset']).'" class="tag-label label label-primary">'.$tag_precedent.'</a>').'" data-content="'.htmlspecialchars('<ul class="unstyled list-unstyled">'.$liste_page.'</ul>', ENT_QUOTES, $this->config['charset']).'">'.$tag_precedent.'</a>'."\n";
+            $texte_liste  = '<li class="tag-list">'."\n".'<a class="tag-link size'.ceil($nb_pages/$mult).'" id="j'.$i.'" data-title="'.htmlspecialchars('<button class="btn-close-popover pull-right close" type="button">&times;</button>'.$texte_page.' '._t('TAGS_CONTAINING_TAG').' : <a href="'.$this->href('listpages', $this->GetPageTag(), 'tags='.$tag_precedent, ENT_QUOTES, null, $this->config['charset']).'" class="tag-label label label-primary">'.$tag_precedent.'</a>').'" data-content="'.htmlspecialchars('<ul class="unstyled list-unstyled">'.$liste_page.'</ul>', ENT_QUOTES, $this->config['charset']).'">'.$tag_precedent.'</a>'."\n";
             $texte_liste .= '</li>'."\n";
             $tab_tag[] = $texte_liste;
 

--- a/tools/tags/handlers/page/epub.php
+++ b/tools/tags/handlers/page/epub.php
@@ -28,7 +28,7 @@ if (isset($metadatas["ebook-title"]) && isset($metadatas["ebook-description"]) &
 
     // Title and Identifier are mandatory!
     $book->setTitle($metadatas["ebook-title"]);
-    $book->setIdentifier($this->href('', $this->getPageTag()), EPub::IDENTIFIER_URI); // Could also be the ISBN number, prefered for published books, or a UUID.
+    $book->setIdentifier($this->href('', $this->getPageTag()), null, EPub::IDENTIFIER_URI); // Could also be the ISBN number, prefered for published books, or a UUID.
     $book->setLanguage($this->config["lang"]); // Not needed, but included for the example, Language is mandatory, but EPub defaults to "en". Use RFC3066 Language codes, such as "en", "da", "fr" etc.
     $book->setDescription($metadatas["ebook-description"]);
     $book->setAuthor($metadatas["ebook-author"], $metadatas["ebook-author-biblio"]);

--- a/tools/templates/actions/nav.php
+++ b/tools/templates/actions/nav.php
@@ -49,16 +49,17 @@ if (!empty($icons)) {
 $listlinks = '';
 foreach ($titles as $key => $title) {
     $linkParts = $this->extractLinkParts($links[$key]);
-    [$url, $method, $params] = ['', '', ''];
+    [$url, $method, $params, $anchor] = ['', '', '', ''];
     if ($linkParts){
         $method = $linkParts['method'];
         $params = $linkParts['params'];
-        $url = $this->href($method, $linkParts['tag'], $params);
+        $anchor = $linkParts['anchor'];
+        $url = $this->href($method, $linkParts['tag'], $params, $anchor);
     } else {
         $url = $links[$key];
     }
     // class="active" if the url have the same url than the current one (independently of the method and the params)
-    $listclass = ($url == $this->href($method, $this->GetPageTag(), $params)) ? ' class="active"' : '';
+    $listclass = ($url == $this->href($method, $this->GetPageTag(), $params, $anchor)) ? ' class="active"' : '';
     $listlinks .= '<li' . $listclass . '><a href="'.$url.'">'
         . (isset($icons[$key]) ? $icons[$key] : '')
         . $title.'</a></li>'."\n";


### PR DESCRIPTION
Suite de https://github.com/YesWiki/yeswiki/pull/593.

J'ai surtout fait en sorte que les ancres soient gérées directement depuis les fonctions de liens et qu'elles ne passent pas en bidouille pour un lien classique.
J'ai gardé le \S, c'était en effet une bonne idée, cela simplifie et ça n'a pas de conséquence sur le reste.
J'ai simplifié au niveau des regexps de Constants, j'ai factorisé extractLinkParts et generateLink et maintenant les liens qui n'ont pas de tag sont reconnus de partout en tant que page courante.

@mrflos Tu avais donné le choix d'utiliser ? ou & pour passer aux paramètres dans l'url. Tu y tiens ?
Je ne suis pas fan dès le départ de laisser ces deux possibilités, car j'ai peur que ça embrouille de voir les deux utilisations. Pour moi, c'est plus clair de laisser le Tag + # pour mettre une ancre + ? pour mettre un paramètre et & pour les autres paramètres : ça respecte la logique des urls  internet. Et on risque en plus de passer un de ces jours à des urls plus classiques avec les @Route de symfony (si on préfère, bref on verra).
Je voulais à la base laisser les 2 possibilités et d'abord t'en parler mais ça m'a bloqué pour avancer, donc je l'ai supprimer.
En effet maintenant que le tag vide renvoie la page courante, quand on écrit `?Bazar&param1=1&param2=2`, on n'aurait pas pu dissocier s'il on voulait la page Bazar avec 2 paramètres, ou la page courante avec le paramètre Bazar sans valeur + param1 et 2 avec valeurs. Maintenant c'est cette dernière option qui est reconnue.

J'ai aussi rajouté la possibilité pour href d'avoir comme ci-dessus des paramètres sans valeur car [ces paramètres sont parfaitement valides](https://stackoverflow.com/a/14194196).

Voici les différents cas testés :
```
[[Bazar/edit&tutu=1&titi=2 Bazar/edit&tutu=1&titi=2]]
[[https://yeswiki.test/?Bazar/edit&tutu=1&titi=2 https://yeswiki.test/?Bazar/edit&tutu=1&titi2=2]]
[[?Bazar/edit&tutu=1&titi=2 ?Bazar/edit&tutu=1&titi=2]]
[[#ancre #ancre]]
[[chemin/fichier.html chemin/fichier.html]]
[[BazaR#toto BazaR#toto]]
```

Et pour le chemin relatif (c'était déjà le cas pour https://github.com/YesWiki/yeswiki/pull/593), ça ne fonctionne pas. En effet, `chemin/fichier.html` est détecté en tant que tag : chemin et method : fichier.html.
Par contre `/files/monpdf.pdf` est détecter en tant que lien classique (car plusieurs /), mais du coup ça marche que sur les wiki qui ne sont pas dans un sous-répertoire...
A voir si c'est important mais s'il on veut, il y a toujours la possibilité de détecter les urls classiques qui commencent par /, et les réécrire en base_url + l'url...















