### PR TITLE
feat(entryUpdate): update and partialUpdate

### DIFF
--- a/tools/bazar/fields/ImageField.php
+++ b/tools/bazar/fields/ImageField.php
@@ -245,6 +245,6 @@ class ImageField extends FileField
         $entry['antispam'] = 1;
         $entry['date_maj_fiche'] = date('Y-m-d H:i:s', time());
 
-        $entryManager->update($entry['id_fiche'], $entry, false, true);
+        $entryManager->update($entry['id_fiche'], $entry);
     }
 }

--- a/tools/bazar/handlers/page/api_patch.php
+++ b/tools/bazar/handlers/page/api_patch.php
@@ -17,7 +17,7 @@ if ($entryManager->isEntry($this->GetPageTag())) {
         $_POST['id_fiche'] = $this->GetPageTag();
         $_POST['antispam'] = 1;
 
-        $entryManager->update($this->GetPageTag(), $_POST, $semantic, false);
+        $entryManager->partialUpdate($this->GetPageTag(), $_POST, $semantic);
         http_response_code(204);
     } else {
         http_response_code(304);

--- a/tools/bazar/handlers/page/api_put.php
+++ b/tools/bazar/handlers/page/api_put.php
@@ -17,7 +17,7 @@ if ($entryManager->isEntry($this->GetPageTag())) {
         $_POST['id_fiche'] = $this->GetPageTag();
         $_POST['antispam'] = 1;
 
-        $entryManager->update($this->GetPageTag(), $_POST, $semantic, true);
+        $entryManager->update($this->GetPageTag(), $_POST, $semantic);
         http_response_code(204);
     } else {
         http_response_code(304);

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -397,7 +397,7 @@ class EntryManager
         $previousData = $this->getOne($tag);
 
         // not possible to init the formManager in the constructor because of circular reference problem
-        $form = $GLOBALS['wiki']->services->get(FormManager::class)->getOne($data['id_typeannonce']);
+        $form = $this->wiki->services->get(FormManager::class)->getOne($data['id_typeannonce']);
 
         for ($i = 0; $i < count($form['template']); ++$i) {
             if ($form['prepared'][$i] instanceof BazarField) {
@@ -425,7 +425,7 @@ class EntryManager
      * @throws \Exception
      */
     //TODO remove $replace param because update is now only with all data (instead of $replace = false, use partialUpdate)
-    public function update($tag, $data, $semantic = false, $replace = false)
+    public function update($tag, $data, $semantic = false)
     {
         if (!$this->wiki->HasAccess('write', $tag)) {
             throw new \Exception(_t('BAZ_ERROR_EDIT_UNAUTHORIZED'));
@@ -516,7 +516,7 @@ class EntryManager
     public function formatDataBeforeSave($data)
     {
         // not possible to init the formManager in the constructor because of circular reference problem
-        $form = $GLOBALS['wiki']->services->get(FormManager::class)->getOne($data['id_typeannonce']);
+        $form = $this->wiki->services->get(FormManager::class)->getOne($data['id_typeannonce']);
 
         // If there is a title field, compute the entry's title
         for ($i = 0; $i < count($form['template']); ++$i) {
@@ -640,7 +640,7 @@ class EntryManager
         // Données sémantiques
         if ($semantic) {
             // not possible to init the formManager in the constructor because of circular reference problem
-            $form = $GLOBALS['wiki']->services->get(FormManager::class)->getOne($fiche['id_typeannonce']);
+            $form = $this->wiki->services->get(FormManager::class)->getOne($fiche['id_typeannonce']);
             $fiche['semantic'] = $this->semanticTransformer->convertToSemanticData($form, $fiche);
         }
     }

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -402,12 +402,12 @@ class EntryManager
         for ($i = 0; $i < count($form['template']); ++$i) {
             if ($form['prepared'][$i] instanceof BazarField) {
                 $propName = $form['prepared'][$i]->getPropertyName();
-                if (!isset($data[$propName])){
+                if (!isset($data[$propName]) && isset($previousData[$propName])){
                     $data[$propName] = $previousData[$propName];
                 }
             } elseif (function_exists($form['template'][$i][0])) {
                 $propName = $form['template'][$i][1];
-                if (!isset($data[$propName])){
+                if (!isset($data[$propName]) && isset($previousData[$propName])){
                     $data[$propName] = $previousData[$propName];
                 }
             }
@@ -437,7 +437,7 @@ class EntryManager
         //$data['id_typeannonce'] = $this->getOne($tag)['id_typeannonce'];
 
         if ($semantic) {
-            $data = $this->semanticTransformer->convertFromSemanticData(data['id_typeannonce'], $data);
+            $data = $this->semanticTransformer->convertFromSemanticData($data['id_typeannonce'], $data);
         }
 
         $this->validate($data);
@@ -639,7 +639,8 @@ class EntryManager
 
         // Données sémantiques
         if ($semantic) {
-            $form = $this->getService(FormManager::class)->getOne($fiche['id_typeannonce']);
+            // not possible to init the formManager in the constructor because of circular reference problem
+            $form = $GLOBALS['wiki']->services->get(FormManager::class)->getOne($fiche['id_typeannonce']);
             $fiche['semantic'] = $this->semanticTransformer->convertToSemanticData($form, $fiche);
         }
     }


### PR DESCRIPTION
Suite de #670 et #690, une autre façon de faire qui me paraît plus simple.

Il différencie bien la fonction `update` qui met à jour avec l'ensemble du tableau $data, de `partialUpdate` qui met à jour juste en donnant les champs qu'on veut mettre à jour.

Jusqu'alors update faisait de la mise à jour partielle sauf quand on spécifiait le paramètre replace = true. Mais les appels étaient surtout fait avec replace = false alors qu'il n'y en avait pas besoin.

L'intérêt de cette solution est que l'update n'a plus le code spécifique qui gère la mise à jour partielle et quand on veut faire une mise à jour partielle, il suffit d'appeler partialUpdate qui rajoute ce code.

J'ai testé en édition et avec des droits spécifiques sur le champ, cela semble bien fonctionner. 
Je n'ai par contre pas testé la mise à jour via l'API mais je préférais déjà voir avec @J9rem, si cette solution lui va.