### PR TITLE
fix(editiframe): when saving a page, save and cancel buttons redirect…

### DIFF
--- a/handlers/EditIframeHandler.php
+++ b/handlers/EditIframeHandler.php
@@ -8,9 +8,6 @@ class EditIframeHandler extends YesWikiHandler
 {
     public function run()
     {
-        // the edit handler use this variable to display the content without the header and footer
-        $GLOBALS['inIframe'] = true;
-
         // on recupere les entetes html mais pas ce qu'il y a dans le body
         $header = explode('<body', $this->wiki->Header());
         $output = $header[0];
@@ -69,8 +66,6 @@ class EditIframeHandler extends YesWikiHandler
         $this->wiki->AddJavascriptFile('tools/templates/libs/vendor/iframeResizer.contentWindow.min.js');
         // on recupere juste les javascripts et la fin des balises body et html
         $output .= preg_replace('/^.+<script/Us', '<script', $this->wiki->Footer());
-
-        unset($GLOBALS['inIframe']);
 
         return $output;
     }

--- a/handlers/page/edit.php
+++ b/handlers/page/edit.php
@@ -67,20 +67,20 @@ if ($this->HasAccess('write') && $this->HasAccess('read')) {
               "<div class=\"page_preview\">\n".
               "<div class=\"prev_alert\"><strong>Aper&ccedil;u</strong></div>\n".
               $this->Format($body)."\n\n".
-              $this->FormOpen('edit').
+              $this->FormOpen(testUrlInIframe() ? 'editiframe' : 'edit').
               "<input type=\"hidden\" name=\"previous\" value=\"$previous\" />\n".
               '<input type="hidden" name="body" value="'.htmlspecialchars($body, ENT_COMPAT, YW_CHARSET)."\" />\n".
               "<br />\n".
               "<input name=\"submit\" type=\"submit\" value=\"Sauver\" accesskey=\"s\" />\n".
               "<input name=\"submit\" type=\"submit\" value=\"R&eacute;&eacute;diter\" accesskey=\"p\" />\n".
-              "<input type=\"button\" value=\"Annulation\" onclick=\"document.location='".addslashes($this->href())."';\" />\n".
+              "<input type=\"button\" value=\"Annulation\" onclick=\"document.location='".addslashes($this->href(testUrlInIframe()))."';\" />\n".
               $this->FormClose()."\n"."</div>\n";
             $this->SetInclusions($temp);
             break;
 
         // pour les navigateurs n'interprétant pas le javascript
         case 'Annulation':
-            $this->Redirect($this->Href());
+            $this->Redirect($this->Href(testUrlInIframe()));
             exit; // sécurité
 
         // only if saving:
@@ -91,16 +91,11 @@ if ($this->HasAccess('write') && $this->HasAccess('read')) {
                 "Cette page a &eacute;t&eacute; modifi&eacute;e par quelqu'un d'autre pendant que vous l'&eacute;ditiez.<br />\n".
                 "Veuillez copier vos changements et r&eacute;&eacute;diter cette page.\n";
             } else { // store
-                if (!isset($GLOBALS['inIframe'])) {
-                    $method = '';
-                } else {
-                    $method = 'iframe';
-                }
                 $body = str_replace("\r", '', $body);
                 // teste si la nouvelle page est differente de la précédente
                 if (rtrim($body) == rtrim($this->page['body'])) {
                     $this->SetMessage('Cette page n\'a pas &eacute;t&eacute; enregistr&eacute;e car elle n\'a subi aucune modification.');
-                    $this->Redirect($this->href($method));
+                    $this->Redirect($this->href(testUrlInIframe()));
                 } else {
                     // l'encodage de la base est en iso-8859-1, voir s'il faut convertir
                     $body = _convert($body, YW_CHARSET, true);
@@ -127,9 +122,9 @@ if ($this->HasAccess('write') && $this->HasAccess('read')) {
 
                     // forward
                     if ($this->page['comment_on']) {
-                        $this->Redirect($this->href($method, $this->page['comment_on']).'#'.$this->tag);
+                        $this->Redirect($this->href(testUrlInIframe(), $this->page['comment_on']).'#'.$this->tag);
                     } else {
-                        $this->Redirect($this->href($method));
+                        $this->Redirect($this->href(testUrlInIframe()));
                     }
                 }
 
@@ -150,7 +145,7 @@ if ($this->HasAccess('write') && $this->HasAccess('read')) {
             }
 
             $output .=
-              $this->FormOpen('edit').
+              $this->FormOpen(testUrlInIframe() ? 'editiframe' : 'edit').
               "<input type=\"hidden\" name=\"previous\" value=\"$previous\" />\n".
               "<textarea id=\"body\" name=\"body\" style='display: none'>" .
                 htmlspecialchars($body, ENT_COMPAT, YW_CHARSET).
@@ -160,7 +155,7 @@ if ($this->HasAccess('write') && $this->HasAccess('read')) {
               "</script>\n".
               ($this->config['preview_before_save'] ? '' : "<input name=\"submit\" type=\"submit\" value=\"Sauver\" accesskey=\"s\" />\n").
               "<input name=\"submit\" type=\"submit\" value=\"Aper&ccedil;u\" accesskey=\"p\" />\n".
-              "<input type=\"button\" value=\"Annulation\" onclick=\"document.location='".addslashes($this->href())."';\" />\n".
+              "<input type=\"button\" value=\"Annulation\" onclick=\"document.location='".addslashes($this->href(testUrlInIframe()))."';\" />\n".
               $this->FormClose();
     } // switch
 } else {
@@ -168,7 +163,7 @@ if ($this->HasAccess('write') && $this->HasAccess('read')) {
 }
 
 // Header
-if (!isset($GLOBALS['inIframe'])) {
+if (!testUrlInIframe()) {
     echo $this->Header();
 }
 
@@ -179,6 +174,6 @@ echo '<div class="page">'."\n".$output."\n".'<hr class="hr_clear" />'."\n".'</di
 include 'tools/aceditor/actions/actions_builder.php';
 
 // Footer
-if (!isset($GLOBALS['inIframe'])) {
+if (!testUrlInIframe()) {
     echo $this->Footer();
 }

--- a/handlers/page/show.php
+++ b/handlers/page/show.php
@@ -68,7 +68,7 @@ if ($HasAccessRead=$this->HasAccess("read")) {
                 $latest = $this->LoadPage($this->tag); ?>
 				<?php
                   $time = isset($_GET['time']) ? $_GET['time'] : '';
-                echo $this->FormOpen('edit'); ?>
+                echo $this->FormOpen(testUrlInIframe() ? 'editiframe' : 'edit'); ?>
 				<input type="hidden" name="time" value="<?php echo $time ?>" />
 				<input type="hidden" name="previous" value="<?php echo  $latest["id"] ?>" />
 				<input type="hidden" name="body" value="<?php echo  htmlspecialchars($this->page["body"], ENT_COMPAT, YW_CHARSET) ?>" />

--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -606,7 +606,7 @@ class Wiki
     // FORMS
     public function FormOpen($method = '', $tag = '', $formMethod = 'post', $class = '')
     {
-        if ($method=='edit') {
+        if ($method=='edit' || $method=='editiframe') {
             $result  = '<form id="ACEditor" name="ACEditor" enctype="multipart/form-data" action="'.$this->href($method, $tag).'" method="'.$formMethod.'"';
             $result .= !empty($class) ? ' class="'.$class.'"' : '';
             $result .= ">\n";

--- a/includes/urlutils.inc.php
+++ b/includes/urlutils.inc.php
@@ -125,3 +125,20 @@ function replaceLinksWithIframe(string $body): string
     );
     return $pagebody;
 }
+
+function testUrlInIframe($url = '')
+{
+    if (empty($url)) {
+        // test si on est dans une iframe
+        $url = getAbsoluteUrl();
+    }
+    $iframe = preg_match('/\/(edit)?iframe/Ui', $url);
+    return $iframe ? 'iframe' : '';
+}
+
+function testRefererUrlInIframe()
+{
+    $url = isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '';
+    $iframe = preg_match('/\/(edit)?iframe/Ui', $url);
+    return $iframe ? 'iframe' : '';
+}

--- a/tools/bazar/libs/bazar.fonct.misc.php
+++ b/tools/bazar/libs/bazar.fonct.misc.php
@@ -205,20 +205,6 @@ function obtenir_extension($filename)
     }
 }
 
-function testUrlInIframe($url = '')
-{
-    if (empty($url)) {
-        // test si on est dans une iframe
-        $url = isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '';
-    }
-    $iframe = preg_match('/\/(edit)?iframe/Ui', $url);
-    if ($iframe) {
-        return 'iframe';
-    } else {
-        return '';
-    }
-}
-
 function renameUrlToSanitizedFilename($url)
 {
     $str = preg_replace('/[\r\n\t ]+/', ' ', basename($url));

--- a/tools/security/handlers/page/__edit.php
+++ b/tools/security/handlers/page/__edit.php
@@ -21,7 +21,7 @@ if ($this->HasAccess('write') && $this->HasAccess('read')) {
             if (isset($this->config['password_for_editing_message']) and !empty($this->config['password_for_editing_message'])) {
                 echo '<p class="password_for_editing_message">'.$this->config['password_for_editing_message'].'</p>'."\n";
             }
-            echo '<form method="post" action="'.$this->href('edit', $this->GetPageTag()).'" class="form-inline">
+            echo '<form method="post" action="'.$this->href(testUrlInIframe() ? 'editiframe' : 'edit', $this->GetPageTag()).'" class="form-inline">
       <div>
         <label for="password_for_editing">'._t('HASHCASH_GENERAL_PASSWORD').'</label>
         <input type="password" class="form-control" id="password_for_editing" name="password_for_editing">';

--- a/tools/templates/handlers/page/edit__.php
+++ b/tools/templates/handlers/page/edit__.php
@@ -100,13 +100,13 @@ if (isset($_SERVER["HTTP_REFERER"])) {
 // le bouton apercu c'est pour les vieilles versions de wikini, on en profite pour rajouter des classes pour colorer les boutons et la personnalisation graphique
 $patterns = array(0 => '/<input name=\"submit\" type=\"submit\" value=\"Sauver\" accesskey=\"s\" \/>/',
                     1 => '/<input name=\"submit\" type=\"submit\" value=\"Aper\&ccedil;u\" accesskey=\"p\" \/>/',
-                    2 => '/<input type=\"button\" value=\"Annulation\" onclick=\"document.location=\''.preg_quote(addslashes($this->href()), '/').'\';\" \/>/',
+                    2 => '/<input type=\"button\" value=\"Annulation\" onclick=\"document.location=\''.preg_quote(addslashes($this->href(testUrlInIframe())), '/').'\';\" \/>/',
                     3 => '/ class=\"edit\">/',
                     );
 $replacements = array(
                     0 => $hidden.'<div class="form-actions">'."\n".'<button type="submit" name="submit" value="Sauver" class="btn btn-primary">'._t('TEMPLATE_SAVE').'</button>'."\n",
                     1 => '',
-                    2 => '<button class="btn btn-default" onclick="location.href=\''.addslashes($this->href()).'\';return false;">'._t('TEMPLATE_CANCEL').'</button>'."\n".
+                    2 => '<button class="btn btn-default" onclick="location.href=\''.addslashes($this->href(testUrlInIframe())).'\';return false;">'._t('TEMPLATE_CANCEL').'</button>'."\n".
                             (($changetheme) ? '<span class="other-actions"><a class="btn btn-neutral" data-toggle="modal" data-target="#graphical_options">'._t('TEMPLATE_THEME').'</a>'."\n" : '').'</span></div>'."\n", // le bouton Theme du bas de l'interface d'edition
                     3 => ' class="edit form-control">',
                     );


### PR DESCRIPTION
j'avais déjà passé pas mal de temps à réécrire le handler editiframe et iframe pour qu'on puisse éditer en iframe et revenir toujours en iframe sur la page après édition.

ça fonctionnait bien pour les fiches bazar mais oh ma joie quand j'ai découvert que ça ne fonctionnait pas complètement pour les pages classiques !
la page s'éditait bien en iframe mais lorsqu'on sauvait ou annulait, on revenait sur la page sans iframe.

on aurait intérêt à prendre le temps à réécrire tous ces handlers edit car c'est bien spaghetti.
j'ai résolu le soucis et en ai profiter pour ne plus utiliser $GLOBALS['inIframe'].

j'utilise testUrlInIframe(...) et j'ai dû la réécrire car celle-ci se basait sur l'adresse HTTP_REFERER et non sur l'adresse courante.
et si je l'utilisais tel quel, un appel direct avec /editiframe (c'est à dire sans qu'on passe de la page en iframe à editiframe) ne s'affichait pas en iframe.
le seul cas où cela peut être intéressant de se baser sur l'adresse du referer c'est pour les handlers, le handler comme cela peut revenir sur la page avec ou sans iframe selon si celui-ci était activé avant son appel.
ainsi j'ai rajouter la fonction testRefererUrlInIframe() qui permet cela (utilisé par exemple dans le lms par le handler réaction)
j'en ai profité pour déplacer ces deux fonctions dans urlutils.inc.php.

@mrflos est-ce que tu vois d'autres extensions qui pourrait utilisé testUrlInInframe dans un handler ?

Aussi, j'ai découvert la fonction $wiki->FormOpen(...), et j'ai vu que celle-ci est utilisé pour générer pas mal de formulaires et ceux-ci  l'appel n'est jamais fait en fonction de mode actuel (iframe ou non). Le mode iframe est alors perdu pour ces appels. Il y a donc encore des améliorations possibles de ce côté là.

