### PR TITLE
feat(BazarListeAction agenda): use agenda param for all templates

### DIFF
--- a/docs/actions/bazar.yaml
+++ b/docs/actions/bazar.yaml
@@ -158,11 +158,13 @@ actions:
         label: _t(AB_bazar_commons2_filter_on_date)
         type: list
         advanced: true
+        hint: _t(AB_bazar_commons2_filter_index)
         options:
           futur: _t(AB_bazar_commons2_filter_on_date_future)
           past: _t(AB_bazar_commons2_filter_on_date_past)
           today: _t(AB_bazar_commons2_filter_on_date_today)
           '>-1M': _t(AB_bazar_commons2_filter_on_date_for_one_month)
+          '>-2Y': _t(AB_bazar_commons2_filter_on_date_for_two_years)
           '>-7D&<+7D': _t(AB_bazar_commons2_filter_on_date_one_week_more_and_less)
 
   # -----------------

--- a/docs/actions/bazar.yaml
+++ b/docs/actions/bazar.yaml
@@ -154,6 +154,16 @@ actions:
         min: 1
         max: 12
         showif: facettes
+      datefilter:
+        label: _t(AB_bazar_commons2_filter_on_date)
+        type: list
+        advanced: true
+        options:
+          futur: _t(AB_bazar_commons2_filter_on_date_future)
+          past: _t(AB_bazar_commons2_filter_on_date_past)
+          today: _t(AB_bazar_commons2_filter_on_date_today)
+          '>-1M': _t(AB_bazar_commons2_filter_on_date_for_one_month)
+          '>-7D&<+7D': _t(AB_bazar_commons2_filter_on_date_one_week_more_and_less)
 
   # -----------------
   # Liste des Actions

--- a/docs/actions/lang/actionsbuilder_en.inc.php
+++ b/docs/actions/lang/actionsbuilder_en.inc.php
@@ -6,6 +6,12 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations'], array(
     'AB_bazar_commons_search_label' => 'Search bar',
     'AB_bazar_facettes_groupsexpanded_false' => "Only first expanded",
     'AB_bazar_facettes_groupsexpanded_true' => "All expanded",
+    'AB_bazar_commons2_filter_on_date' => "Filter on date",
+    'AB_bazar_commons2_filter_on_date_future' => "future",
+    'AB_bazar_commons2_filter_on_date_past' => "past",
+    'AB_bazar_commons2_filter_on_date_today' => "today",
+    'AB_bazar_commons2_filter_on_date_for_one_month' => "for one month",
+    'AB_bazar_commons2_filter_on_date_one_week_more_and_less' => "+/- one week",
     //video
     'AB_attach_video_label' => "Embeded video",
     'AB_attach_video_description' => "Embeding of youtube, vimeo or peertube video.",

--- a/docs/actions/lang/actionsbuilder_en.inc.php
+++ b/docs/actions/lang/actionsbuilder_en.inc.php
@@ -11,7 +11,9 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations'], array(
     'AB_bazar_commons2_filter_on_date_past' => "past",
     'AB_bazar_commons2_filter_on_date_today' => "today",
     'AB_bazar_commons2_filter_on_date_for_one_month' => "for one month",
+    'AB_bazar_commons2_filter_on_date_for_two_years' => "for two years",
     'AB_bazar_commons2_filter_on_date_one_week_more_and_less' => "+/- one week",
+    'AB_bazar_commons2_filter_index' => "'bf_date_debut_evenement' shoud be defined.",
     //video
     'AB_attach_video_label' => "Embeded video",
     'AB_attach_video_description' => "Embeding of youtube, vimeo or peertube video.",

--- a/docs/actions/lang/actionsbuilder_fr.inc.php
+++ b/docs/actions/lang/actionsbuilder_fr.inc.php
@@ -13,7 +13,9 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations'], array(
     'AB_bazar_commons2_filter_on_date_past' => "passé",
     'AB_bazar_commons2_filter_on_date_today' => "aujourd'hui",
     'AB_bazar_commons2_filter_on_date_for_one_month' => "depuis un mois",
+    'AB_bazar_commons2_filter_on_date_for_two_years' => "depuis deux ans",
     'AB_bazar_commons2_filter_on_date_one_week_more_and_less' => "+/- une semaine",
+    'AB_bazar_commons2_filter_index' => "'bf_date_debut_evenement' doit être défini.",
     //video
     'AB_attach_video_label' => "Vidéo intégrée",
     'AB_attach_video_description' => "Intégration d'une vidéo youtube, vimeo ou peertube.",

--- a/docs/actions/lang/actionsbuilder_fr.inc.php
+++ b/docs/actions/lang/actionsbuilder_fr.inc.php
@@ -8,6 +8,12 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations'], array(
     'AB_bazar_commons2_filter_user_as_owner' => "N'afficher que les fiches de l'utilisateur courant",
     'AB_bazar_facettes_groupsexpanded_false' => "Uniquement la première dépliée",
     'AB_bazar_facettes_groupsexpanded_true' => "Toutes Dépliées",
+    'AB_bazar_commons2_filter_on_date' => "Filtrer sur les dates",
+    'AB_bazar_commons2_filter_on_date_future' => "futur",
+    'AB_bazar_commons2_filter_on_date_past' => "passé",
+    'AB_bazar_commons2_filter_on_date_today' => "aujourd'hui",
+    'AB_bazar_commons2_filter_on_date_for_one_month' => "depuis un mois",
+    'AB_bazar_commons2_filter_on_date_one_week_more_and_less' => "+/- une semaine",
     //video
     'AB_attach_video_label' => "Vidéo intégrée",
     'AB_attach_video_description' => "Intégration d'une vidéo youtube, vimeo ou peertube.",

--- a/tools/bazar/actions/BazarListeAction.php
+++ b/tools/bazar/actions/BazarListeAction.php
@@ -81,9 +81,9 @@ class BazarListeAction extends YesWikiAction
             'user' => $arg['user'] ?? (isset($arg['filteruserasowner']) && $arg['filteruserasowner'] == "true") ?
                 $this->getService(UserManager::class)->getLoggedUserName() : null,
             // Ordre du tri (asc ou desc)
-            'ordre' => $arg['ordre'] ?? 'asc',
+            'ordre' => $arg['ordre'] ?? ((empty($arg['champ']) && !empty($arg['agenda'])) ? 'desc' : 'asc') ,
             // Champ du formulaire utilisé pour le tri
-            'champ' => $arg['champ'] ?? 'bf_titre',
+            'champ' => $arg['champ'] ?? (!empty($arg['agenda']) ? 'bf_date_debut_evenement' : 'bf_titre') ,
             // Nombre maximal de résultats à afficher
             'nb' => $arg['nb'] ?? null,
             // Nombre de résultats affichés pour la pagination (permet d'activer la pagination)

--- a/tools/bazar/actions/BazarListeAction.php
+++ b/tools/bazar/actions/BazarListeAction.php
@@ -637,6 +637,7 @@ class BazarListeAction extends YesWikiAction
                 // start before date
                 return (
                     $date->diff($entryStartDate)->invert == 1
+                    && $entryEndDate && $date->diff($entryEndDate)->invert == 1
                     );
                 break;
             case ">":

--- a/tools/bazar/presentation/templates/agenda.tpl.html
+++ b/tools/bazar/presentation/templates/agenda.tpl.html
@@ -11,51 +11,6 @@ $modal = ''; // declaration d'une chaine de char vide
 ?>
 <!-- traces : pour avoir date en mois : <?php echo str_replace('00:00', '', date("M", strtotime($fiche['bf_date_debut_evenement']))); ?> -->
 
-<?php
-/**************************************************************************************************
- * parametres du template :
- * ils peuvent être passés dans l'action bazar ou bazarliste, mais sont spécifiques à ce template
- **************************************************************************************************/
-
- // test si on veut affichage de toutes les activités (tout) (par défaut) ou seulement celles à venir (futur)
- $agenda = $GLOBALS['wiki']->GetParameter('agenda');
- if (empty($agenda)) {
-     $agenda = 'tout';
- }
-
- if ($agenda=='futur') {
-
-      if (!function_exists('date_periode')) {
-       function date_periode($fiche) {
-          $nbjour = 290;
-          $datejour = time();
-          $datemax = $datejour + ($nbjour*24*60*60);  // date max � J+ nb de jours
-          $datefiche = strtotime($fiche['bf_date_debut_evenement']);
-        $datefin = strtotime($fiche['bf_date_fin_evenement']);
-          if (($datefiche >=$datejour  && $datefiche <=$datemax ) || ($datefin >=$datejour  && $datefin <=$datemax )) {
-              return true;
-              }
-           else  {
-               return  false;
-          }
-      }
-      }
-      if (!function_exists('date_compare')) {
-          //tri par ordre chronologique
-           function date_compare($a, $b)
-           {
-             $t1 = strtotime($a['bf_date_debut_evenement']);    // strtotime = fonction qui transforme une chaine de caractere en date informatque (= un chiffre calcul� depuis 1970)
-             $t2 = strtotime($b['bf_date_debut_evenement']);
-           return $t1 - $t2;
-         }
-      }
-        $fiches = array_filter($fiches, "date_periode");
-        usort($fiches, 'date_compare');  // http://php.net/manual/fr/function.usort.php (si on veut avoir mal au crane)
- }
-?>
-
-
-
 <div class="agenda-container">
   <?php foreach($fiches as $fiche): ?>
   <div class="agenda-entry-container">


### PR DESCRIPTION
Je propose cet nouvelle fonctionnalité pour pouvoir faire davantage de tri sur les dates et surtout pouvoir appliquer des tris sur les dates avec tous les templates.
Cas d'usage : n'afficher que les futurs événements sur une carte.

A priori, il est possible de retirer le tri dans agenda.tpl.html
Par contre, il n'y a plus de tri automatique des fiches, ce qui était le cas avec le paramètre agenda=futur.