### PR TITLE
feat(TagsField): is now facettable

### DIFF
--- a/tools/bazar/fields/TagsField.php
+++ b/tools/bazar/fields/TagsField.php
@@ -9,13 +9,14 @@ use YesWiki\Tags\Service\TagsManager;
 /**
  * @Field({"tags"})
  */
-class TagsField extends BazarField
+class TagsField extends EnumField
 {
     public function __construct(array $values, ContainerInterface $services)
     {
         parent::__construct($values, $services);
 
         $this->maxChars = $this->maxChars ?? 255;
+        $this->propertyName = $this->name ;
     }
 
     protected function renderInput($entry)
@@ -111,5 +112,25 @@ class TagsField extends BazarField
         } else {
             return null ;
         }
+    }
+
+    public function getOptions()
+    {
+        if (empty($this->options) || count($this->options) == 0) {
+            $this->loadOptionsFromTags();
+        }
+        return parent::getOptions() ;
+    }
+
+    private function loadOptionsFromTags()
+    {
+        // TODO use TagsManager instead of TripleStore
+        $tripleStore = $this->getService(TripleStore::class);
+
+        $rawOptions = $tripleStore->getMatching(null,'http://outils-reseaux.org/_vocabulary/tag');
+        $this->options = array_map(function ($rawOption) {
+            return $rawOption['value'] ;
+        },$rawOptions);
+        $this->options = array_combine($this->options,$this->options);
     }
 }

--- a/tools/bazar/fields/TagsField.php
+++ b/tools/bazar/fields/TagsField.php
@@ -116,7 +116,7 @@ class TagsField extends EnumField
 
     public function getOptions()
     {
-        if (empty($this->options) || count($this->options) == 0) {
+        if (empty($this->options)) {
             $this->loadOptionsFromTags();
         }
         return parent::getOptions() ;
@@ -127,10 +127,10 @@ class TagsField extends EnumField
         // TODO use TagsManager instead of TripleStore
         $tripleStore = $this->getService(TripleStore::class);
 
-        $rawOptions = $tripleStore->getMatching(null,'http://outils-reseaux.org/_vocabulary/tag');
+        $rawOptions = $tripleStore->getMatching(null, 'http://outils-reseaux.org/_vocabulary/tag');
         $this->options = array_map(function ($rawOption) {
             return $rawOption['value'] ;
-        },$rawOptions);
-        $this->options = array_combine($this->options,$this->options);
+        }, $rawOptions);
+        $this->options = array_combine($this->options, $this->options);
     }
 }

--- a/tools/bazar/libs/bazar.fonct.php
+++ b/tools/bazar/libs/bazar.fonct.php
@@ -1185,7 +1185,7 @@ function getCustomValueForEntry($parameter, $field, $entry, $default)
     if (is_array($parameter) && !empty($field)) {
         if (isset($entry[$field])) {
             // pour les checkbox, on teste les differentes valeurs et on renvoie la premiere qui va bien
-            if (0 === strpos($field, 'checkbox')) {
+            if (!isset($parameter[$entry[$field]]) && strpos($entry[$field], ',') !== false) {
                 $tab = explode(',', $entry[$field]);
                 foreach ($tab as $value) {
                     if (isset($parameter[$value])) {

--- a/tools/bazar/services/FormManager.php
+++ b/tools/bazar/services/FormManager.php
@@ -4,7 +4,9 @@ namespace YesWiki\Bazar\Service;
 
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use YesWiki\Bazar\Field\BazarField;
+use YesWiki\Bazar\Field\CheckboxEntryField;
 use YesWiki\Bazar\Field\EnumField;
+use YesWiki\Bazar\Field\SelectEntryField;
 use YesWiki\Core\Service\DbService;
 use YesWiki\Wiki;
 
@@ -317,14 +319,18 @@ class FormManager
                     }
 
                     if ($fieldPropName) {
-                        $islistforeign = (strpos($fieldPropName, 'listefiche')===0) || (strpos($fieldPropName, 'checkboxfiche')===0);
-                        $islist = in_array($fieldType, array('checkbox', 'select', 'scope', 'radio', 'liste')) && !$islistforeign;
-                        $istext = (!in_array($fieldType, array('checkbox', 'select', 'scope', 'radio', 'liste', 'checkboxfiche', 'listefiche')));
 
-                        if ($islistforeign) {
-                            // listefiche ou checkboxfiche
-                            $facetteValue[$fieldPropName]['type'] = 'fiche';
+                        if ($field instanceof EnumField) {
+
+                            if ($field instanceof SelectEntryField || $field instanceof CheckboxEntryField ) {
+                                // listefiche ou checkboxfiche
+                                $facetteValue[$fieldPropName]['type'] = 'fiche';
+                            } else {
+                                $facetteValue[$fieldPropName]['type'] = 'liste';
+                            }
+                            
                             $facetteValue[$fieldPropName]['source'] = $key;
+
                             $tabval = explode(',', $value);
                             foreach ($tabval as $tval) {
                                 if (isset($facetteValue[$fieldPropName][$tval])) {
@@ -333,19 +339,7 @@ class FormManager
                                     $facetteValue[$fieldPropName][$tval] = 1;
                                 }
                             }
-                        } elseif ($islist) {
-                            // liste ou checkbox
-                            $facetteValue[$fieldPropName]['type'] = 'liste';
-                            $facetteValue[$fieldPropName]['source'] = $key;
-                            $tabval = explode(',', $value);
-                            foreach ($tabval as $tval) {
-                                if (isset($facetteValue[$fieldPropName][$tval])) {
-                                    ++$facetteValue[$fieldPropName][$tval];
-                                } else {
-                                    $facetteValue[$fieldPropName][$tval] = 1;
-                                }
-                            }
-                        } elseif ($istext and !$onlyLists) {
+                        } elseif ( !$onlyLists) {
                             // texte
                             $facetteValue[$key]['type'] = 'form';
                             $facetteValue[$key]['source'] = $key;


### PR DESCRIPTION
Afin de rendre les tags filtrables dans les facettes
1. passage de TagsField à extend EnumField
2. ajout de TagsField->getOptions
3. dans bazar;fonct, le test de la fonction getCustomValueForEntry est un peu moins strict (ce qui permet entre autre de profiter des customs fields qui vont étendre les checkbox)
4. Refacto de FormManager->scanAllFacettable pour le rendre compatible avec les EnumField (plus souple)