### PR TITLE
Ajout de l'option nofullimagelink dans composant

### DIFF
--- a/docs/actions/attach.yaml
+++ b/docs/actions/attach.yaml
@@ -24,6 +24,12 @@ actions:
         type: text
         showif:
           file: \.(png|jpg|jpeg|gif)$
+      nofullimagelink:
+        label: Rendre l'image non clicable
+        type: list
+        options:
+          1: oui, désactiver le clic
+          0: non, permettre le clic
       size:
         label: Taille de l'image
         type: list

--- a/docs/actions/attach.yaml
+++ b/docs/actions/attach.yaml
@@ -25,11 +25,11 @@ actions:
         showif:
           file: \.(png|jpg|jpeg|gif)$
       nofullimagelink:
-        label: Rendre l'image non clicable
+        label: Permettre de cliquer sur l'image pour l'afficher en grand
         type: list
         options:
-          1: oui, désactiver le clic
-          0: non, permettre le clic
+          0: Oui
+          1: Non
       size:
         label: Taille de l'image
         type: list


### PR DESCRIPTION
Si vous pouvez relire je suis pas contre, ça fonctionne sur mon wiki en local, mais c'est peut-être un coup de chance ^^

## Description of pull request / Description de la demande d'ajout
Permet de sélectionner les option de paramètre fullimagelink dans le composant Attach.
