### PR TITLE
fix(action-bilder/flying-bar): display at right place for textarea

### DIFF
--- a/tools/aceditor/presentation/javascripts/components/flying-action-bar.js
+++ b/tools/aceditor/presentation/javascripts/components/flying-action-bar.js
@@ -27,7 +27,7 @@ export default class {
         <i class="fa fa-pencil-alt"></i>
       </a>
     </div>`)
-    $('textarea#body').before(this.flyingActionBar);
+    $('textarea#body,textarea.action-builder-anchor').before(this.flyingActionBar);
 
     this.editor.onCursorChange(() => this.onCusrorChange())
     this.onCusrorChange()
@@ -39,6 +39,7 @@ export default class {
       this.flyingActionBar.toggleClass('active', this.actionIsSelected);
       $('.component-action-list').toggleClass('only-edit', this.actionIsSelected)
       if (this.actionIsSelected) {
+        $('.ace_gutter').removeAttr('aria-hidden'); // to catch offset, css put opacity to 0
         let top = $('.ace_gutter-active-line').offset().top - $('.ace-editor-container').offset().top + $('.aceditor-toolbar').height()
         this.flyingActionBar.css('top', top + 'px')
       }

--- a/tools/aceditor/presentation/styles/aceditor.css
+++ b/tools/aceditor/presentation/styles/aceditor.css
@@ -4,7 +4,8 @@
 }
 /* Show line numbers only on page edit */
 form:not(#ACEditor) .ace-editor-container .ace_gutter {
-  display: none !important;
+  opacity: 0;
+  z-index:0 ;
 }
 form:not(#ACEditor) .ace-editor-container .ace_scroller {
   left: .7em !important;


### PR DESCRIPTION
L'idée est de pouvoir utiliser le bouton avec le crayon qui permet de modifier l'action sélectionnée avec l'action-builder, lors de la modification d'une page ET lors de la modification d'une fiche qui possède un textarea.wiki-textarea avec le bon nom.

J'ouvre une PR car il y a des besoins d'échanges préalables avant déploiement avec @acheype 
