### PR TITLE
do not render a field when empty

### DIFF
--- a/tools/bazar/fields/BazarField.php
+++ b/tools/bazar/fields/BazarField.php
@@ -78,9 +78,10 @@ abstract class BazarField
     // Render the show view of the field
     public function renderStatic($entry)
     {
-        return $this->render("@bazar/fields/{$this->type}.twig", [
+        $value = $this->getValue($entry);
+        return ($value) ? $this->render("@bazar/fields/{$this->type}.twig", [
             'value' => $this->getValue($entry)
-        ]);
+        ]) : '';
     }
 
     // each field should implement this method instead of the renderInputIfPermitted


### PR DESCRIPTION
Bon, même si le correctif est très très petit, là je fais une PR car il joue sur l'interface d'affichage des fiches.
J'avais fait cette demande il y quelques temps pendant le refacto et ça n'a pas été pris en compte.
donc, n'ayant pas de trace du pourquoi, je fais une PR.
@mrflos es-tu d'accord que, par défaut, un champ vide ne s'affiche pas, ni son titre ?

(après il est toujours possible pour un champ de redéfinir la fonction renderStatic pour contourner ce comportement par défaut)
