### PR TITLE
update yeswiki version during update

### DIFF
--- a/tools/autoupdate/app/PackageCore.php
+++ b/tools/autoupdate/app/PackageCore.php
@@ -64,6 +64,7 @@ class PackageCore extends Package
         $configuration = new Configuration('wakka.config.php');
         $configuration->load();
         $configuration['yeswiki_release'] = $this->release;
+        $configuration['yeswiki_version'] = $this->requestedVersion();
         return $configuration->write();
     }
 


### PR DESCRIPTION
fix  #502 
Lors de la mise à jour de cercopitheque vers doryphore avec ce code
```{{update version="doryphore"}}```

il n'y a pas de mises à jour de la version dans  wakka.config
Je duplique la PR pour faire aussi une mise à jour de la branche cercopitheque
