### PR TITLE
Creates block action.

### DIFF
--- a/docs/actions/block.yaml
+++ b/docs/actions/block.yaml
@@ -1,0 +1,26 @@
+label: _t(AB_BLOCK_LABEL)
+position: 3
+previewHeight: 200px
+actions:
+  block:
+    label: _t(AB_BLOCK_LABEL)
+    description: _t(AB_BLOCK_DESC)
+    isWrapper: true
+    wrappedContentExample: _t(AB_BLOCK_SAMPLE)
+    properties:
+      class:
+        label: _t(AB_BLOCK_CLASS_LABEL)
+        type: text
+        hint: _t(AB_BLOCK_CLASS_HINT)
+      style:
+        label: _t(AB_BLOCK_STYLE_LABEL)
+        type: text
+        hint: _t(AB_BLOCK_STYLE_HINT)
+      id:
+        label: _t(AB_BLOCK_ID_LABEL)
+        type: text
+        hint: _t(AB_BLOCK_ID_HINT)
+      data:
+        label: _t(AB_BLOCK_DATA_LABEL)
+        type: text
+        hint: _t(AB_BLOCK_DATA_HINT)

--- a/docs/actions/lang/actionsbuilder_en.inc.php
+++ b/docs/actions/lang/actionsbuilder_en.inc.php
@@ -27,4 +27,16 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations'], array(
     'AB_attach_pdf_position_label' => "Position",
     'AB_attach_pdf_largeur_max_label' => "PDF file maximum width",
     'AB_attach_pdf_hauteur_max_label' => "PDF file Video maximum height)",
+    //block
+    'AB_BLOCK_LABEL' => 'Block',
+    'AB_BLOCK_DESC' => 'Creates a block which layout you can specify. You can also name the block (to be able to link directly to it).',
+    'AB_BLOCK_SAMPLE' => "If you see all grey, move the elephant!",
+    'AB_BLOCK_CLASS_LABEL' => "CSS Class",
+    'AB_BLOCK_CLASS_HINT' => 'The CSS class(es) (from you wiki) you want to apply to this block',
+    'AB_BLOCK_STYLE_LABEL' => "Style (CSS)",
+    'AB_BLOCK_STYLE_HINT' => "If you know about CSS and want to change this block's layout",
+    'AB_BLOCK_ID_LABEL' => "Id",
+    'AB_BLOCK_ID_HINT' => "Gives this block a name you can use to create links",
+    'AB_BLOCK_DATA_LABEL' => "Data",
+    'AB_BLOCK_DATA_HINT' => "To add more attributes to the block, this way: \"attribute1=value1,attribute2=value2\"",
 ));

--- a/docs/actions/lang/actionsbuilder_fr.inc.php
+++ b/docs/actions/lang/actionsbuilder_fr.inc.php
@@ -27,4 +27,16 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations'], array(
     'AB_attach_pdf_position_label' => "Position du pdf",
     'AB_attach_pdf_largeur_max_label' => "Largeur maximale",
     'AB_attach_pdf_hauteur_max_label' => "Hauteur maximale",
+    //block
+    'AB_BLOCK_LABEL' => 'Bloc',
+    'AB_BLOCK_DESC' => 'Crée un bloc pour lequel vous pouvez préciser une présentation ou un comportement. Vous pouvez également le nommer ce qui permet, par la suite de créer des liens qui y pointent directement.',
+    'AB_BLOCK_SAMPLE' => "Si tu vois tout en gris, déplace l'éléphant !",
+    'AB_BLOCK_CLASS_LABEL' => "Classe",
+    'AB_BLOCK_CLASS_HINT' => 'La ou les classes CSS (parmi celles de votre wiki) que vous souhaitez appliquer à ce bloc',
+    'AB_BLOCK_STYLE_LABEL' => "Style (CSS)",
+    'AB_BLOCK_STYLE_HINT' => "Si vous connaissez la syntaxe CSS et souhaitez modifier l'affichage ou le comportement de ce bloc",
+    'AB_BLOCK_ID_LABEL' => "Identifiant",
+    'AB_BLOCK_ID_HINT' => "Donne un nom au bloc, ce qui permet de créer des liens qui y pointent",
+    'AB_BLOCK_DATA_LABEL' => "Data",
+    'AB_BLOCK_DATA_HINT' => "Pour ajouter d'autres attributs au bloc, sous la forme \"attribut1=valeur1,attribut2=valeur2\"",
 ));

--- a/tools/templates/actions/block.php
+++ b/tools/templates/actions/block.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+block.php
+
+Block opens a section HTML element.
+*/
+
+// Get the action's parameters :
+
+// div id
+$id = $this->GetParameter('id');
+
+// div class
+$class = $this->GetParameter('class');
+
+// div style attribute
+$style = $this->GetParameter('style');
+
+// div data attributes
+$data = getDataParameter();
+
+// notifying action counter
+$pagetag = $this->GetPageTag();
+if (!isset($GLOBALS['check_' . $pagetag]['block'])) {
+    $GLOBALS['check_' . $pagetag]['block'] = check_graphical_elements('block', $pagetag, $this->page['body']);
+}
+if ($GLOBALS['check_' . $pagetag]['block']) {
+    
+    echo '<!-- start of block -->
+    <section' 
+    .(!empty($id) ? ' id="'.$id .'"' : '') 
+    .(!empty($class) ? ' class="'.$class .'"' : '') 
+    .(!empty($style) ? ' style="'.$style .'"' : '');
+    if (is_array($data)) {
+        foreach ($data as $key => $value) {
+            echo ' data-'.$key.'="'.$value.'"';
+        }
+    }
+    echo '>' . "\n";
+} else {
+    echo '<div class="alert alert-danger"><strong>' . _t('TEMPLATE_ACTION_BLOCK') . '</strong> : '
+        . _t('TEMPLATE_ELEM_BLOCK_NOT_CLOSED') . '.</div>' . "\n";
+    return;
+}

--- a/tools/templates/actions/end.php
+++ b/tools/templates/actions/end.php
@@ -33,6 +33,9 @@ if (empty($elem)) {
             case 'col':
                 echo "\n</div> <!-- end of col -->\n";
                 break;
+            case 'block':
+                echo "\n</section> <!-- end of block -->\n";
+                break;
             case 'section':
                 echo "\n</div>\n</section> <!-- end of section -->\n";
                 break;

--- a/tools/templates/lang/templates_fr.inc.php
+++ b/tools/templates/lang/templates_fr.inc.php
@@ -142,6 +142,10 @@ $GLOBALS['translations'] = array_merge(
     'TEMPLATE_ACTION_GRID' => 'Action {{grid ...}}',
     'TEMPLATE_ELEM_GRID_NOT_CLOSED' => 'l\'action {{grid ...}} doit &ecirc;tre ferm&eacute;e par une action {{end elem="grid"}}',
 
+    // actions/block.php
+    'TEMPLATE_ACTION_BLOCK' => 'Action {{block ...}}',
+    'TEMPLATE_ELEM_BLOCK_NOT_CLOSED' => 'l\'action {{block ...}} doit &ecirc;tre ferm&eacute;e par une action {{end elem="block"}}',
+
     // action/panel.php
     'TEMPLATE_ACTION_PANEL' => 'Action {{panel ...}}',
     'TEMPLATE_ELEM_PANEL_NOT_CLOSED' => 'l\'action {{panel ...}} doit &ecirc;tre ferm&eacute;e par une action {{end elem="panel"}}',


### PR DESCRIPTION
L'action `{{block}}` crée une section HTML
*Suite à PR [578](https://github.com/YesWiki/yeswiki/pull/578)*

## Description of pull request / Description de la demande d'ajout
Mettre les outils CSS de mise en page de bloc à disposition des utilisateurs finaux en minimisant l'ajout de code HTML.
Permet d'imbriquer facilement un conteneur (flex ou grid par exemple) et les blocs à mettre en page dans ce conteneur.

Rend plus simple l'approche pédagogique d'outils CSS performants dans YesWiki.

Techniquement, ça crée une `<section>` HTML (parce qu'avec des `div`, les mises en page trop complexes se plantent).

Les attributs `class`, `style` et `id` sont récupérés. On peut aussi créer des attributs du type `data`.
