### PR TITLE
Keep ViewUpdate file for autoupdate from cercopitheque

### DIFF
--- a/tools/autoupdate/app/ViewUpdate.php
+++ b/tools/autoupdate/app/ViewUpdate.php
@@ -1,5 +1,10 @@
 <?php
-// file only to prevent errors when updating from cercopitheque to doryphore
+/* === WARNING !!!! ==== DO NOT USE THIS CLASS IN DORYPHORE
+ *
+ * This file is only to prevent errors when updating from cercopitheque to doryphore.
+ * It is executed in a cercopitheque version in RAM on server. Do not call new others classes
+ * because we can not be sure that this class exists in the RAM or if the file is ever on the file system.
+ */
 namespace AutoUpdate;
 
 class ViewUpdate
@@ -8,6 +13,7 @@ class ViewUpdate
     protected $messages;
     protected $baseURL;
     
+    // important do not change the arguments of this method because called form cercopitheque
     public function __construct($autoUpdate, $messages)
     {
         $this->autoUpdate = $autoUpdate;
@@ -24,14 +30,21 @@ class ViewUpdate
         return $infos;
     }
     
+    // important do not change the arguments of this method because called form cercopitheque
     public function show()
     {
-        $output = '';
+        $data = [];
         foreach ($this->messages as $message) {
-            $output .= $message['text'] . ':' . $message['status'] . ';';
+            $data['messages']['status'] = $message['status'];
+            $data['messages']['text'] = $message['text'];
         }
-        $_SESSION['message'] = $output;
-        header("Location: ".$this->baseURL);
+        $data['baseURL'] = $this->baseURL;
+        $_SESSION['message'] = json_encode($data);
+
+        // call the handler 'welcomdoryphore' to reload wiki in doryphore version
+        // give $data by $_SESSION['message']
+        $newAdress = $GLOBALS['wiki']->Href('welcomedoryphore');
+        header("Location: ".$newAdress);
         exit();
     }
 }

--- a/tools/autoupdate/app/ViewUpdate.php
+++ b/tools/autoupdate/app/ViewUpdate.php
@@ -35,8 +35,10 @@ class ViewUpdate
     {
         $data = [];
         foreach ($this->messages as $message) {
-            $data['messages']['status'] = $message['status'];
-            $data['messages']['text'] = $message['text'];
+            $data_message = [];
+            $data_message['status'] = $message['status'];
+            $data_message['text'] = $message['text'];
+            $data['messages'][] = $data_message;
         }
         $data['baseURL'] = $this->baseURL;
         $_SESSION['message'] = json_encode($data);

--- a/tools/autoupdate/app/ViewUpdate.php
+++ b/tools/autoupdate/app/ViewUpdate.php
@@ -1,0 +1,37 @@
+<?php
+// file only to prevent errors when updating from cercopitheque to doryphore
+namespace AutoUpdate;
+
+class ViewUpdate
+{
+    protected $autoUpdate;
+    protected $messages;
+    protected $baseURL;
+    
+    public function __construct($autoUpdate, $messages)
+    {
+        $this->autoUpdate = $autoUpdate;
+        $this->baseURL = $autoUpdate->baseUrl();
+        $this->messages = $messages;
+    }
+
+    protected function grabInformations()
+    {
+        $infos = array(
+            'messages' => $this->messages,
+            'baseUrl' => $this->autoUpdate->baseUrl(),
+        );
+        return $infos;
+    }
+    
+    public function show()
+    {
+        $output = '';
+        foreach ($this->messages as $message) {
+            $output .= $message['text'] . ':' . $message['status'] . ';';
+        }
+        $_SESSION['message'] = $output;
+        header("Location: ".$this->baseURL);
+        exit();
+    }
+}

--- a/tools/autoupdate/handlers/WelcomeDoryphoreHandler.php
+++ b/tools/autoupdate/handlers/WelcomeDoryphoreHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+use YesWiki\Core\YesWikiHandler;
+use YesWiki\Core\Service\Performer;
+
+/*
+ * This handler is called from /tools/autoupdate/Viewupdate.php only when upgrading from cercopitheque to doryphore.
+ * whereas it is not used.
+ * This handlers will not be useful for ectoplasme.
+ */
+
+class WelcomeDoryphoreHandler extends YesWikiHandler
+{
+    public function run()
+    {
+        // search data in session message
+        $message = $this->wiki->GetMessage();
+        
+        $error = empty($message);
+
+        // check integrity of data
+        if (!$error) {
+            $data = json_decode($message, true);
+            $error = !is_array($data) && !isset($data['messages']) && !isset($data['baseURL']);
+        }
+
+        // on error call handler 'show'
+        if ($error) {
+            if (!empty($message)) {
+                // save received message as if it was not extracted
+                $this->wiki->SetMessage($message) ;
+            }
+            return $this->getService(Performer::class)->run('show', 'handler', []);
+        }
+
+        // finished rendering of autoupdate
+        $output = '<h1>Welcome on Doryphore</h1>'."\n";
+        // $output .= $message;
+        $output .= $this->wiki->render("@autoupdate/update.twig", [
+            'messages' => $data['messages'],
+            'baseUrl' => $data['baseURL'],
+        ]);
+        $output = $this->wiki->Header() . $output ;
+        $output .= $this->wiki->Footer();
+        return $output;
+    }
+}

--- a/tools/autoupdate/handlers/WelcomeDoryphoreHandler.php
+++ b/tools/autoupdate/handlers/WelcomeDoryphoreHandler.php
@@ -34,7 +34,7 @@ class WelcomeDoryphoreHandler extends YesWikiHandler
         }
 
         // finished rendering of autoupdate
-        $output = '<h1>Welcome on Doryphore</h1>'."\n";
+        $output = '<h1>'._t('AU_YESWIKI_DORYPHORE_POSTINSTALL').'</h1>'."\n";
         // $output .= $message;
         $output .= $this->wiki->render("@autoupdate/update.twig", [
             'messages' => $data['messages'],

--- a/tools/autoupdate/lang/autoupdate_fr.inc.php
+++ b/tools/autoupdate/lang/autoupdate_fr.inc.php
@@ -33,6 +33,7 @@ $GLOBALS['translations'] = array_merge(
         'AU_DELETE_EXT' => "Supprimer",
         'AU_DELETE' => "Suppression des fichiers",
         'AU_NO_DESCRIPTION' => "Description non disponible.",
-        'AU_DOCUMENTATION_LINK' => "documentation"
+        'AU_DOCUMENTATION_LINK' => "documentation",
+        'AU_YESWIKI_DORYPHORE_POSTINSTALL' => "Welcome on Doryphore",
     )
 );


### PR DESCRIPTION
pour résoudre le souci de #662 

PR en DRAFT car je ne l'ai pas assez testé.
L'idée est de conserver un fichier ViewUpdate qui est chargé juste après la mise à jour des fichiers quand on vient de cerco.
Ce fichier doit être le plus sobre possible pour ne pas tenter d'appeler des fichiers et classes qui ne sont pas encore instanciées dans Doryphore.

Le principe faire un rechargement de la page.
J'ai commencé à compiler les messages dans $_SESSION['message'].

Toutefois, je me dis que nous pourrions appeler une action à créer dans Doryphore qui récupère ce message et le met mieux en forme.
Qu'en dis-tu @mrflos ?
