### PR TITLE
fix(File/ImageFiled): do not unlink files if not owner

### DIFF
--- a/tools/bazar/fields/FileField.php
+++ b/tools/bazar/fields/FileField.php
@@ -23,25 +23,26 @@ class FileField extends BazarField
 
         if (isset($value) && $value != '') {
             if (isset($_GET['delete_file']) && $_GET['delete_file'] == $value) {
-                if ($this->getService(Guard::class)->isAllowed('supp_fiche', (isset($entry['owner']) ? $entry['owner'] : ''))) {
+                if ($this->isAllowedToDeleteFile($entry)) {
                     if (file_exists(BAZ_CHEMIN_UPLOAD . $value)) {
                         unlink(BAZ_CHEMIN_UPLOAD . $value);
                     }
                 } else {
-                    return '<div class="alert alert-info">' . _t('BAZ_DROIT_INSUFFISANT') . '</div>' . "\n";
+                    $alertMessage = '<div class="alert alert-info">' . _t('BAZ_DROIT_INSUFFISANT') . '</div>' . "\n";
                 }
             }
 
             if (file_exists(BAZ_CHEMIN_UPLOAD . $value)) {
-                return $this->render('@bazar/inputs/file.twig', [
+                return ($alertMessage ?? '') .$this->render('@bazar/inputs/file.twig', [
                     'value' => $value,
                     'fileUrl' => BAZ_CHEMIN_UPLOAD . $value,
-                    'deleteUrl' => $GLOBALS['wiki']->href('edit', $GLOBALS['wiki']->GetPageTag(), 'delete_file=' . $value, false)
+                    'deleteUrl' => $GLOBALS['wiki']->href('edit', $GLOBALS['wiki']->GetPageTag(), 'delete_file=' . $value, false),
+                    'isAllowedToDeleteFile' => $this->isAllowedToDeleteFile($entry)
                 ]);
             }
         }
 
-        return $this->render('@bazar/inputs/file.twig');
+        return ($alertMessage ?? '') . $this->render('@bazar/inputs/file.twig');
     }
 
     public function formatValuesBeforeSave($entry)
@@ -87,5 +88,15 @@ class FileField extends BazarField
         }
 
         return null;
+    }
+
+    /**
+     * check if user is allowed to delete file
+     * @param array $entry
+     * @return bool
+     */
+    protected function isAllowedToDeleteFile(array $entry):bool
+    {
+        return $this->getService(Guard::class)->isAllowed('supp_fiche', $entry['owner'] ?? '');
     }
 }

--- a/tools/bazar/services/Guard.php
+++ b/tools/bazar/services/Guard.php
@@ -37,6 +37,8 @@ class Guard
 
         switch ($action) {
             case 'supp_fiche':
+                // it should not be possible to delete a file if not connected even if no owner (prevent spam)
+                return $ownerId != '' && $isOwner;
             case 'voir_champ':
                 return $isOwner;
 

--- a/tools/bazar/templates/inputs/file.twig
+++ b/tools/bazar/templates/inputs/file.twig
@@ -4,8 +4,19 @@
     <div class="input-group">
         {% if value %}
             <a href="{{ fileUrl }}" target="_blank">{{ value }}</a>
-            &nbsp;-&nbsp;
-            <a href="{{ deleteUrl }}" onClick="javascript:return confirm('{{ _t('BAZ_CONFIRMATION_SUPPRESSION_FICHIER') }}');">{{ _t('BAZ_SUPPRIMER') }}</a>
+            &nbsp;-&nbsp;            
+            {% if isAllowedToDeleteFile %}
+                <a href="{{ deleteUrl }}" 
+                    onClick="javascript:return confirm('{{ _t('BAZ_CONFIRMATION_SUPPRESSION_FICHIER') }}');">
+                    {{- _t('BAZ_SUPPRIMER') -}}
+                </a>            
+            {% else %}            
+                <button class="btn btn-sm btn-danger" disabled="disabled"
+                    data-toggle="tooltip" data-placement="bottom" title="{{ _t('BAZ_DROIT_INSUFFISANT') }}">
+                    <i class="fa fa-trash"></i>
+                    {{ _t('BAZ_SUPPRIMER') }}
+                </button>
+            {% endif %}
             <br />
             <input
                 type="hidden"

--- a/tools/bazar/templates/inputs/image.twig
+++ b/tools/bazar/templates/inputs/image.twig
@@ -15,10 +15,18 @@
                     accept=".jpeg, .jpg, .gif, .png"
                 >
             </label>
-            <a class="btn btn-sm btn-block btn-danger" href="{{ deleteUrl }}" onclick="javascript:return confirm('{{ _t('BAZ_CONFIRMATION_SUPPRESSION_IMAGE') }}');">
-                <i class="fa fa-trash"></i>
-                {{ _t('BAZ_SUPPRIMER_IMAGE') }}
-            </a>
+            {% if isAllowedToDeleteFile %}
+                <a class="btn btn-sm btn-block btn-danger" href="{{ deleteUrl }}" onclick="javascript:return confirm('{{ _t('BAZ_CONFIRMATION_SUPPRESSION_IMAGE') }}');">
+                    <i class="fa fa-trash"></i>
+                    {{ _t('BAZ_SUPPRIMER_IMAGE') }}
+                </a>
+            {% else %}            
+                <button class="btn btn-sm btn-block btn-danger" disabled="disabled"
+                    data-toggle="tooltip" data-placement="bottom" title="{{ _t('BAZ_DROIT_INSUFFISANT') }}">
+                    <i class="fa fa-trash"></i>
+                    {{ _t('BAZ_SUPPRIMER_IMAGE') }}
+                </button>
+            {% endif %}
         </div>
         <output id="img-{{ field.propertyName }}" class="col-xs-9">{{ image|raw }}</output>
         <input type="hidden" id="oldimage_{{ field.propertyName }}" name="oldimage_{{ field.propertyName }}" value="{{ value }}" />


### PR DESCRIPTION
Ceci est pour répondre à un souci de suppression des images associées aux fiches sans propriétaires.
AVANT : il est possible de supprimer l'image associée à une fiche sans propriétaire pour laquelle l'édition du champ ImageField est ouverte à tous.
MAINTENANT : il faut être admin ou owner connecté de la fiche.

Effet collatéral,
1. il n'est pas possible de supprimer un fichier si on n'est pas connecté
2. lors de la modification d'une image par une personne non connectée, il n'y a pas suppression de l'image de cache et de l'ancienne image (alors que ce sera possible avec un admin ou owner).

Travaux:
- pas de refacto
- uniquement factorisation de la méthode isAllowedToDeleteFile dans FileField
- **modification du critère dans le Guard**
- quelques adaptations dans les twig pour rendre inopérant les boutons de suppressions quand l'utilisateur courant n'a pas le droit
- et quelques modifications dans FileField et ImageField pour que les messages d'info se placent au dessus du formulaire de modification de fichiers sans le remplacer (AVANT il n'y avait que le message d'alerte)