### PR TITLE
improve link tracking for button nav include

### DIFF
--- a/actions/include.php
+++ b/actions/include.php
@@ -33,6 +33,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
     -- valeur "show" :  ajoute un lien "[édition]" en haut é droite de la boite
 */
 
+use YesWiki\Core\Service\LinkTracker;
+
 // récuperation du nom de la page é inclure
 $incPageName = trim($this->GetParameter('page'));
 
@@ -69,6 +71,7 @@ if (empty($incPageName)) {
 }
 // Affichage de la page quand il n'y a pas d'erreur
 elseif ($this->HasAccess('read', $incPageName)) {
+    $this->services->get(LinkTracker::class)->forceAddIfNotIncluded($incPageName);
     $this->RegisterInclusion($incPageName);
     $output = $this->Format($incPage['body']);
     if (isset($classes)) {

--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -533,19 +533,17 @@ class Wiki
     {
         if (empty($link)) {
             return null;
-        } elseif (preg_match('/^(' . WN_CAMEL_CASE_EVOLVED . ')(?:\/(' . WN_CAMEL_CASE_EVOLVED . '))?(?:[?&]('
-            . RFC3986_URI_CHARS . '))?$/', $link, $linkParts)) {
-            $tag = !empty($linkParts[1]) ? $linkParts[1] : null;
-            $method = !empty($linkParts[2]) ? $linkParts[2] : null;
-            $paramsStr = !empty($linkParts[3]) ? $linkParts[3] : null;
-            parse_str($paramsStr, $params);
-            return $this->href($method, $tag, $params);
-        } elseif (filter_var($link, FILTER_VALIDATE_URL)) {
-            // a valid url
-            return $link;
         } else {
-            // for now let's be tolerant : it may be a relative url or an anchor
-            return $link;
+            $linkParts = $this->extractLinkParts($link) ;
+            if ($linkParts) {
+                return $this->href($linkParts['method'], $linkParts['tag'], $linkParts['params']);
+            } elseif (filter_var($link, FILTER_VALIDATE_URL)) {
+                // a valid url
+                return $link;
+            } else {
+                // for now let's be tolerant : it may be a relative url or an anchor
+                return $link;
+            }
         }
     }
     /**

--- a/includes/services/LinkTracker.php
+++ b/includes/services/LinkTracker.php
@@ -45,6 +45,17 @@ class LinkTracker
         return $oldState;
     }
 
+    public function forceAddIfNotIncluded(string $tag) : bool
+    {
+        $inclusions = $this->wiki->GetAllInclusions() ;
+        if ($inclusions && count($inclusions) <2 && !in_array($tag,$this->links)) {
+            $this->links[] = $tag ;
+            return true ;
+        } else {
+            return false ;
+        }
+    }
+
     public function add($tag)
     {
         if ($this->track()) {

--- a/tools/templates/actions/button.php
+++ b/tools/templates/actions/button.php
@@ -1,4 +1,7 @@
 <?php
+
+use YesWiki\Core\Service\LinkTracker;
+
 if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
 }
@@ -15,6 +18,7 @@ if ($link == "config/root_page") {
 $linkParts = $this->extractLinkParts($link);
 if ($linkParts){
     $link = $this->href($linkParts['method'], $linkParts['tag'], $linkParts['params']);
+    $this->services->get(LinkTracker::class)->forceAddIfNotIncluded($linkParts['tag']);
 }
 // change short yeswiki urls in real links
 $link = $this->generateLink($link);

--- a/tools/templates/actions/nav.php
+++ b/tools/templates/actions/nav.php
@@ -1,4 +1,7 @@
 <?php
+
+use YesWiki\Core\Service\LinkTracker;
+
 if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
 }
@@ -51,6 +54,7 @@ foreach ($titles as $key => $title) {
     $linkParts = $this->extractLinkParts($links[$key]);
     [$url, $method, $params] = ['', '', ''];
     if ($linkParts){
+        $this->services->get(LinkTracker::class)->forceAddIfNotIncluded($linkParts['tag']);
         $method = $linkParts['method'];
         $params = $linkParts['params'];
         $url = $this->href($method, $linkParts['tag'], $params);


### PR DESCRIPTION
## Description of pull request / Description de la demande d'ajout
Je fais cette proposition pour résoudre l'issue #480.

L'idée est de permettre le suivi de lien pour les actions button, nav, include.
Il serait possible d'utiliser cette nouvelle fonctionnalité de LinkTracker dans les autres actions si besoins.

Il y a un test pour s'assurer que nous ne sommes pas dans une inclusion et éviter ainsi les récursions.

Voyez-vous d'autres effets de bords potentiels ?

ping : @acheype si tu as envie de faire une revue, tu peux , sinon il y a déjà @mrflos 
@srosset81 c'est pour m'assurer que tout va bien avec le linktracker