### PR TITLE
Fix mail sendmail (& add possibility to have several sendmail in a form)

### DIFF
--- a/includes/services/Mailer.php
+++ b/includes/services/Mailer.php
@@ -80,7 +80,8 @@ class Mailer
         }
     }
 
-    public function notifyEmail($email, $data) {
+    public function notifyEmail($email, $data)
+    {
         include_once 'includes/email.inc.php';
         $lien = str_replace('/wakka.php?wiki=', '', $this->params->get('base_url'));
         $sujet = removeAccents('['.str_replace(array('http://', 'https://'), '', $lien).'] Votre fiche : '.$data['bf_titre']);
@@ -98,7 +99,7 @@ class Mailer
         $fiche = $texthtml.str_replace('src="tools', 'src="'.$lien.'/tools', $this->wiki->services->get(EntryController::class)->view($data['id_fiche']));
         $html = '<html><head><style type="text/css">'.$style.'</style></head><body>'.$fiche.'</body></html>';
 
-        send_mail($this->params-get('BAZ_ADRESSE_MAIL_ADMIN'), $this->params-get('BAZ_ADRESSE_MAIL_ADMIN'), $email, $sujet, $text, $html);
+        send_mail($this->params->get('BAZ_ADRESSE_MAIL_ADMIN'), $this->params->get('BAZ_ADRESSE_MAIL_ADMIN'), $email, $sujet, $text, $html);
     }
 
     public function notifyNewUser($wikiName, $email)

--- a/tools/bazar/fields/EmailField.php
+++ b/tools/bazar/fields/EmailField.php
@@ -32,7 +32,7 @@ class EmailField extends BazarField
             // add propertyName to the list of emails if several sendmail in same form
             $secondPartReturn = ['sendmail' => ((isset($entry['sendmail'])) ? $entry['sendmail'] . ',' : '') . $this->propertyName] ;
         } else {
-            $secondPartReturn = ['fields-to-remove' => ['sendmail']];
+            $secondPartReturn = [];
         }
         return array_merge(
             [

--- a/tools/bazar/fields/EmailField.php
+++ b/tools/bazar/fields/EmailField.php
@@ -28,12 +28,17 @@ class EmailField extends BazarField
 
     public function formatValuesBeforeSave($entry)
     {
-        // TODO make sure the sendmail parameter is correctly passed
-        return [
-            $this->propertyName => $this->getValue($entry),
+        if ($this->sendMail) {
             // add propertyName to the list of emails if several sendmail in same form
-            'sendmail' => (($entry['sendmail']) ? $entry['sendmail'] . ',' : '') . $this->propertyName
-        ];
+            $secondPartReturn = ['sendmail' => ((isset($entry['sendmail'])) ? $entry['sendmail'] . ',' : '') . $this->propertyName] ;
+        } else {
+            $secondPartReturn = ['fields-to-remove' => ['sendmail']];
+        }
+        return array_merge(
+            [
+            $this->propertyName => $this->getValue($entry)],
+            $secondPartReturn
+        );
     }
 
     protected function renderStatic($entry)
@@ -53,5 +58,14 @@ class EmailField extends BazarField
             'showContactForm' => $this->showContactForm,
             'contactFormUrl' => $this->showContactForm ? $GLOBALS['wiki']->href('mail', $GLOBALS['wiki']->GetPageTag(), 'field='.$this->propertyName) : null
         ]);
+    }
+
+    public function jsonSerialize()
+    {
+        return array_merge(
+            parent::jsonSerialize(),
+            ['sendMail' => $this->sendMail,
+            'showContactForm' => $this->showContactForm]
+        );
     }
 }

--- a/tools/bazar/fields/EmailField.php
+++ b/tools/bazar/fields/EmailField.php
@@ -31,17 +31,20 @@ class EmailField extends BazarField
         // TODO make sure the sendmail parameter is correctly passed
         return [
             $this->propertyName => $this->getValue($entry),
-            'sendmail' => $this->sendMail
+            // add propertyName to the list of emails if several sendmail in same form
+            'sendmail' => (($entry['sendmail']) ? $entry['sendmail'] . ',' : '') . $this->propertyName
         ];
     }
 
     protected function renderStatic($entry)
     {
         $value = $this->getValue($entry);
-        if( !$value ) return null;
+        if (!$value) {
+            return null;
+        }
         
         // TODO add JS libraries with Twig
-        if( $this->showContactForm ) {
+        if ($this->showContactForm) {
             $GLOBALS['wiki']->addJavascriptFile('tools/contact/libs/contact.js');
         }
 

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -334,6 +334,12 @@ class EntryManager
             $ignoreAcls = $this->params->get('bazarIgnoreAcls');
         }
 
+        // extract $data['sendmail'] before save
+        if (isset($data['sendmail'])) {
+            $sendmail = $data['sendmail'] ;
+            unset($data['sendmail']);
+        }
+
         // on sauve les valeurs d'une fiche dans une PageWiki, retourne 0 si succès
         $saved = $this->wiki->SavePage(
             $data['id_fiche'],
@@ -370,6 +376,18 @@ class EntryManager
             if (!empty($olduser)) {
                 $this->wiki->SetUser($olduser, 1);
             }
+        }
+
+        
+        // If sendmail field exist, send an email
+        if ($sendmail) {
+            $emailsLabels = explode(',', $sendmail);
+            foreach ($emailsLabels as $emailLabel) {
+                if (!empty($data[$emailLabel])) {
+                    $this->mailer->notifyEmail($data[$emailLabel], $data);
+                }
+            }
+            unset($sendmail);
         }
 
         if ($this->params->get('BAZ_ENVOI_MAIL_ADMIN')) {
@@ -412,8 +430,25 @@ class EntryManager
 
         $data = $this->formatDataBeforeSave($data);
 
+        // extract $data['sendmail'] before save
+        if (isset($data['sendmail'])) {
+            $sendmail = $data['sendmail'] ;
+            unset($data['sendmail']);
+        }
+
         // on sauve les valeurs d'une fiche dans une PageWiki, pour garder l'historique
         $this->wiki->SavePage($data['id_fiche'], json_encode($data));
+
+        // If sendmail field exist, send an email
+        if ($sendmail) {
+            $emailsLabels = explode(',', $sendmail);
+            foreach ($emailsLabels as $emailLabel) {
+                if (!empty($data[$emailLabel])) {
+                    $this->mailer->notifyEmail($data[$emailLabel], $data);
+                }
+            }
+            unset($sendmail);
+        }
 
         if ($this->params->get('BAZ_ENVOI_MAIL_ADMIN')) {
             // Envoi d'un mail aux administrateurs
@@ -533,14 +568,6 @@ class EntryManager
             }
         }
         $data['date_maj_fiche'] = date('Y-m-d H:i:s', time());
-
-        // If sendmail field exist, send an email
-        if (isset($data['sendmail'])) {
-            if (isset($data[$data['sendmail']]) && $data[$data['sendmail']] != '') {
-                $this->mailer->notifyEmail($data[$data['sendmail']], $data);
-            }
-            unset($data['sendmail']);
-        }
 
         // on enleve les champs hidden pas necessaires a la fiche
         unset($data['valider']);

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -441,7 +441,7 @@ class EntryManager
 
         // If sendmail field exist, send an email
         if ($sendmail) {
-            $emailsLabels = explode(',', $sendmail);
+            $emailsLabels = array_unique(explode(',', $sendmail));
             foreach ($emailsLabels as $emailLabel) {
                 if (!empty($data[$emailLabel])) {
                     $this->mailer->notifyEmail($data[$emailLabel], $data);


### PR DESCRIPTION
J'ai trouvé que ça ne marchait plus très bien le champ sendmail suite au refacto.
Je propose cette PR pour résoudre le souci d'envoi des e-mails lors des modif et création d'une fiche.
1. stockage du champ concerné dans 'sendmail' au lieu de stocker true
2. possibilité d'avoir plusieurs sendmail dans le même formulaire
3. déplacement de l'envoi des e-mails après la sauvegarde de la fiche et non avant
4. ajout d'un jsonSerialize dans EmailField
5. correctif dans notify email
