### PR TITLE
fix empty field acl in forms and bazarfields

### DIFF
--- a/includes/services/AclService.php
+++ b/includes/services/AclService.php
@@ -175,7 +175,7 @@ class AclService
      *            The name of the page or form to be tested when $acl contains '%'.
      *            By Default ''
      * @param string $mode
-     *            Mode for case $acl contains '%'
+     *            Mode for cases when $acl contains '%'
      *            Default '', standard case. $mode = 'creation', the test returns true
      *            even if the user is connected
      * @return bool True if the $user satisfies the $acl, false otherwise

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -94,19 +94,18 @@ class EntryController extends YesWikiController
         // If not found, use default template
         if (empty($renderedEntry)) {
             for ($i = 0; $i < count($form['template']); ++$i) {
-                // Check if we should display the field
-                if (empty($form['template'][$i][11]) || $this->aclService->check(
-                        $form['template'][$i][11],
-                        null,
-                        true,
-                        $entryId)
-                ) {
-                    if ($form['prepared'][$i] instanceof BazarField) {
+                if ($form['prepared'][$i] instanceof BazarField) {
+                    $field = $form['prepared'][$i];
+                    if ($this->wiki->CheckACL($field->getReadAccess(), null, true, $entryId)) {
                         // TODO handle html_outside_app mode for images
-                        $renderedEntry .= $form['prepared'][$i]->renderStatic($entry);
-                    } else {
-                        $functionName = $form['template'][$i][0];
-                        if (function_exists($functionName)) {
+                        $renderedEntry .= $field->renderStatic($entry);
+                    }
+                } else {
+                    // Check if we should display the field
+                    $functionName = $form['template'][$i][0];
+                    if (function_exists($functionName)) {
+                        if (empty($form['prepared'][$i]['read_acl']) ||
+                                $this->wiki->CheckACL($form['prepared'][$i]['read_acl'], null, true, $entryId)) {
                             $renderedEntry .= $functionName(
                                 $formtemplate,
                                 $form['template'][$i],
@@ -156,8 +155,12 @@ class EntryController extends YesWikiController
         if (isset($_POST['bf_titre'])) {
             $entry = $this->entryManager->create($formId, $_POST);
             if (empty($redirectUrl)) {
-                $redirectUrl = $this->wiki->Href('', '',
-                    ['vue' => 'consulter', 'action' => 'voir_fiche', 'id_fiche' => $entry['id_fiche']], false);
+                $redirectUrl = $this->wiki->Href(
+                    '',
+                    '',
+                    ['vue' => 'consulter', 'action' => 'voir_fiche', 'id_fiche' => $entry['id_fiche']],
+                    false
+                );
             }
             header('Location: ' . $redirectUrl);
             exit;
@@ -211,10 +214,9 @@ class EntryController extends YesWikiController
         for ($i = 0; $i < count($form['prepared']); ++$i) {
             if ($form['prepared'][$i] instanceof BazarField) {
                 $renderedFields[] = $form['prepared'][$i]->renderInputIfPermitted($entry);
-            } else {
-                if (function_exists($form['template'][$i][0])) {
-                    $renderedFields[] = $form['template'][$i][0]($formtemplate, $form['template'][$i], 'saisie',
-                        $entry);
+            } elseif (function_exists($form['template'][$i][0])) {
+                if (empty($form['prepared'][$i]['write_acl']) || $this->wiki->CheckACL($form['prepared'][$i]['write_acl'], null, true, ($entry['id_fiche'] ?? null))) {
+                    $renderedFields[] = $form['template'][$i][0]($formtemplate, $form['template'][$i], 'saisie', $entry);
                 }
             }
         }
@@ -268,17 +270,21 @@ class EntryController extends YesWikiController
     {
         $html = $formtemplate = [];
         for ($i = 0; $i < count($form['template']); ++$i) {
-            if (empty($form['template'][$i][11]) ||
-                $this->aclService->check($form['template'][$i][11], null, true, $entry['id_fiche'])) {
-                if ($form['prepared'][$i] instanceof BazarField) {
+            $replace = false ;
+            if ($form['prepared'][$i] instanceof BazarField) {
+                if ($this->wiki->CheckACL($form['prepared'][$i]->getReadAccess(), null, true, $entry['id_fiche'])) {
                     $id = $form['prepared'][$i]->getPropertyName();
                     $html[$id] = $form['prepared'][$i]->renderStatic($entry);
-                } else {
-                    if (function_exists($form['template'][$i][0])) {
-                        $id = $form['template'][$i][1];
-                        $html[$id] = $form['template'][$i][0]($formtemplate, $form['template'][$i], 'html', $entry);
-                    }
+                    $replace = true ;
                 }
+            } elseif (function_exists($form['template'][$i][0])) {
+                if (empty($form['prepared'][$i]['read_acl']) || $this->wiki->CheckACL($form['prepared'][$i]['read_acl'], null, true, $entry['id_fiche'])) {
+                    $id = $form['template'][$i][1];
+                    $html[$id] = $form['template'][$i][0]($formtemplate, $form['template'][$i], 'html', $entry);
+                    $replace = true ;
+                }
+            }
+            if ($replace) {
                 preg_match_all('/<span class="BAZ_texte">\s*(.*)\s*<\/span>/is', $html[$id], $matches);
                 if (isset($matches[1][0]) && $matches[1][0] != '') {
                     $html[$id] = $matches[1][0];
@@ -287,8 +293,11 @@ class EntryController extends YesWikiController
         }
 
         try {
-            $html['semantic'] = $this->semanticTransformer->convertToSemanticData($form['bn_id_nature'], $html,
-                true);
+            $html['semantic'] = $this->semanticTransformer->convertToSemanticData(
+                $form['bn_id_nature'],
+                $html,
+                true
+            );
         } catch (\Exception $e) {
             // Do nothing if semantic type is not available
         }

--- a/tools/bazar/fields/BazarField.php
+++ b/tools/bazar/fields/BazarField.php
@@ -61,6 +61,15 @@ abstract class BazarField
     }
 
     // Render the edit view of the field. Check ACLS first
+    public function renderStaticIfPermitted($entry)
+    {
+        // Safety checks, must be run before every renderStatic
+        if( !$this->canRead($entry) ) return '';
+
+        return $this->renderStatic($entry);
+    }
+
+    // Render the edit view of the field. Check ACLS first
     public function renderInputIfPermitted($entry)
     {
         // Safety checks, must be run before every renderInput
@@ -76,7 +85,7 @@ abstract class BazarField
     }
 
     // Render the show view of the field
-    public function renderStatic($entry)
+    protected function renderStatic($entry)
     {
         return $this->render("@bazar/fields/{$this->type}.twig", [
             'value' => $this->getValue($entry)
@@ -107,7 +116,15 @@ abstract class BazarField
 
     // HELPERS
 
-    /* Return true if we are in edit mode and editing is not allowed */
+    /* Return true if we are if reading is allowed for the field */
+    protected function canRead($entry)
+    {
+        $readAcl = empty($this->readAccess) ? '' : $this->readAccess;
+        $isCreation = !$entry;
+        return empty($readAcl) || $GLOBALS['wiki']->CheckACL($readAcl, null, true, $isCreation ? '' : $entry['id_fiche']);
+    }
+
+    /* Return true if we are if editing is allowed for the field */
     protected function canEdit($entry)
     {
         $writeAcl = empty($this->writeAccess) ? '' : $this->writeAccess;

--- a/tools/bazar/services/FormManager.php
+++ b/tools/bazar/services/FormManager.php
@@ -99,7 +99,7 @@ class FormManager
     public function create($data)
     {
         // If ID is not set or if it is already used, find a new ID
-        if( !$data['bn_id_nature'] || $this->getOne($data['bn_id_nature']) ) {
+        if (!$data['bn_id_nature'] || $this->getOne($data['bn_id_nature'])) {
             $data['bn_id_nature'] = $this->findNewId();
         }
 
@@ -132,7 +132,7 @@ class FormManager
     {
         //TODO : suppression des fiches associees au formulaire
 
-        return $this->dbService->query('DELETE FROM '.$this->dbService->prefixTable('nature').'WHERE bn_id_nature='. $id );
+        return $this->dbService->query('DELETE FROM '.$this->dbService->prefixTable('nature').'WHERE bn_id_nature='. $id);
     }
 
     public function clear($id)
@@ -141,19 +141,22 @@ class FormManager
             'DELETE FROM'. $this->dbService->prefixTable('acls').
             'WHERE page_tag IN (SELECT tag FROM '.$this->dbService->prefixTable('pages').
             'WHERE tag IN (SELECT resource FROM '.$this->dbService->prefixTable('triples').
-            'WHERE property="http://outils-reseaux.org/_vocabulary/type" AND value="fiche_bazar") AND body LIKE \'%"id_typeannonce":"'.$id.'"%\' );');
+            'WHERE property="http://outils-reseaux.org/_vocabulary/type" AND value="fiche_bazar") AND body LIKE \'%"id_typeannonce":"'.$id.'"%\' );'
+        );
 
         // TODO use PageManager
         $this->dbService->query(
             'DELETE FROM'.$this->dbService->prefixTable('pages').
             'WHERE tag IN (SELECT resource FROM '.$this->dbService->prefixTable('triples').
-            'WHERE property="http://outils-reseaux.org/_vocabulary/type" AND value="fiche_bazar") AND body LIKE \'%"id_typeannonce":"'.$id.'"%\';');
+            'WHERE property="http://outils-reseaux.org/_vocabulary/type" AND value="fiche_bazar") AND body LIKE \'%"id_typeannonce":"'.$id.'"%\';'
+        );
 
         // TODO use TripleStore
         $this->dbService->query(
             'DELETE FROM'.$this->dbService->prefixTable('triples').
             'WHERE resource NOT IN (SELECT tag FROM '.$this->dbService->prefixTable('pages').
-            'WHERE 1) AND property="http://outils-reseaux.org/_vocabulary/type" AND value="fiche_bazar";');
+            'WHERE 1) AND property="http://outils-reseaux.org/_vocabulary/type" AND value="fiche_bazar";'
+        );
     }
 
     public function findNewId()
@@ -198,13 +201,23 @@ class FormManager
                 $tablignechampsformulaire = array_map("trim", explode("***", $ligne));
 
                 // TODO find another way to check that the field is valid
-                if ( true /*function_exists($tablignechampsformulaire[self::FIELD_TYPE])*/) {
+                if (true /*function_exists($tablignechampsformulaire[self::FIELD_TYPE])*/) {
                     if (count($tablignechampsformulaire) > 3) {
                         $tableau_template[$nblignes] = $tablignechampsformulaire;
                         for ($i=0; $i < 16; $i++) {
                             if (!isset($tableau_template[$nblignes][$i])) {
                                 $tableau_template[$nblignes][$i] = '';
                             }
+                        }
+                        // default values for read acl
+                        if (empty(trim($tableau_template[$nblignes][self::FIELD_READ_ACCESS]))) {
+                            $defaultVal = $this->params->has('default_read_acl') ? $this->params->get('default_read_acl') : '*' ;
+                            $tableau_template[$nblignes][self::FIELD_READ_ACCESS] = $defaultVal;
+                        }
+                        // default values for write  acl
+                        if (empty(trim($tableau_template[$nblignes][self::FIELD_WRITE_ACCESS]))) {
+                            $defaultVal = $this->params->has('default_write_acl') ? $this->params->get('default_write_acl') : '*' ;
+                            $tableau_template[$nblignes][self::FIELD_WRITE_ACCESS] = $defaultVal;
                         }
                         $nblignes++;
                     }
@@ -223,10 +236,9 @@ class FormManager
         $form['template'] = _convert($form['template'], 'ISO-8859-15');
 
         foreach ($form['template'] as $field) {
-
             $classField = $this->fieldFactory->create($field);
 
-            if( $classField ) {
+            if ($classField) {
                 $prepared[$i] = $classField;
                 $i++;
                 continue;

--- a/tools/bazar/services/FormManager.php
+++ b/tools/bazar/services/FormManager.php
@@ -209,16 +209,7 @@ class FormManager
                                 $tableau_template[$nblignes][$i] = '';
                             }
                         }
-                        // default values for read acl
-                        if (empty(trim($tableau_template[$nblignes][self::FIELD_READ_ACCESS]))) {
-                            $defaultVal = $this->params->has('default_read_acl') ? $this->params->get('default_read_acl') : '*' ;
-                            $tableau_template[$nblignes][self::FIELD_READ_ACCESS] = $defaultVal;
-                        }
-                        // default values for write  acl
-                        if (empty(trim($tableau_template[$nblignes][self::FIELD_WRITE_ACCESS]))) {
-                            $defaultVal = $this->params->has('default_write_acl') ? $this->params->get('default_write_acl') : '*' ;
-                            $tableau_template[$nblignes][self::FIELD_WRITE_ACCESS] = $defaultVal;
-                        }
+
                         $nblignes++;
                     }
                 }
@@ -236,6 +227,16 @@ class FormManager
         $form['template'] = _convert($form['template'], 'ISO-8859-15');
 
         foreach ($form['template'] as $field) {
+        
+            // default values for read acl
+            if (empty(trim($field[self::FIELD_READ_ACCESS]))) {
+                $field[self::FIELD_READ_ACCESS] = '*' ;
+            }
+            // default values for write  acl
+            if (empty(trim($field[self::FIELD_WRITE_ACCESS]))) {
+                $field[self::FIELD_WRITE_ACCESS] = '*' ;
+            }
+
             $classField = $this->fieldFactory->create($field);
 
             if ($classField) {
@@ -266,6 +267,12 @@ class FormManager
 
             // texte d'aide
             $prepared[$i]['helper'] = $field[self::FIELD_HELP];
+
+            // values for read acl
+            $prepared[$i]['read_acl'] = $field[self::FIELD_READ_ACCESS];
+
+            // values for write acl
+            $prepared[$i]['write_acl'] = $field[self::FIELD_WRITE_ACCESS];
 
             // traitement sémantique
             // TODO move to BazarField

--- a/tools/bazar/services/FormManager.php
+++ b/tools/bazar/services/FormManager.php
@@ -227,16 +227,6 @@ class FormManager
         $form['template'] = _convert($form['template'], 'ISO-8859-15');
 
         foreach ($form['template'] as $field) {
-        
-            // default values for read acl
-            if (empty(trim($field[self::FIELD_READ_ACCESS]))) {
-                $field[self::FIELD_READ_ACCESS] = '*' ;
-            }
-            // default values for write  acl
-            if (empty(trim($field[self::FIELD_WRITE_ACCESS]))) {
-                $field[self::FIELD_WRITE_ACCESS] = '*' ;
-            }
-
             $classField = $this->fieldFactory->create($field);
 
             if ($classField) {


### PR DESCRIPTION
Bon je ne suis vraiment pas sûr d'avoir trouvé le meilleur endroit pour ce correctif.

Le problème : un formulaire peut avoir un template avec des champs readACL et writeACL vident.
Si le formulaire est modifié, c'est résolu par le javascript de l'édition des formulaires.

Toutefois, lors de la migration cercopitheque vers doryphore, OU vieux doryphore ou install par défaut, ces champs sont vides :
conséquences : il n'y a pas d'affichage des données car checkACL aimerait trouver une chaîne non vide.

1. @srosset81 es-tu OK avec la proposition de modifier le code à cet endroit ?
2. @mrflos est-ce que tu es d'accord avec le choix de récupérer les valeurs par défaut pour default_read_acl et default_write_acl normalement réservés pour les pages ?

A priori ça pourrait résoudre le souci d'oncletom.

_Je peux me charger de la fusion nettoyage de la branche etc une fois les revues validées._
