### PR TITLE
`{{section}}` : utilisation de `background-color` au lieu de `background`

### DIFF
--- a/tools/templates/actions/section.php
+++ b/tools/templates/actions/section.php
@@ -85,7 +85,7 @@ if ($GLOBALS['check_' . $pagetag]['section']) {
     
     echo '<!-- start of section -->
     <section' . (!empty($id) ? ' id="'.$id .'"' : '') . ' class="'. ($backgroundimg ? 'background-image' : '') . ($visible ? '' : ' remove-this-div-on-page-load ') . (!empty($class) ? ' ' . $class : '') . '" style="'
-        .(!empty($bgcolor) ? 'background:' . $bgcolor .'; ' : '')
+        .(!empty($bgcolor) ? 'background-color:' . $bgcolor .'; ' : '')
         .(!empty($height) ? 'height:' . $height . 'px; ' : '')
         .(isset($fullFilename) ? 'background-image:url(' . $fullFilename . ');' : '').'"';
     if (is_array($data)) {


### PR DESCRIPTION
L'utilisation de `background` surcharge tout attribut qui modifie `background-position`, `background-repeat` et `background-size`.

Par exemple, l'attribut `cover`, ajouté par l'option "Comportement de l'image" n'est pas effectif à cause de ça.

![image](https://user-images.githubusercontent.com/138627/106603810-198e8080-655f-11eb-9715-4fb887e21eb0.png)

## Avant

```
{{section bgcolor="var(--neutral-color);" class="white text-center cover" file="bandeau.jpg" }}
```

![image](https://user-images.githubusercontent.com/138627/106603924-3925a900-655f-11eb-900a-49475ab3a367.png)

![image](https://user-images.githubusercontent.com/138627/106604339-cc5ede80-655f-11eb-8889-db727aa94846.png)




## Après

```
{{section bgcolor="var(--neutral-color);" class="white text-center cover" file="bandeau.jpg" }}
```

![image](https://user-images.githubusercontent.com/138627/106603996-4f336980-655f-11eb-965e-f6b4ffb71a6b.png)

![image](https://user-images.githubusercontent.com/138627/106604083-6d996500-655f-11eb-984d-fb403180c242.png)

