### PR TITLE
refacto(semantic): don't call semantic transformer when no semantic type

### DIFF
--- a/tools/bazar/controllers/ApiController.php
+++ b/tools/bazar/controllers/ApiController.php
@@ -67,8 +67,8 @@ class ApiController extends YesWikiController
                 '@id' => $this->wiki->Href('fiche/' . $formId, 'api'),
                 '@type' => [ 'ldp:Container', 'ldp:BasicContainer' ],
                 'dcterms:title' => $form['bn_label_nature'],
-                'ldp:contains' => array_map(function ($entry) {
-                    $resource = $this->getService(SemanticTransformer::class)->convertToSemanticData($entry['id_typeannonce'], $entry, true);
+                'ldp:contains' => array_map(function ($entry) use ($form) {
+                    $resource = $this->getService(SemanticTransformer::class)->convertToSemanticData($form, $entry, true);
                     unset($resource['@context']);
                     return $resource;
                 }, array_values($entries)),

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -329,16 +329,10 @@ class EntryController extends YesWikiController
                 }
             }
         }
-
-        try {
+        
+        if ($form['bn_sem_type']){
             $html['id_fiche'] = $entry['id_fiche'];
-            $html['semantic'] = $this->semanticTransformer->convertToSemanticData(
-                $form['bn_id_nature'],
-                $html,
-                true
-            );
-        } catch (\Exception $e) {
-            // Do nothing if semantic type is not available
+            $html['semantic'] = $GLOBALS['wiki']->services->get(SemanticTransformer::class)->convertToSemanticData($form, $html, true);
         }
 
         $values['html'] = $html;

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -615,7 +615,8 @@ class EntryManager
 
         // Données sémantiques
         if ($semantic) {
-            $fiche['semantic'] = $this->semanticTransformer->convertToSemanticData($fiche['id_typeannonce'], $fiche);
+            $form = $this->getService(FormManager::class)->getOne($fiche['id_typeannonce']);
+            $fiche['semantic'] = $this->semanticTransformer->convertToSemanticData($form, $fiche);
         }
     }
 

--- a/tools/bazar/services/SemanticTransformer.php
+++ b/tools/bazar/services/SemanticTransformer.php
@@ -6,15 +6,14 @@ use YesWiki\Bazar\Field\BazarField;
 
 class SemanticTransformer
 {
-    public function convertToSemanticData($formId, $data, $isHtmlFormatted = false)
+    public function convertToSemanticData($form, $data, $isHtmlFormatted = false)
     {
-        $form = baz_valeurs_formulaire($formId);
         if (!$form['bn_sem_type']) {
             throw new \Exception(_t('BAZAR_SEMANTIC_TYPE_MISSING'));
         }
 
         // If context is a JSON decode it, otherwise use the string
-        $semanticData['@context'] = (array) json_decode($form['bn_sem_context']) ?: $form['bn_sem_context'];
+        $semanticData['@context'] = (array)json_decode($form['bn_sem_context']) ?: $form['bn_sem_context'];
 
         // If we have multiple types split by comma, generate an array, otherwise use a string
         $semanticData['@type'] = strpos($form['bn_sem_type'], ',')
@@ -27,6 +26,7 @@ class SemanticTransformer
         $semanticData['@id'] = $GLOBALS['wiki']->href('', $data['id_fiche']);
 
         foreach ($form['prepared'] as $field) {
+
             if ($field instanceof BazarField) {
                 $fieldPropName = $field->getPropertyName();
                 $fieldSemanticPredicate = $field->getSemanticPredicate();
@@ -74,13 +74,18 @@ class SemanticTransformer
         $form = baz_valeurs_formulaire($formId);
 
         // Initialize by copying basic information
-        $nonSemanticData = ['id_fiche' => $data['id_fiche'], 'antispam' => $data['antispam'], 'id_typeannonce' => $data['id_typeannonce']];
+        $nonSemanticData = [
+            'id_fiche' => $data['id_fiche'],
+            'antispam' => $data['antispam'],
+            'id_typeannonce' => $data['id_typeannonce']
+        ];
 
         if (($data['@type'] && $data['@type'] !== $form['bn_sem_type']) || $data['type'] && $data['type'] !== $form['bn_sem_type']) {
             exit('The @type of the sent data must be ' . $form['bn_sem_type']);
         }
 
         foreach ($form['prepared'] as $field) {
+
             if ($field instanceof BazarField) {
                 $fieldPropName = $field->getPropertyName();
                 $fieldSemanticPredicate = $field->getSemanticPredicate();
@@ -101,7 +106,7 @@ class SemanticTransformer
                     $nonSemanticData[$fieldPropName . '_hour'] = $date->format('H');
                     $nonSemanticData[$fieldPropName . '_minutes'] = $date->format('i');
                 } elseif ($fieldType === 'image') {
-                    $nonSemanticData['image'.$fieldPropName] = $data[$fieldSemanticPredicate];
+                    $nonSemanticData['image' . $fieldPropName] = $data[$fieldSemanticPredicate];
                 } else {
                     $nonSemanticData[$fieldPropName] = $data[$fieldSemanticPredicate];
                 }


### PR DESCRIPTION
j'ai vu que le transformer semantic était systémiquement appelé suite à des questions d'oncle tom sur le canal dev.

je propose donc ces modifs qui évitent ça, de ne pas recharger le formulaire dans certains cas où on l'a déjà, et d'utiliser un catch pour traiter un cas classique.
 
ça implique très peu de code mais j'avoue ne pas avoir testé avec un formulaire "sémantique" (EDITED) :/
 
