### PR TITLE
Bazarlisteprerenderaction

### DIFF
--- a/index.php
+++ b/index.php
@@ -60,7 +60,11 @@ spl_autoload_register(function ($className) {
                     require 'tools/' . $extension . '/fields/' . $classNameArray[3] . '.php';
                 }
             } elseif ($classNameArray[2] === 'Controller') {
-                require 'tools/' . $extension . '/controllers/' . $classNameArray[3] . '.php';
+                if ($extension == 'custom') {
+                    require 'custom/controllers/' . $classNameArray[3] . '.php';
+                } else {
+                    require 'tools/' . $extension . '/controllers/' . $classNameArray[3] . '.php';
+                }
             }
         }
     }

--- a/tools/bazar/actions/BazarListeAction.php
+++ b/tools/bazar/actions/BazarListeAction.php
@@ -69,23 +69,29 @@ class BazarListeAction extends YesWikiAction
             }
         }
         
-        $template = $_GET['template'] ?? $arg['template'] ?? $this->params->get('default_bazar_template');
+        
+        $template = $_GET['template'] ?? $arg['template'] ?? null ;
+        $template = (!empty($template)) ? $template : $this->params->get('default_bazar_template');
         $prerenderer = $arg['prerenderer'] ?? null ;
         
         if (empty($prerenderer)) {
-            if (preg_match_all("/^(.*)(.twig|.tpl.html)$/i", $template, $matches)) {
-                $prerenderer = $matches[1][0] ;
+            if (preg_match_all("/^(.*)(.tpl.html)$/i", $template, $matches)) {
+                $prerenderer = null ; // not prerenderer if .tpl.html
             } else {
-                $prerenderer = $template ;
+                if (preg_match_all("/^(.*)(.twig)$/i", $template, $matches)) {
+                    $prerenderer = $matches[1][0] ;
+                } else {
+                    $prerenderer = $template ;
+                }
+                $prerenderer .= 'PreRenderer' ;
             }
-            $prerenderer .= 'PreRenderer' ;
-        } 
-        if (!empty($prerenderer)){
+        }
+        if (!empty($prerenderer)) {
             $prerenderer =
                 (
                     ($serviceName = 'YesWiki\\Custom\\Controller\\' . $prerenderer) &&
                     $this->wiki->services->has($serviceName)
-                ) ? $serviceName : 
+                ) ? $serviceName :
                 (
                     (
                         ($serviceName = 'YesWiki\\Bazar\\Controller\\' . $prerenderer) &&
@@ -96,9 +102,7 @@ class BazarListeAction extends YesWikiAction
                         $this->wiki->services->has($serviceName)
                     ) ? $serviceName : null
                 );
-        } 
-
-        $template = $_GET['template'] ?? $arg['template'] ?? null ;
+        }
 
         return([
             // SELECTION DES FICHES
@@ -129,7 +133,7 @@ class BazarListeAction extends YesWikiAction
 
             // AFFICHAGE
             // Template pour l'affichage de la liste de fiches
-            'template' => (!empty($template)) ? $template : $this->params->get('default_bazar_template'),
+            'template' => $template,
             // classe css a ajouter en rendu des templates liste
             'class' => $arg['class'] ?? '',
             // ajout du footer pour gérer la fiche (modifier, droits, etc,.. )
@@ -299,7 +303,7 @@ class BazarListeAction extends YesWikiAction
             $data['pager_links'] = '<div class="bazar_numero text-center"><ul class="pagination">'.$pager->links.'</ul></div>';
         }
 
-        if (!empty($this->arguments['prerenderer'])){                
+        if (!empty($this->arguments['prerenderer'])) {
             $data = $this->getService($this->arguments['prerenderer'])->preRender($data) ;
         }
         try {

--- a/tools/bazar/actions/BazarListePreRenderAction.php
+++ b/tools/bazar/actions/BazarListePreRenderAction.php
@@ -1,0 +1,56 @@
+<?php
+
+use YesWiki\Core\YesWikiAction;
+
+class BazarListePreRenderAction extends YesWikiAction
+{
+    private $error ;
+
+    function formatArguments($arg)
+    {
+        $this->error = '' ;
+        $this->error .= ($this->checkIndex($arg,'calledBy')) ? 
+            (
+                ($arg['calledBy'] != 'BazarListeAction') ? 
+                  '<br/>' . get_class($this) . ' can only be called by "BazarListeAction" !' :
+                  ''
+            ):
+            '';
+        $this->checkIndex($arg,'listId') ;
+        $this->checkIndex($arg,'numEntries') ;
+        $this->checkIndex($arg,'forms') ;
+        $this->checkIndex($arg,'pageTag') ;
+        return([
+            
+        ]);
+    }
+
+    private function checkIndex(array $arg,string $index): bool
+    {
+        if (isset($arg[$index])) {
+            return true ;
+        } else {
+            $this->error .= '<br/>The item \''.$index.'\' shoud be defined in arguments';
+            return false
+        }
+    }
+
+    function run()
+    {
+        if (!empty($this->error)) {
+            $this->error = 'Error occured in ' . self::class . ' :' . $this->error ;
+            return $this->render('@templates/alert-message.twig', [
+                'type' => 'danger',
+                'message' => $this->error
+            ]);
+        }
+
+        return $this->render('@bazar/entries/list.twig', $this->arguments]);
+    }
+
+    // this method is called by child class before render template
+    protected function preRender(? array $arg): ? array
+    {
+        return $arg;
+    }
+}

--- a/tools/bazar/controllers/templateNamePreRenderer.php
+++ b/tools/bazar/controllers/templateNamePreRenderer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace YesWiki\Bazar\Controller;
+
+use YesWiki\Core\YesWikiController;
+
+class templateNamePreRenderer extends YesWikiController
+{
+
+    public function preRender(?array $data): ?array
+    {
+        foreach ($data['fiches'] as $id => $fiche){
+            $fiche['bf_titre'] = 'Titre de test';
+            $data['fiches'][$id] = $fiche;
+        }
+        return $data ;
+    }
+
+}


### PR DESCRIPTION
J'ouvre un espace de premiers échanges sur une prerendenrer.
C'est un contrôleur qui serait appelé juste avant de faire le rendu d'un template bazarliste.
**Ceci est plus une concertation, donc un PR en Draft**
Je pense que je vais faire vivre le contenu de la branche au fur et à mesure des remarques.

Je propose pour faire simple dans un premier temps, de ne pas implanter les modifications au niveau du TemplateEngine car il y a de trop nombreux cas à gérer.
Alors qu'au niveau de BazarListe, c'est simple.

1. il y a un nouveau paramètre facultatif `prerenderer` qui permet de choisir le prerender voulu
2. Il est possible d'avoir des prerenderer dans le dossier custom/controllers qui surchagent les prerender par défaut
3. Si le paramètre n'est pas complété, il y a recherche des prerenderer en se basant sur le nom du template utilisé.
