### PR TITLE
fix(EntryManager->search): do not return pages without id_fiche

### DIFF
--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -83,8 +83,13 @@ class EntryManager
         return $data;
     }
 
-    /**
-     *
+    /** getDataFromPage
+     * @param array $page , content of page from sql
+     * @param string $tag , tag of the entry
+     * @param bool $semantic
+     * @param bool $debug, to throw exception in case of error
+     * 
+     * @return array data formated
      */
     private function getDataFromPage($page, string $tag, bool $semantic = false, bool $debug = false): array
     {

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -291,7 +291,11 @@ class EntryManager
                 $json = $this->decode($page['body']);
                 // TODO call this function only when necessary
                 $this->appendDisplayData($json);
-                $GLOBALS['_BAZAR_'][$reqid][$json['id_fiche']] = $json;
+                if (!empty($json['id_fiche'])) {
+                    $GLOBALS['_BAZAR_'][$reqid][$json['id_fiche']] = $json;
+                } elseif ($this->wiki->UserIsAdmin() && $this->wiki->GetConfigValue('debug') == 'yes') {
+                    throw new Exception('empty \'id_fiche\' for page '.json_encode($page));
+                }
             }
         }
         return $GLOBALS['_BAZAR_'][$reqid];

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -77,42 +77,41 @@ class EntryManager
         }
 
         $page = $this->pageManager->getOne($tag, $time || null, $cache, $bypassAcls);
-        $adminDebug = ($this->wiki->UserIsAdmin() && $this->wiki->GetConfigValue('debug') == 'yes');
-        $data = $this->getDataFromPage($page, $tag, $semantic, $adminDebug);
+        $debug = ($this->wiki->GetConfigValue('debug') == 'yes');
+        $data = $this->getDataFromPage($page, $semantic, $debug);
 
         return $data;
     }
 
     /** getDataFromPage
      * @param array $page , content of page from sql
-     * @param string $tag , tag of the entry
      * @param bool $semantic
      * @param bool $debug, to throw exception in case of error
      * 
      * @return array data formated
      */
-    private function getDataFromPage($page, string $tag, bool $semantic = false, bool $debug = false): array
+    private function getDataFromPage($page, bool $semantic = false, bool $debug = false): array
     {
         if (!empty($page['body'])) {
             $data = $this->decode($page['body']);
 
             if ($debug) {
                 if (empty($data['id_fiche'])) {
-                    throw new Exception('empty \'id_fiche\' in body of page '.json_encode($page).'<br> edit it to create id_fiche');
+                    trigger_error('empty \'id_fiche\' in EntryManager::getDataFromPage in body of page \''. $page['tag'].'\'. Edit it to create id_fiche');
                 }
-                if (empty($tag)) {
-                    throw new Exception('empty \'tag\' ! ');
+                if (empty($page['tag'])) {
+                    trigger_error('empty $page[\'tag\'] in EntryManager::getDataFromPage! ');
                 }
             }
 
             // cas ou on ne trouve pas les valeurs id_fiche
             if (!isset($data['id_fiche'])) {
-                $data['id_fiche'] = $tag;
+                $data['id_fiche'] = $page['tag'];
             }
             // TODO call this function only when necessary
             $this->appendDisplayData($data, $semantic);
         } elseif ($debug) {
-            throw new Exception('empty \'body\' for page '.json_encode($page));
+            trigger_error('empty \'body\'  in EntryManager::getDataFromPage for page \''. $page['tag'] .'\'');
         }
 
         return $data;
@@ -315,9 +314,9 @@ class EntryManager
         if (!isset($GLOBALS['_BAZAR_'][$reqid])) {
             $GLOBALS['_BAZAR_'][$reqid] = array();
             $results = $this->dbService->loadAll($requete);
-            $adminDebug = ($this->wiki->UserIsAdmin() && $this->wiki->GetConfigValue('debug') == 'yes');
+            $debug = ($this->wiki->GetConfigValue('debug') == 'yes');
             foreach ($results as $page) {
-                $data = $this->getDataFromPage($page, $page['tag'] ??  null, false, $adminDebug);
+                $data = $this->getDataFromPage($page, false, $debug);
                 $GLOBALS['_BAZAR_'][$reqid][$data['id_fiche']] = $data;
             }
         }

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -451,7 +451,7 @@ class EntryManager
         }
 
         // replace id_fiche with $tag to prevent errors before getOne
-        $data['id_fiche'] = trim($tag);
+        $data['id_fiche'] = $tag;
         // if there are some restricted fields, load the previous data by bypassing the rights
         $previousData = $this->getOne($data['id_fiche'], false, null, false, true);
         $data['id_typeannonce'] = $previousData['id_typeannonce'];

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -288,13 +288,17 @@ class EntryManager
             $GLOBALS['_BAZAR_'][$reqid] = array();
             $results = $this->dbService->loadAll($requete);
             foreach ($results as $page) {
-                $json = $this->decode($page['body']);
-                // TODO call this function only when necessary
-                $this->appendDisplayData($json);
-                if (!empty($json['id_fiche'])) {
-                    $GLOBALS['_BAZAR_'][$reqid][$json['id_fiche']] = $json;
+                if (!empty($page['body'])) {
+                    $json = $this->decode($page['body']);
+                    if (!empty($json['id_fiche'])) {
+                        // TODO call this function only when necessary
+                        $this->appendDisplayData($json);
+                        $GLOBALS['_BAZAR_'][$reqid][$json['id_fiche']] = $json;
+                    } elseif ($this->wiki->UserIsAdmin() && $this->wiki->GetConfigValue('debug') == 'yes') {
+                        throw new Exception('empty \'id_fiche\' for page '.json_encode($page));
+                    }
                 } elseif ($this->wiki->UserIsAdmin() && $this->wiki->GetConfigValue('debug') == 'yes') {
-                    throw new Exception('empty \'id_fiche\' for page '.json_encode($page));
+                    throw new Exception('empty \'body\' for page '.json_encode($page));
                 }
             }
         }

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -87,7 +87,7 @@ class EntryManager
      * @param array $page , content of page from sql
      * @param bool $semantic
      * @param bool $debug, to throw exception in case of error
-     * 
+     *
      * @return array data formated
      */
     private function getDataFromPage($page, bool $semantic = false, bool $debug = false): array
@@ -97,10 +97,11 @@ class EntryManager
 
             if ($debug) {
                 if (empty($data['id_fiche'])) {
-                    trigger_error('empty \'id_fiche\' in EntryManager::getDataFromPage in body of page \''. $page['tag'].'\'. Edit it to create id_fiche');
+                    trigger_error('empty \'id_fiche\' in EntryManager::getDataFromPage in body of page \''
+                        . $page['tag'].'\'. Edit it to create id_fiche', E_USER_WARNING);
                 }
                 if (empty($page['tag'])) {
-                    trigger_error('empty $page[\'tag\'] in EntryManager::getDataFromPage! ');
+                    trigger_error('empty $page[\'tag\'] in EntryManager::getDataFromPage! ', E_USER_WARNING);
                 }
             }
 
@@ -111,7 +112,7 @@ class EntryManager
             // TODO call this function only when necessary
             $this->appendDisplayData($data, $semantic);
         } elseif ($debug) {
-            trigger_error('empty \'body\'  in EntryManager::getDataFromPage for page \''. $page['tag'] .'\'');
+            trigger_error('empty \'body\'  in EntryManager::getDataFromPage for page \''. $page['tag'] .'\'', E_USER_WARNING);
         }
 
         return $data;

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -294,7 +294,7 @@ class EntryManager
 
                     if ($debugAdmin) {
                         if (empty($json['id_fiche'])) {
-                            throw new Exception('empty \'id_fiche\' in body of page '.json_encode($page));
+                            throw new Exception('empty \'id_fiche\' in body of page '.json_encode($page).'<br> edit it to create id_fiche');
                         }
                         if (empty($page['tag'])) {
                             throw new Exception('empty \'tag\' of page '.json_encode($page));


### PR DESCRIPTION
@mrflos (ou @acheype ) est-ce que vous seriez OK pour cette proposition pour éviter de rendre des fiches sans id_fiche (et en mettant un mécanisme simple pour les admins pour retrouver les intrus?)