### PR TITLE
Fix performer order action

### DIFF
--- a/includes/services/Performer.php
+++ b/includes/services/Performer.php
@@ -77,17 +77,23 @@ class Performer
                     $filePath = $dir . $file;
                     $object = &$this->objectList[$objectType][$objectName];
                     if (startsWith($file, '__')) {
-                        $object['before_callbacks'][] = [
+                        if (!isset($object['before_callbacks'])) {
+                            $object['before_callbacks'] = [] ;
+                        }
+                        array_unshift($object['before_callbacks'], [
                             'filePath' => $filePath,
                             'baseName' => $baseName,
                             'isDefinedAsClass' => $isDefinedAsClass
-                        ];
+                        ]);
                     } elseif (endsWith($file, '__.php')) {
-                        $object['after_callbacks'][] = [
+                        if (!isset($object['after_callbacks'])) {
+                            $object['after_callbacks'] = [] ;
+                        }
+                        array_unshift($object['after_callbacks'], [
                             'filePath' => $filePath,
                             'baseName' => $baseName,
                             'isDefinedAsClass' => $isDefinedAsClass
-                        ];
+                        ]);
                     } else {
                         $object = [
                             'filePath' => $filePath,

--- a/tools/attach/actions/__include.php
+++ b/tools/attach/actions/__include.php
@@ -5,4 +5,4 @@
 
     $oldpage = $this->GetPageTag();
     $this->tag = trim($this->GetParameter('page'));
-    $this->page = $this->LoadPage($this->tag);
+    $this->setPage($this->LoadPage($this->tag));

--- a/tools/templates/actions/__include.php
+++ b/tools/templates/actions/__include.php
@@ -10,11 +10,15 @@ $pageincluded = $this->GetParameter('page');
 
 // if metadata exists to change included page, we take the value of it
 if (isset($this->metadatas[$pageincluded])) {
+    $oldpageincluded = $pageincluded ;
     $pageincluded = $this->metadatas[$pageincluded];
     $this->parameter["page"] = $pageincluded;
-    // redo tools\attach\actions\__include.php without changing oldpage
-    $this->tag = trim($pageincluded);
-    $this->page = $this->LoadPage($this->tag);
+    // to prevent errors in actions order in Performer
+    if ($this->tag == trim($oldpageincluded)) { // case /attach/actions/___include before this
+        // redo tools\attach\actions\__include.php without changing oldpage
+        $this->tag = trim($pageincluded);
+        $this->page = $this->LoadPage($this->tag);
+    }
 }
 $clear = $this->GetParameter('clear');
 $class = $this->GetParameter('class');


### PR DESCRIPTION
Bon, j'ai l'impression que les refacto ont introduit un comportement différent dans l'ordre de traitement des actions, handlers, formatters.
AVANT :
`YesWiki->loadExtensions()`[L1888](https://github.com/YesWiki/yeswiki/blob/3fd6626c860180804c886b626404a6ac331ce4fc/includes/YesWiki.php#L1888)
 - charge la liste des extensions dans l'ordre alphabétique puis ajoute custom et actionsbuilder
 - balaye cette liste pour ajouter les chemins de fichiers en début du tableau config['action_path'], config['handler_path'], ce qui donne comme exemple
 ['/custom/handlers/','/tools/templates/handlers/','tools/bazar/handlers','/handlers']
 - ensuite lors de l'appel d'une action ou handler, il y a balayage de ce tableau dans l'ordre
 dans `YesWiki->IncludeBuffered()`[L891](https://github.com/YesWiki/yeswiki/blob/3fd6626c860180804c886b626404a6ac331ce4fc/includes/YesWiki.php#L891)
 
 Donc `\tools\bazar\handlers\page\__edit.php` est exécuté après `\custom\handlers\page\__edit.php` et `\tools\webhooks\handlers\page\__edit.php`
 
 MAINTENANT :
`YesWiki->loadExtensions()`[L1315](https://github.com/YesWiki/yeswiki/blob/88ebf4a9d9fc40e7c2b2cd9ee25cd0354b3e046b/includes/YesWiki.php#L1315)
 - charge la liste des extensions dans l'ordre alphabétique puis ajoute custom et actionsbuilder
 - mais ne balaye plus cette liste pour ajouter les chemins de fichiers en début du tableau, ce qui donne comme exemple
 ['/custom/handlers/','/tools/templates/handlers/','tools/bazar/handlers','/handlers']
 - c'est la classe [Performer](https://github.com/YesWiki/yeswiki/blob/88ebf4a9d9fc40e7c2b2cd9ee25cd0354b3e046b/includes/services/Performer.php#L50) qui lors de la construction, crée un tableau des actions, cette fois-ci dans l'ordre direct.
 sans utiliser le paramètre config['action_path'], config['handler_path'], ....
 
 Donc `\tools\bazar\handlers\__EditHandler.php` est exécuté avant `\custom\handlers\page\__edit.php` et avant `\tools\webhooks\handlers\page\__edit.php`
 
 Je propose cette PR pour rétablir le bon ordre.
et en plus ça répare webhooks pour edit et create