### PR TITLE
Fix api links in form table

### DIFF
--- a/tools/bazar/controllers/ApiController.php
+++ b/tools/bazar/controllers/ApiController.php
@@ -41,11 +41,10 @@ class ApiController extends YesWikiController
     }
 
     /**
-     * @Route("/api/forms/{formId}/entries/{output}/{selectedEntries}", methods={"GET"})
+     * @Route("/api/forms/{formId}/entries/{output}/{selectedEntries}", methods={"GET"},options={"acl":{"public"}})
      */
     public function getAllFormEntries($formId, $output = null, $selectedEntries = null)
     {
-
         $entries = $this->getService(EntryManager::class)->search([
             'formsIds' => $formId,
             'queries' => !empty($selectedEntries) ? ['id_fiche' => $selectedEntries] : [],
@@ -67,7 +66,6 @@ class ApiController extends YesWikiController
      */
     public function getAllEntries($output = null, $selectedEntries = null)
     {
-
         $entries = $this->getService(EntryManager::class)->search([
             'queries' => !empty($selectedEntries) ? ['id_fiche' => $selectedEntries] : [],
         ]);
@@ -88,7 +86,8 @@ class ApiController extends YesWikiController
         // Put data inside LDP container
         $form = $this->getService(FormManager::class)->getOne($formId);
 
-        return new ApiResponse([
+        return new ApiResponse(
+            [
             '@context' => (array)json_decode($form['bn_sem_context']) ?: $form['bn_sem_context'],
             '@id' => $this->wiki->Href('fiche/' . $formId, 'api'),
             '@type' => ['ldp:Container', 'ldp:BasicContainer'],

--- a/tools/bazar/controllers/ApiController.php
+++ b/tools/bazar/controllers/ApiController.php
@@ -48,7 +48,7 @@ class ApiController extends YesWikiController
         $entries = $this->getService(EntryManager::class)->search([
             'formsIds' => $formId,
             'queries' => !empty($selectedEntries) ? ['id_fiche' => $selectedEntries] : [],
-        ]);
+        ], true);
 
         if ($output == 'json-ld' || strpos($_SERVER['HTTP_ACCEPT'], 'application/ld+json') !== false) {
             return $this->getAllSemanticEntries($formId, $entries);

--- a/tools/bazar/controllers/ApiController.php
+++ b/tools/bazar/controllers/ApiController.php
@@ -48,7 +48,7 @@ class ApiController extends YesWikiController
         $entries = $this->getService(EntryManager::class)->search([
             'formsIds' => $formId,
             'queries' => !empty($selectedEntries) ? ['id_fiche' => $selectedEntries] : [],
-        ], true);
+        ], true, true);
 
         if ($output == 'json-ld' || strpos($_SERVER['HTTP_ACCEPT'], 'application/ld+json') !== false) {
             return $this->getAllSemanticEntries($formId, $entries);

--- a/tools/bazar/controllers/ApiController.php
+++ b/tools/bazar/controllers/ApiController.php
@@ -10,7 +10,6 @@ use YesWiki\Bazar\Service\EntryManager;
 use YesWiki\Bazar\Service\FormManager;
 use YesWiki\Bazar\Service\SemanticTransformer;
 use YesWiki\Core\ApiResponse;
-use YesWiki\Core\Service\AclService;
 use YesWiki\Core\Service\TripleStore;
 use YesWiki\Core\YesWikiController;
 
@@ -50,20 +49,6 @@ class ApiController extends YesWikiController
             'formsIds' => $formId,
             'queries' => !empty($selectedEntries) ? ['id_fiche' => $selectedEntries] : [],
         ]);
-
-        // filter only readable entries
-        $entries = array_filter($entries, function ($entry) {
-            return $this->getService(AclService::class)->hasAccess('read', $entry['id_fiche']);
-        });
-
-        // for not admins use Guard
-        if (!$this->wiki->UserIsAdmin()) {
-            // TODO guard usage in EntryManager->search()
-            $entryManager = $this->getService(EntryManager::class);
-            $entries = array_map(function ($entry) use ($entryManager) {
-                return $entryManager->getOne($entry['id_fiche']);
-            }, $entries);
-        }
 
         if ($output == 'json-ld' || strpos($_SERVER['HTTP_ACCEPT'], 'application/ld+json') !== false) {
             return $this->getAllSemanticEntries($formId, $entries);

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -121,9 +121,10 @@ class EntryManager
     /**
      * Return an array of fiches based on search parameters
      * @param array $params
+     * @param bool $useGuard
      * @return mixed
      */
-    public function search($params = []): array
+    public function search($params = [], bool $useGuard = false): array
     {
         // Merge les paramètres passé avec des paramètres par défaut
         $params = array_merge(
@@ -321,7 +322,11 @@ class EntryManager
             $results = $this->dbService->loadAll($requete);
             $debug = ($this->wiki->GetConfigValue('debug') == 'yes');
             foreach ($results as $page) {
-                $data = $this->getDataFromPage($page, false, $debug);
+                // not possible to init the Guard in the constructor because of circular reference problem
+                $filteredPage = (!$this->wiki->UserIsAdmin() && $useGuard)
+                    ? $this->wiki->services->get(Guard::class)->checkAcls($page, $page['tag'])
+                    : $page;
+                $data = $this->getDataFromPage($filteredPage, false, $debug);
                 $GLOBALS['_BAZAR_'][$reqid][$data['id_fiche']] = $data;
             }
         }

--- a/tools/bazar/services/Guard.php
+++ b/tools/bazar/services/Guard.php
@@ -82,7 +82,8 @@ class Guard
                         if ($field instanceof EmailField
                                 && $field->getShowContactForm() == 'form'
                                 && ($this->wiki->getMethod() == 'raw'
-                                || $this->wiki->getMethod() == 'json')
+                                || $this->wiki->getMethod() == 'json'
+                                || $this->wiki->GetPageTag() == 'api')
                                 ) {
                             $fieldname[] = $field->getPropertyName();
                         }

--- a/tools/bazar/templates/forms/forms_table.twig
+++ b/tools/bazar/templates/forms/forms_table.twig
@@ -44,11 +44,11 @@
             <a class="btn btn-default btn-xs" title="{{ _t('BAZ_CSV') }}" href="{{ url({ params: { 'vue': 'exporter', 'id': key }}) }}" data-toggle="tooltip" data-placement="bottom">
               CSV
             </a>
-            <a class="btn btn-default btn-mini btn-xs" target="_blank" title="{{ _t('BAZ_JSON') }}" href="{{ url({ tag: 'api/fiche/' ~ key }) }}" data-toggle="tooltip" data-placement="bottom">
+            <a class="btn btn-default btn-mini btn-xs" target="_blank" title="{{ _t('BAZ_JSON') }}" href="{{ url({ tag: 'api',handler:'forms/' ~ key ~'/entries'}) }}" data-toggle="tooltip" data-placement="bottom">
               JSON
             </a>
             {% if form.isSemantic %}
-              <a class="btn btn-default btn-mini btn-xs" target="_blank" title="{{ _t('BAZ_JSON_LD') }}" href="{{ url({ tag: 'api/fiche/' ~ key ~ '/json-ld' }) }}" data-toggle="tooltip" data-placement="bottom">
+              <a class="btn btn-default btn-mini btn-xs" target="_blank" title="{{ _t('BAZ_JSON_LD') }}" href="{{ url({ tag: 'api',handler:'forms/' ~ key ~'/entries/json-ld'}) }}" data-toggle="tooltip" data-placement="bottom">
                 JSON-LD
               </a>
             {% endif %}


### PR DESCRIPTION
Pour répondre à #708
je propose cette ouverture de l'api avec une vérification des droits de lecture et usage du Guard pour éviter les fuites d'e-mails.

OK pour toi @mrflos  ?

Cette PR implique:
- ouverture de la `route /api/forms/{formId}/entries/{output}/{selectedEntries}` en mode public même sans bearer et sans check acl
- transmission uniquement des fiches dont l'utilisateur a les droits en lecture (alors qu'avant c'est toutes les fiches) (un admin voit tout)
- pour un non-admin, utilisation du Guard pour ne transmettre que les informations autorisées (au passage ceci s'applique maintenant sur toutes les routes api qui utilisent `PageManager->getOne` ou `EntryManager->getOne`