### PR TITLE
Refacto oldfield

### DIFF
--- a/tools/bazar/actions/BazarListeAction.php
+++ b/tools/bazar/actions/BazarListeAction.php
@@ -474,10 +474,6 @@ class BazarListeAction extends YesWikiAction
                     if ($field->getPropertyName() === $name) {
                         return $field;
                     }
-                } elseif (is_array($field)) {
-                    if (isset($field['id']) && $field['id'] === $name) {
-                        return $field;
-                    }
                 }
             }
         }

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -85,10 +85,10 @@ class EntryController extends YesWikiController
 
         // if not found, use default template
         if (is_null($renderedEntry)) {
-            for ($i = 0; $i < count($form['template']); ++$i) {
-                if ($form['prepared'][$i] instanceof BazarField) {
+            foreach ($form['prepared'] as $field) {
+                if ($field instanceof BazarField) {
                     // TODO handle html_outside_app mode for images
-                    $renderedEntry .= $form['prepared'][$i]->renderStaticIfPermitted($entry);
+                    $renderedEntry .= $field->renderStaticIfPermitted($entry);
                 }
             }
         }

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -89,20 +89,6 @@ class EntryController extends YesWikiController
                 if ($form['prepared'][$i] instanceof BazarField) {
                     // TODO handle html_outside_app mode for images
                     $renderedEntry .= $form['prepared'][$i]->renderStaticIfPermitted($entry);
-                } else {
-                    // Check if we should display the field
-                    $functionName = $form['template'][$i][0];
-                    if (function_exists($functionName)
-                        && (empty($form['prepared'][$i]['read_acl'])
-                            || $this->wiki->CheckACL($form['prepared'][$i]['read_acl'], null, true, $entryId))
-                    ) {
-                        $renderedEntry .= $functionName(
-                            $formtemplate,
-                            $form['template'][$i],
-                            'html',
-                            $entry
-                        );
-                    }
                 }
             }
         }
@@ -227,19 +213,6 @@ class EntryController extends YesWikiController
         for ($i = 0; $i < count($form['prepared']); ++$i) {
             if ($form['prepared'][$i] instanceof BazarField) {
                 $renderedFields[] = $form['prepared'][$i]->renderInputIfPermitted($entry);
-            } else {
-                $functionName = $form['template'][$i][0];
-                if (function_exists($functionName)
-                    && (empty($form['prepared'][$i]['write_acl'])
-                        || $this->wiki->CheckACL(
-                            $form['prepared'][$i]['write_acl'],
-                            null,
-                            true,
-                            $entry['id_fiche'] ?? null
-                        ))
-                ) {
-                    $renderedFields[] = $functionName($formtemplate, $form['template'][$i], 'saisie', $entry);
-                }
             }
         }
         return $renderedFields;
@@ -303,27 +276,9 @@ class EntryController extends YesWikiController
     {
         $html = $formtemplate = [];
         for ($i = 0; $i < count($form['template']); ++$i) {
-            $replace = false;
             if ($form['prepared'][$i] instanceof BazarField) {
                 $id = $form['prepared'][$i]->getPropertyName();
                 $html[$id] = $form['prepared'][$i]->renderStaticIfPermitted($entry);
-                $replace = true;
-            } else {
-                $functionName = $form['template'][$i][0];
-                if (function_exists($functionName)) {
-                    if (empty($form['prepared'][$i]['read_acl']) || $this->wiki->CheckACL(
-                        $form['prepared'][$i]['read_acl'],
-                        null,
-                        true,
-                        $entry['id_fiche']
-                    )) {
-                        $id = $form['template'][$i][1];
-                        $html[$id] = $functionName($formtemplate, $form['template'][$i], 'html', $entry);
-                        $replace = true;
-                    }
-                }
-            }
-            if ($replace) {
                 if ($id == 'bf_titre') {
                     preg_match('/<h1 class="BAZ_fiche_titre">\s*(.*)\s*<\/h1>.*$/is', $html[$id], $matches);
                 } else {

--- a/tools/bazar/fields/BazarField.php
+++ b/tools/bazar/fields/BazarField.php
@@ -127,7 +127,7 @@ abstract class BazarField implements \JsonSerializable
     // HELPERS
 
     /* Return true if we are if reading is allowed for the field */
-    protected function canRead($entry)
+    public function canRead($entry)
     {
         $readAcl = empty($this->readAccess) ? '' : $this->readAccess;
         $isCreation = !$entry;

--- a/tools/bazar/fields/EmailField.php
+++ b/tools/bazar/fields/EmailField.php
@@ -63,13 +63,18 @@ class EmailField extends BazarField
         ]);
     }
 
+    public function getShowContactForm()
+    {
+        return $this->showContactForm ;
+    }
+
     public function jsonSerialize()
     {
         return array_merge(
             parent::jsonSerialize(),
             [
                 'sendMail' => $this->sendMail,
-                'showContactForm' => $this->showContactForm
+                'showContactForm' => $this->getShowContactForm()
             ]
         );
     }

--- a/tools/bazar/fields/OldField.php
+++ b/tools/bazar/fields/OldField.php
@@ -6,11 +6,11 @@ use Psr\Container\ContainerInterface;
 use YesWiki\Core\Service\TemplateEngine;
 
 /**
- * Ensure retrocompatibility with old format field
+ * Ensure backwardompatibility with old format field
  *
- * @Field({"retrocomp"})
+ * @Field({"old"})
  */
-class RetroCompField extends BazarField
+class OldField extends BazarField
 {
     protected $functionName ;
     protected $template ;

--- a/tools/bazar/fields/OldField.php
+++ b/tools/bazar/fields/OldField.php
@@ -24,7 +24,7 @@ class OldField extends BazarField
             $this->error = $twig->render(
                 '@templates/alert-message.twig',
                 ['type' => 'danger',
-                 'message' => "Error \$values['functionName'] is not defined while creating RetroCompField. \n<br>".
+                 'message' => "Error \$values['functionName'] is not defined while creating ".get_class($this).". \n<br>".
                  "Do not use 'retrocomp' field in form builder."
                 ]
             );
@@ -32,7 +32,7 @@ class OldField extends BazarField
             $this->error = $twig->render(
                 '@templates/alert-message.twig',
                 ['type' => 'danger',
-                 'message' => "Error function '".$this->functionName."' is not defined while creating RetroCompField"
+                 'message' => "Error function '".$this->functionName."' is not defined while creating ".get_class($this)
                 ]
             );
         } else {

--- a/tools/bazar/fields/OldField.php
+++ b/tools/bazar/fields/OldField.php
@@ -47,14 +47,18 @@ class OldField extends BazarField
 
     protected function renderInput($entry)
     {
-        return $this->error ?? $this->functionName([], $this->template, 'saisie', $entry) ;
+        $funcName = $this->functionName ;
+        $templateForm = [] ;
+        return $this->error ?? $funcName($templateForm, $this->template, 'saisie', $entry) ;
     }
 
     // Format input values before save
     public function formatValuesBeforeSave($entry)
     {
+        $funcName = $this->functionName ;
+        $templateForm = [] ;
         return ($this->error) ? [$this->propertyName => null]
-            : $this->functionName([], $this->template, 'requete', $entry) ;
+            : $funcName($templateForm, $this->template, 'requete', $entry) ;
     }
 
     // Replace data before format data
@@ -76,7 +80,9 @@ class OldField extends BazarField
 
     protected function renderStatic($entry)
     {
-        return $this->error ?? $this->functionName([], $this->template, 'html', $entry) ;
+        $funcName = $this->functionName ;
+        $templateForm = [] ;
+        return $this->error ?? $funcName($templateForm, $this->template, 'html', $entry) ;
     }
 
     public function jsonSerialize()

--- a/tools/bazar/fields/OldField.php
+++ b/tools/bazar/fields/OldField.php
@@ -61,23 +61,6 @@ class OldField extends BazarField
             : $funcName($templateForm, $this->template, 'requete', $entry) ;
     }
 
-    // Replace data before format data
-    public function formatValuesBeforeSaveWithReplace($entry, $previousEntry, $replace = false)
-    {
-        if (!$this->canEdit($entry)) {
-            if (isset($previousEntry[$this->propertyName])) {
-                $entry[$this->propertyName] = $previousEntry[$this->propertyName];
-            } elseif (isset($entry[$this->propertyName])) {
-                unset($entry[$this->propertyName]);
-            }
-        }
-        // same behaviour as before
-        if (!$replace) {
-            $entry = array_merge($previousEntry,$entry) ;
-        }
-        return $this->formatValuesBeforeSave($entry) ;
-    }
-
     protected function renderStatic($entry)
     {
         $funcName = $this->functionName ;

--- a/tools/bazar/fields/OldField.php
+++ b/tools/bazar/fields/OldField.php
@@ -53,8 +53,25 @@ class OldField extends BazarField
     // Format input values before save
     public function formatValuesBeforeSave($entry)
     {
-        return ($this->error) ? [$this->propertyName => $this->error]
+        return ($this->error) ? [$this->propertyName => null]
             : $this->functionName([], $this->template, 'requete', $entry) ;
+    }
+
+    // Replace data before format data
+    public function formatValuesBeforeSaveWithReplace($entry, $previousEntry, $replace = false)
+    {
+        if (!$this->canEdit($entry)) {
+            if (isset($previousEntry[$this->propertyName])) {
+                $entry[$this->propertyName] = $previousEntry[$this->propertyName];
+            } elseif (isset($entry[$this->propertyName])) {
+                unset($entry[$this->propertyName]);
+            }
+        }
+        // same behaviour as before
+        if (!$replace) {
+            $entry = array_merge($previousEntry,$entry) ;
+        }
+        return $this->formatValuesBeforeSave($entry) ;
     }
 
     protected function renderStatic($entry)

--- a/tools/bazar/fields/OldField.php
+++ b/tools/bazar/fields/OldField.php
@@ -12,34 +12,36 @@ use YesWiki\Core\Service\TemplateEngine;
  */
 class OldField extends BazarField
 {
-    protected $functionName ;
-    protected $template ;
-    protected $error ;
+    protected $functionName;
+    protected $template;
+    protected $error;
 
     public function __construct(array $values, ContainerInterface $services)
     {
-        $this->functionName = $values['functionName'] ?? null ;
+        $this->functionName = $values['functionName'] ?? null;
         $twig = $services->get(TemplateEngine::class);
         if (empty($this->functionName)) {
             $this->error = $twig->render(
                 '@templates/alert-message.twig',
-                ['type' => 'danger',
-                 'message' => "Error \$values['functionName'] is not defined while creating ".get_class($this).". \n<br>".
-                 "Do not use 'retrocomp' field in form builder."
+                [
+                    'type' => 'danger',
+                    'message' => "Error \$values['functionName'] is not defined while creating " . get_class($this) . ". \n<br>" .
+                        "Do not use 'retrocomp' field in form builder."
                 ]
             );
         } elseif (!function_exists($this->functionName)) {
             $this->error = $twig->render(
                 '@templates/alert-message.twig',
-                ['type' => 'danger',
-                 'message' => "Error function '".$this->functionName."' is not defined while creating ".get_class($this)
+                [
+                    'type' => 'danger',
+                    'message' => "Error function '" . $this->functionName . "' is not defined while creating " . get_class($this)
                 ]
             );
         } else {
-            $this->error = null ;
+            $this->error = null;
         }
-        unset($values['functionName']) ;
-        $this->template = $values ;
+        unset($values['functionName']);
+        $this->template = $values;
         $this->template[0] = $this->functionName;
         parent::__construct($values, $services);
         $this->type = $this->functionName;
@@ -47,25 +49,25 @@ class OldField extends BazarField
 
     protected function renderInput($entry)
     {
-        $funcName = $this->functionName ;
-        $templateForm = [] ;
-        return $this->error ?? $funcName($templateForm, $this->template, 'saisie', $entry) ;
+        $funcName = $this->functionName;
+        $templateForm = [];
+        return $this->error ?? $funcName($templateForm, $this->template, 'saisie', $entry);
     }
 
     // Format input values before save
     public function formatValuesBeforeSave($entry)
     {
-        $funcName = $this->functionName ;
-        $templateForm = [] ;
+        $funcName = $this->functionName;
+        $templateForm = [];
         return ($this->error) ? [$this->propertyName => null]
-            : $funcName($templateForm, $this->template, 'requete', $entry) ;
+            : $funcName($templateForm, $this->template, 'requete', $entry);
     }
 
     protected function renderStatic($entry)
     {
-        $funcName = $this->functionName ;
-        $templateForm = [] ;
-        return $this->error ?? $funcName($templateForm, $this->template, 'html', $entry) ;
+        $funcName = $this->functionName;
+        $templateForm = [];
+        return $this->error ?? $funcName($templateForm, $this->template, 'html', $entry);
     }
 
     public function jsonSerialize()

--- a/tools/bazar/fields/RetroCompField.php
+++ b/tools/bazar/fields/RetroCompField.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace YesWiki\Bazar\Field;
+
+use Psr\Container\ContainerInterface;
+use YesWiki\Core\Service\TemplateEngine;
+
+/**
+ * Ensure retrocompatibility with old format field
+ *
+ * @Field({"retrocomp"})
+ */
+class RetroCompField extends BazarField
+{
+    protected $functionName ;
+    protected $template ;
+    protected $error ;
+
+    public function __construct(array $values, ContainerInterface $services)
+    {
+        $this->functionName = $values['functionName'] ?? null ;
+        $twig = $services->get(TemplateEngine::class);
+        if (empty($this->functionName)) {
+            $this->error = $twig->render(
+                '@templates/alert-message.twig',
+                ['type' => 'danger',
+                 'message' => "Error \$values['functionName'] is not defined while creating RetroCompField. \n<br>".
+                 "Do not use 'retrocomp' field in form builder."
+                ]
+            );
+        } elseif (!function_exists($this->functionName)) {
+            $this->error = $twig->render(
+                '@templates/alert-message.twig',
+                ['type' => 'danger',
+                 'message' => "Error function '".$this->functionName."' is not defined while creating RetroCompField"
+                ]
+            );
+        } else {
+            $this->error = null ;
+        }
+        unset($values['functionName']) ;
+        $this->template = $values ;
+        $this->template[0] = $this->functionName;
+        parent::__construct($values, $services);
+        $this->type = $this->functionName;
+    }
+
+    protected function renderInput($entry)
+    {
+        return $this->error ?? $this->functionName([], $this->template, 'saisie', $entry) ;
+    }
+
+    // Format input values before save
+    public function formatValuesBeforeSave($entry)
+    {
+        return ($this->error) ? [$this->propertyName => $this->error]
+            : $this->functionName([], $this->template, 'requete', $entry) ;
+    }
+
+    protected function renderStatic($entry)
+    {
+        return $this->error ?? $this->functionName([], $this->template, 'html', $entry) ;
+    }
+
+    public function jsonSerialize()
+    {
+        return array_merge(
+            parent::jsonSerialize(),
+            ['functionName' => $this->functionName]
+        );
+    }
+}

--- a/tools/bazar/handlers/page/json.php
+++ b/tools/bazar/handlers/page/json.php
@@ -87,7 +87,7 @@ if (isset($_REQUEST['demand'])) {
             } else {
                 $wikipage = $this->LoadPage($idfiche);
                 if ($wikipage) {
-                    if ($this->HasAccess('read',$idfiche)) {
+                    if ($this->HasAccess('read', $idfiche)) {
                         if ($html==1) {
                             echo json_encode(array('html' => baz_voir_fiche(0, $idfiche)));
                         } else {
@@ -151,6 +151,7 @@ if (isset($_REQUEST['demand'])) {
                                 '</div> <!-- /.BAZ_rubrique -->' . "\n" .
                                 '{{/if}}' . "\n\n";
                         } elseif (function_exists($tableau[$i][0])) {
+                            //TODO replace with BazarField
                             $texte = trim(
                                 $tableau[$i][0](
                                     $formtemplate,
@@ -216,7 +217,7 @@ if (isset($_REQUEST['demand'])) {
             $pages = _convert($this->LoadAll($sql), 'ISO-8859-15');
             $pagesindex = array();
             foreach ($pages as $page) {
-                if ($this->HasAccess('read',$page["tag"])) {
+                if ($this->HasAccess('read', $page["tag"])) {
                     $pagesindex[$page["tag"]] = $page;
                 }
             }

--- a/tools/bazar/services/FormManager.php
+++ b/tools/bazar/services/FormManager.php
@@ -247,7 +247,7 @@ class FormManager
                 $prepared[$i] = $classField;
             } elseif (function_exists($field[0])) {
                 $functionName = $field[0];
-                $fieldName = 'retrocomp' ;
+                $fieldName = 'old' ;
                 $field[0] = $fieldName;
                 $field['functionName'] = $functionName ;
                 $classField = $this->fieldFactory->create($field);

--- a/tools/bazar/services/FormManager.php
+++ b/tools/bazar/services/FormManager.php
@@ -245,44 +245,14 @@ class FormManager
 
             if ($classField) {
                 $prepared[$i] = $classField;
-            } else {
-                /*
-                 * DEFAULT VALUES
-                 */
-
-                // champs obligatoire
-                if ($field[self::FIELD_REQUIRED] == 1) {
-                    $prepared[$i]['required'] = true;
-                } else {
-                    $prepared[$i]['required'] = false;
-                }
-
-                // texte d'invitation à la saisie
-                $prepared[$i]['label'] = $field[self::FIELD_LABEL];
-
-                // attributs html du champs
-                $prepared[$i]['attributes'] = '';
-
-                // valeurs associées
-                $prepared[$i]['values'] = '';
-
-                // texte d'aide
-                $prepared[$i]['helper'] = $field[self::FIELD_HELP];
-
-                // values for read acl
-                $prepared[$i]['read_acl'] = $field[self::FIELD_READ_ACCESS];
-
-                // values for write acl
-                $prepared[$i]['write_acl'] = $field[self::FIELD_WRITE_ACCESS];
-
-                // traitement sémantique
-                // TODO move to BazarField
-                if (!empty($field[self::FIELD_SEMANTIC])) {
-                    $prepared[$i]['sem_type'] = strpos($field[self::FIELD_SEMANTIC], ',')
-                        ? array_map(function ($str) {
-                            return trim($str);
-                        }, explode(',', $field[self::FIELD_SEMANTIC]))
-                        : $field[self::FIELD_SEMANTIC];
+            } elseif (function_exists($field[0])) {
+                $functionName = $field[0];
+                $fieldName = 'retrocomp' ;
+                $field[0] = $fieldName;
+                $field['functionName'] = $functionName ;
+                $classField = $this->fieldFactory->create($field);
+                if ($classField) {
+                    $prepared[$i] = $classField;
                 }
             }
             $i++;
@@ -313,9 +283,6 @@ class FormManager
                     if ($field instanceof BazarField) {
                         $fieldPropName = $field->getPropertyName();
                         $fieldType = $field->getType();
-                    } elseif (is_array($field)) {
-                        $fieldPropName = $field['id'];
-                        $fieldType = $field['type'];
                     }
 
                     if ($fieldPropName) {
@@ -371,8 +338,6 @@ class FormManager
             return array_filter($fields, function ($field) use ($id) {
                 if ($field instanceof BazarField) {
                     return $id[0] === 'all' || in_array($field->getPropertyName(), $id);
-                } elseif (is_array($field) && isset($field['id'])) {
-                    return $id[0] === 'all' || in_array($field['id'], $id);
                 }
             });
         }

--- a/tools/bazar/services/FormManager.php
+++ b/tools/bazar/services/FormManager.php
@@ -20,23 +20,6 @@ class FormManager
 
     protected $cachedForms;
 
-    private const FIELD_TYPE = 0;
-    private const FIELD_ID = 1;
-    private const FIELD_LABEL = 2;
-    private const FIELD_SIZE = 3;
-    private const FIELD_MAX_LENGTH = 4;
-    private const FIELD_DEFAULT = 5;
-    private const FIELD_PATTERN = 6;
-    private const FIELD_SUB_TYPE = 7;
-    private const FIELD_REQUIRED = 8;
-    private const FIELD_SEARCHABLE = 9;
-    private const FIELD_HELP = 10;
-    private const FIELD_READ_ACCESS = 11;
-    private const FIELD_WRITE_ACCESS = 12;
-    private const FIELD_KEYWORDS = 13;
-    private const FIELD_SEMANTIC = 14;
-    private const FIELD_QUERIES = 15;
-
     public function __construct(
         Wiki $wiki,
         DbService $dbService,

--- a/tools/bazar/services/FormManager.php
+++ b/tools/bazar/services/FormManager.php
@@ -123,10 +123,10 @@ class FormManager
     public function delete($id)
     {
         //TODO : suppression des fiches associees au formulaire
-        
+
         // tests of if $formId is int
         if (strval(intval($id)) != strval($id)) {
-            return null ;
+            return null;
         }
 
         return $this->dbService->query('DELETE FROM ' . $this->dbService->prefixTable('nature') . 'WHERE bn_id_nature=' . $id);
@@ -229,11 +229,7 @@ class FormManager
             if ($classField) {
                 $prepared[$i] = $classField;
             } elseif (function_exists($field[0])) {
-                $functionName = $field[0];
-                $fieldName = 'old' ;
-                $field[0] = $fieldName;
-                $field['functionName'] = $functionName ;
-                $classField = $this->fieldFactory->create($field);
+                $classField = $this->fieldFactory->create([0 => 'old', 'functionName' => $field[0]]);
                 if ($classField) {
                     $prepared[$i] = $classField;
                 }
@@ -269,10 +265,8 @@ class FormManager
                     }
 
                     if ($fieldPropName) {
-
                         if ($field instanceof EnumField) {
-
-                            if ($field instanceof SelectEntryField || $field instanceof CheckboxEntryField ) {
+                            if ($field instanceof SelectEntryField || $field instanceof CheckboxEntryField) {
                                 // listefiche ou checkboxfiche
                                 $facetteValue[$fieldPropName]['type'] = 'fiche';
                             } else {
@@ -289,7 +283,7 @@ class FormManager
                                     $facetteValue[$fieldPropName][$tval] = 1;
                                 }
                             }
-                        } elseif ( !$onlyLists) {
+                        } elseif (!$onlyLists) {
                             // texte
                             $facetteValue[$key]['type'] = 'form';
                             $facetteValue[$key]['source'] = $key;
@@ -311,7 +305,7 @@ class FormManager
      */
     private function filterFieldsByPropertyName(array $fields, array $id)
     {
-        if (count($id)===1 && $id[0]==='all') {
+        if (count($id) === 1 && $id[0] === 'all') {
             return array_filter($fields, function ($field) use ($id) {
                 if ($field instanceof EnumField) {
                     return true;

--- a/tools/bazar/services/Guard.php
+++ b/tools/bazar/services/Guard.php
@@ -77,22 +77,19 @@ class Guard
                 $form = $this->formManager->getOne($valeur['id_typeannonce']);
                 if ($form) {
                     $fieldname = array();
-                    $iMax = count($form['template']) ;
-                    for ($i = 0; $i < $iMax; ++$i) {
-                        if (isset($form['prepared'][$i])){
-                            // cas des formulaires champs mails, qui ne doivent pas apparaitre en /raw
-                            if ($form['prepared'][$i] instanceof EmailField
-                                    && $form['prepared'][$i]->getShowContactForm() == 'form'
-                                    && ($this->wiki->getMethod() == 'raw'
-                                    || $this->wiki->getMethod() == 'json')
-                                    ) {
-                                $fieldname[] = $line[1];
-                            }
-                            if ($form['prepared'][$i] instanceof BazarField
-                                    && !$form['prepared'][$i]->canRead(['id_fiche' => $tag])
-                                    ){
-                                $fieldname[] = $form['prepared'][$i]->getPropertyName() ;
-                            }
+                    foreach ($form['prepared'] as $field) {
+                        // cas des formulaires champs mails, qui ne doivent pas apparaitre en /raw
+                        if ($field instanceof EmailField
+                                && $field->getShowContactForm() == 'form'
+                                && ($this->wiki->getMethod() == 'raw'
+                                || $this->wiki->getMethod() == 'json')
+                                ) {
+                            $fieldname[] = $field->getPropertyName();
+                        }
+                        if ($field instanceof BazarField
+                                && !$field->canRead(['id_fiche' => $tag])
+                                ) {
+                            $fieldname[] = $field->getPropertyName() ;
                         }
                     }
                     if (count($fieldname) > 0) {

--- a/tools/bazar/services/SemanticTransformer.php
+++ b/tools/bazar/services/SemanticTransformer.php
@@ -26,15 +26,10 @@ class SemanticTransformer
         $semanticData['@id'] = $GLOBALS['wiki']->href('', $data['id_fiche']);
 
         foreach ($form['prepared'] as $field) {
-
             if ($field instanceof BazarField) {
                 $fieldPropName = $field->getPropertyName();
                 $fieldSemanticPredicate = $field->getSemanticPredicate();
                 $fieldType = $field->getType();
-            } else {
-                $fieldPropName = $field['id'];
-                $fieldSemanticPredicate = $field['sem_type'];
-                $fieldType = $field['type'];
             }
 
             // If the file is not semantically defined, ignore it
@@ -85,15 +80,10 @@ class SemanticTransformer
         }
 
         foreach ($form['prepared'] as $field) {
-
             if ($field instanceof BazarField) {
                 $fieldPropName = $field->getPropertyName();
                 $fieldSemanticPredicate = $field->getSemanticPredicate();
                 $fieldType = $field->getType();
-            } else {
-                $fieldPropName = $field['id'];
-                $fieldSemanticPredicate = $field['sem_type'];
-                $fieldType = $field['type'];
             }
 
             // If the file is not semantically defined, ignore it


### PR DESCRIPTION
création d'un branche séparée et d'un PR séparée pour facilite le relecture de #670.

Cette PR regroupe toutes les modifications concernant la création d'un champ OldField qui permet d'utiliser les anciens champs bazar (qui sont des fontions) comme des Bazar Field.

Ceci permet de simplifier le code et de réduire les risques d'erreurs.

a priori @acheype tu avais dit que c'était OK, je te laisse confirmer.
