### PR TITLE
Improve merge fields entry (!!! + BazarField RetroCompField refacto !!!)

### DIFF
--- a/includes/services/PageManager.php
+++ b/includes/services/PageManager.php
@@ -39,7 +39,7 @@ class PageManager
     public function getOne($tag, $time = null, $cache = true, $bypassAcls = false): ?array
     {
         // retrieve from cache
-        if (!$time && $cache && (($cachedPage = $this->getCached($tag)) !== false)) {
+        if (!$bypassAcls && !$time && $cache && (($cachedPage = $this->getCached($tag)) !== false)) {
             if ($cachedPage and !isset($cachedPage["metadatas"])) {
                 $cachedPage["metadatas"] = $this->getMetadata($tag);
             }
@@ -61,7 +61,7 @@ class PageManager
             }
 
             // cache result
-            if (!$time) {
+            if (!$bypassAcls && !$time) {
                 $this->cache($page, $tag);
             }
         }
@@ -203,8 +203,10 @@ class PageManager
         $user = $this->userManager->getLoggedUserName();
 
         // check bypass of rights or write privilege
-        $rights = $bypass_acls || ($comment_on ? $this->aclService->hasAccess('comment',
-                $comment_on) : $this->aclService->hasAccess('write', $tag));
+        $rights = $bypass_acls || ($comment_on ? $this->aclService->hasAccess(
+            'comment',
+            $comment_on
+        ) : $this->aclService->hasAccess('write', $tag));
 
         if ($rights) {
             // is page new?

--- a/includes/services/PageManager.php
+++ b/includes/services/PageManager.php
@@ -36,7 +36,7 @@ class PageManager
         $this->pageCache = [];
     }
 
-    public function getOne($tag, $time = "", $cache = 1): ?array
+    public function getOne($tag, $time = null, $cache = true, $bypassAcls = false): ?array
     {
         // retrieve from cache
         if (!$time && $cache && (($cachedPage = $this->getCached($tag)) !== false)) {
@@ -55,7 +55,7 @@ class PageManager
             }
 
             // not possible to init the EntryManager in the constructor because of circular reference problem
-            if ($this->wiki->services->get(EntryManager::class)->isEntry($tag)) {
+            if ($this->wiki->services->get(EntryManager::class)->isEntry($tag) && !$bypassAcls) {
                 // not possible to init the Guard in the constructor because of circular reference problem
                 $page = $this->wiki->services->get(Guard::class)->checkAcls($page, $tag);
             }

--- a/tools/bazar/fields/BazarField.php
+++ b/tools/bazar/fields/BazarField.php
@@ -93,6 +93,23 @@ abstract class BazarField implements \JsonSerializable
         return empty($this->propertyName) ? [] : [$this->propertyName => $this->getValue($entry)];
     }
 
+    // Replace data before format data
+    public function formatValuesBeforeSaveWithReplace($entry, $previousEntry, $replace = false)
+    {
+        if (!$this->canEdit($entry)) {
+            if (isset($previousEntry[$this->propertyName])) {
+                $entry[$this->propertyName] = $previousEntry[$this->propertyName];
+            } elseif (isset($entry[$this->propertyName])) {
+                unset($entry[$this->propertyName]);
+            }
+        } elseif (!$replace
+                && isset($previousEntry[$this->propertyName])
+                && !isset($entry[$this->propertyName])) {
+            $entry[$this->propertyName] = $previousEntry[$this->propertyName];
+        }
+        return $this->formatValuesBeforeSave($entry) ;
+    }
+
     // Render the show view of the field
     protected function renderStatic($entry)
     {

--- a/tools/bazar/fields/BazarField.php
+++ b/tools/bazar/fields/BazarField.php
@@ -93,23 +93,6 @@ abstract class BazarField implements \JsonSerializable
         return empty($this->propertyName) ? [] : [$this->propertyName => $this->getValue($entry)];
     }
 
-    // Replace data before format data
-    public function formatValuesBeforeSaveWithReplace($entry, $previousEntry, $replace = false)
-    {
-        if (!$this->canEdit($entry)) {
-            if (isset($previousEntry[$this->propertyName])) {
-                $entry[$this->propertyName] = $previousEntry[$this->propertyName];
-            } elseif (isset($entry[$this->propertyName])) {
-                unset($entry[$this->propertyName]);
-            }
-        } elseif (!$replace
-                && isset($previousEntry[$this->propertyName])
-                && !isset($entry[$this->propertyName])) {
-            $entry[$this->propertyName] = $previousEntry[$this->propertyName];
-        }
-        return $this->formatValuesBeforeSave($entry) ;
-    }
-
     // Render the show view of the field
     protected function renderStatic($entry)
     {
@@ -152,7 +135,7 @@ abstract class BazarField implements \JsonSerializable
     }
 
     /* Return true if we are if editing is allowed for the field */
-    protected function canEdit($entry)
+    public function canEdit($entry)
     {
         $writeAcl = empty($this->writeAccess) ? '' : $this->writeAccess;
         $isCreation = !$entry;

--- a/tools/bazar/handlers/page/api_patch.php
+++ b/tools/bazar/handlers/page/api_patch.php
@@ -14,7 +14,6 @@ if ($entryManager->isEntry($this->GetPageTag())) {
     if ($apiService->isAuthorized()) {
         $semantic = strpos($_SERVER['CONTENT_TYPE'], 'application/ld+json') !== false;
 
-        $_POST['id_fiche'] = $this->GetPageTag();
         $_POST['antispam'] = 1;
 
         $entryManager->update($this->GetPageTag(), $_POST, $semantic, false);

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -649,8 +649,8 @@ class EntryManager
         // on regarde si des champs sont restreints en écriture pour l'utilisateur, et pour ceux-ci ont leur assigne la même valeur
         
         // get previous data without Guard
-        $previousPage = $this->pageManager->getOne($tag) ;
-        $previousData = $this->decode($this->pageManager->getById($previousPage['id'])['body']);
+        $previousPage = $this->wiki->services->get(PageManager::class)->getOne($tag) ;
+        $previousData = $this->decode($this->wiki->services->get(PageManager::class)->getById($previousPage['id'])['body']);
         
         // fixed fields
         $data['id_fiche'] = $previousData['id_fiche'] ?? null ;

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -471,8 +471,8 @@ class EntryManager
      *
      * @param array $data the provided data to update
      * @param array $previousData the provided previousData to update
+     * @param array $form the entry form
      * @return array the data with the restricted values added
-     * @throws Exception
      */
     protected function assignRestrictedFields(array $data, array $previousData, array $form)
     {
@@ -497,6 +497,8 @@ class EntryManager
                 if (isset($previousData[$propName])) {
                     $data[$propName] = $previousData[$propName] ;
                 } elseif (isset($data[$propName])) {
+                    // only for cases when a field is maliciously injected in $_POST (so in $data) and the key doesn't
+                    // exist in $previousData
                     unset($data[$propName]);
                 }
             }
@@ -507,6 +509,7 @@ class EntryManager
     /**
      * Add the $previousData attributes which match the actual form and which are not in $data
      * @param array $previousData the data saved in the entry
+     * @param array $form the entry form
      * @param array $data the provided data to update
      * @return array the data with the merged values
      * @throws Exception

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -65,16 +65,18 @@ class EntryManager
      * @param $tag
      * @param bool $semantic
      * @param string $time pour consulter une fiche dans l'historique
-     * @param bool $bypassAcls is true, all fields are loaded regardless of acls
+     * @param bool $cache if false, don't use the page cache
+     * @param bool $bypassAcls if true, all fields are loaded regardless of acls
      * @return mixed|null
+     * @throws Exception
      */
-    public function getOne($tag, $semantic = false, $time = null): ?array
+    public function getOne($tag, $semantic = false, $time = null, $cache = true, $bypassAcls = false): ?array
     {
         if (!$this->isEntry($tag)) {
             return null;
         }
 
-        $page = $this->pageManager->getOne($tag, $time || '');
+        $page = $this->pageManager->getOne($tag, $time || null, $cache, $bypassAcls);
         $data = $this->decode($page['body']);
 
         // cas ou on ne trouve pas les valeurs id_fiche
@@ -479,13 +481,13 @@ class EntryManager
                 if (!$field->canRead($data) && !$field->canEdit($data)) {
                     $restrictedFields[] = $propName;
                 }
-                // TODO when entry update by the form will be done by partiel update ($replace = true), copy the field value when canRead & !canEdit
+                // TODO when entry update from the form will be done by partiel update ($replace = true), copy the field value when canRead & !canEdit
             }
         }
 
         if (!empty($restrictedFields)) {
             // if there are some restricted fields, load the previous data by bypassing the rights
-            $previousData = $this->getOne($data['id_fiche'], false, null, true);
+            $previousData = $this->getOne($data['id_fiche'], false, null, false, true);
 
             // get the value of the restricted fields in the previous data
             foreach ($restrictedFields as $propName) {

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -122,8 +122,8 @@ class EntryManager
         if (!empty($params['formsIds'])) {
             if (is_array($params['formsIds'])) {
                 $requete .= ' AND ' . join(' OR ', array_map(function ($formId) {
-                        return 'body LIKE \'%"id_typeannonce":"' . $formId . '"%\'';
-                    }, $params['formsIds']));
+                    return 'body LIKE \'%"id_typeannonce":"' . $formId . '"%\'';
+                }, $params['formsIds']));
             } else {
                 // on a une chaine de caractere pour l'id plutot qu'un tableau
                 $requete .= ' AND body LIKE \'%"id_typeannonce":"' . $params['formsIds'] . '"%\'';
@@ -482,8 +482,10 @@ class EntryManager
         $this->pageManager->deleteOrphaned($tag);
         $this->tripleStore->delete($tag, TripleStore::TYPE_URI, null, '', '');
         $this->tripleStore->delete($tag, TripleStore::SOURCE_URL_URI, null, '', '');
-        $this->wiki->LogAdministrativeAction($this->userManager->getLoggedUserName(),
-            "Suppression de la page ->\"\"" . $tag . "\"\"");
+        $this->wiki->LogAdministrativeAction(
+            $this->userManager->getLoggedUserName(),
+            "Suppression de la page ->\"\"" . $tag . "\"\""
+        );
     }
 
     /*
@@ -666,7 +668,7 @@ class EntryManager
         // (un LoadPage qui passe les droits ACLS est nécéssaire)
         
         // not possible to init the formManager in the constructor because of circular reference problem
-        $form = $this->getService(FormManager::class)->getOne($previousData['id_typeannonce']);
+        $form = $this->wiki->services->get(FormManager::class)->getOne($previousData['id_typeannonce']);
         $data['id_fiche'] = $previousData['id_fiche'];
         $data['id_typeannonce'] = $previousData['id_typeannonce'];
         for ($i = 0; $i < count($form['template']); ++$i) {

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -671,7 +671,7 @@ class EntryManager
                                 !isset($data[$propName]) && $complete
                               )
                             ) {
-                            $data[$propName] = $previousEntry[$propName] ;
+                            $data[$propName] = $previousData[$propName] ;
                         } elseif (!$field->canEdit($data) &&
                                   !isset($previousData[$propName]) &&
                                   isset($data[$propName])) {

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -485,8 +485,7 @@ class EntryManager
 
         if (!empty($restrictedFields)) {
             // if there are some restricted fields, load the previous data by bypassing the rights
-            $previousPage = $this->wiki->services->get(PageManager::class)->getOne($data['id_fiche']);
-            $previousData = $this->decode($this->wiki->services->get(PageManager::class)->getById(intval($previousPage['id']))['body']);
+            $previousData = $this->getOne($data['id_fiche'], false, null, true);
 
             // get the value of the restricted fields in the previous data
             foreach ($restrictedFields as $propName) {
@@ -519,6 +518,11 @@ class EntryManager
         return $data;
     }
 
+    /**
+     * @param $entryId
+     * @param $accepted
+     * @throws Exception
+     */
     public function publish($entryId, $accepted)
     {
         // not possible to init the Guard in the constructor because of circular reference problem

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -663,10 +663,20 @@ class EntryManager
             foreach ($form['prepared'] as $field) {
                 if ($field instanceof BazarField) {
                     $propName = $field->getPropertyName();
-                    if (!$field->canEdit($data)) {
-                        $data[$propName] = $previousData[$propName] ?? null;
-                    } elseif ($complete && !isset($data[$propName])) {
-                        $data[$propName] = $previousEntry[$propName] ?? null;
+                    if (!empty($propName)) { // do not create empty key
+                        if ( // 2 cases for update
+                              (!$field->canEdit($data) && isset($previousData[$propName])) ||
+                              (
+                                  $field->canEdit($data) && isset($previousData[$propName]) &&
+                                !isset($data[$propName]) && $complete
+                              )
+                            ) {
+                            $data[$propName] = $previousEntry[$propName] ;
+                        } elseif (!$field->canEdit($data) &&
+                                  !isset($previousData[$propName]) &&
+                                  isset($data[$propName])) {
+                            unset($data[$propName]) ;
+                        }
                     }
                 }
             }

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -505,7 +505,7 @@ class EntryManager
      * @return array
      * @throws Exception
      */
-    public function formatDataBeforeSave($data, $previousdata = null)
+    public function formatDataBeforeSave($data, $previousData = null)
     {
         // not possible to init the formManager in the constructor because of circular reference problem
         $form = $this->getService(FormManager::class)->getOne($data['id_typeannonce']);


### PR DESCRIPTION
**11 mars 2021**:mise à jour de cet en-tête
Intention principale : pouvoir éviter que les anciens champs restent présents dans une fiche.
 - modification de EntryManager pour la méthode de fusion des données lors de l'update (ne pas ajouter les anciennes données mais que celles qui correspondent à un champ).
 - mise à jour de quelques Fields pour rester compatibles avec canEdit
 - refacto pour la gestion des anciens champs sous forme de fonction (parce que ça devenait trop compliqué de maintenir la rétrocompatibilité comme le code était, maintenant c'est plus simple).
 - refacto du Guard pour prendre en compte directement les BazarField
 -  corrections de quelques erreurs dans le EntryManager

Tests du 11 mars 2021 
[Tests #670.zip](https://github.com/YesWiki/yeswiki/files/6122697/Tests.670.zip)


**Cette PR semble intégrer des modifications qui ne sont pas prioritaires. Toutefois, elle permet de résoudre le problème de données en trop (BUG) et aussi facilite la correction des autres futurs bugs. C'est pour ceci que je me permets de le proposer sur Doryphore et non Ectoplasme**

----
Texte d'avant
----
Lors de la mise à jour d'une fiche, il y a pour le moment fusion entre les anciennes données et les nouvelles données.
Conséquence:
- ça permet de reconstruire les données manquantes qui auraient pu disparaître lors du passage sur le navigateur du client.
- ça complique la remise à zéro des données en tableau comme les checkbox
- ça ne permet pas de supprimer les anciennes données qui ne sont plus utilisées.

Le correctif que je propose permet de continuer de récupérer les anciennes données sans garder les données qui sont maintenant inutiles.

Je te sollicite @acheype dans un premier temps pour avoir ton avis.
Qu'en penses-tu ?
J'ai ouvert une PR pour permettre un espace d'échange facilité.
Elle est en brouillon car elle n'est pas prête à être fusionnée.
N'importe qui peut se joindre à cette discussion voire faire une revue. :wink:

J'ai des questions sur la possibilité de déplacer la sauvegarde des données des champs non accessibles en écriture dans les champs dédiés.

**ET je n'ai pas encore fait tous les tests**
