### PR TITLE
fix(robots.txt): init at creation of wiki

### DIFF
--- a/includes/YesWikiInit.php
+++ b/includes/YesWikiInit.php
@@ -204,7 +204,7 @@ class Init
             'default_read_acl' => '*',
             'default_comment_acl' => '@admins',
             'preview_before_save' => 0,
-            'allow_raw_html' => false,
+            'allow_raw_html' => true,
             'disable_wiki_links' => false,
             'timezone'=>'GMT' // Only used if not set in wakka.config.php nor in php.ini
         );

--- a/setup/default.php
+++ b/setup/default.php
@@ -278,7 +278,8 @@ if (!defined('WIKINI_VERSION')) {
                 <div class="checkbox">
                   <label>
                     <input type="hidden" name="config[rewrite_mode]" value="0" />
-                    <input type="checkbox" name="config[rewrite_mode]" value="1" <?php echo $wakkaConfig['rewrite_mode'] ? 'checked' : '' ?> >
+                    <input type="checkbox" name="config[rewrite_mode]" value="1" <?php
+                      echo ($wakkaConfig['rewrite_mode'] ?? true) ? 'checked' : '' ?> />
                     <span></span>
                     &nbsp;<?php echo _t('ACTIVATE_REDIRECTION_MODE'); ?>
                   </label>
@@ -287,7 +288,8 @@ if (!defined('WIKINI_VERSION')) {
 
                 <div class="checkbox">
                   <label>
-                    <input type="checkbox" name="config[allow_raw_html]" value="1" <?php echo $wakkaConfig['allow_raw_html'] ? '' : 'checked' ?> />
+                    <input type="checkbox" name="config[allow_raw_html]" value="1" <?php
+                      echo ($wakkaConfig['allow_raw_html'] ?? true) ? 'checked' : '' ?> />
                     <span></span>
                     &nbsp;<?php echo _t('AUTHORIZE_HTML_INSERTION'); ?>
                   </label>
@@ -296,7 +298,8 @@ if (!defined('WIKINI_VERSION')) {
 
                 <div class="checkbox">
                   <label>
-                    <input type="checkbox" name="allowRobots" value="1" <?php echo isset($wakkaConfig['allowRobots']) ? '' : 'checked' ?> />
+                    <input type="checkbox" name="config[allow_robots]" value="1" <?php
+                      echo ($wakkaConfig['allow_robots'] ?? true) ? 'checked' : '' ?> />
                     <span></span>
                     &nbsp;<?php echo _t('AUTHORIZE_INDEX_BY_ROBOTS'); ?>
                   </label>

--- a/setup/install.php
+++ b/setup/install.php
@@ -132,6 +132,51 @@ test(
     0
 );
 
+// Config indexation by robots
+if (!isset($config['allow_robots']) || $config['allow_robots'] != '1') {
+    // update robots.txt file
+    if (file_exists('robots.txt')) {
+        $robotFile = file_get_contents('robots.txt');
+        // Append User-agent
+        $strToAppend = 'User-agent: *';
+        $endLine = "\n";
+        if (strpos($strToAppend."\r\n", $robotFile) != false) {
+            $endLine = "\r\n";
+        }
+
+        $robotFile = str_replace(
+            $strToAppend.$endLine,
+            $strToAppend.$endLine.
+            'Disallow: /'.$endLine,
+            $robotFile
+        );
+    } else {
+        $robotFile .= "User-agent: *\r\n";
+        $robotFile .= "Disallow: /\r\n";
+    }
+    // save robots.txt file
+    file_put_contents('robots.txt', $robotFile);
+
+    // set meta
+    $config['meta'] = array_merge(
+        $config['meta'] ?? [],
+        ['robots' => 'noindex,nofollow,max-image-preview:none,noarchive,noimageindex']
+    );
+}
+
+
+if (isset($config['allow_robots'])) {
+    // do not save this config because not use by YesWiki
+    unset($config['allow_robots']);
+}
+
+// update some values
+foreach (['allow_raw_html','rewrite_mode'] as $name) {
+    if (isset($config[$name])) {
+        $config[$name] = (in_array($config[$name], ['1',true,'true'])) ? true : false;
+    }
+}
+
 ?>
 <br />
 <div class="alert alert-info"><?php echo _t('NEXT_STEP_WRITE_CONFIGURATION_FILE'); ?>


### PR DESCRIPTION
Pour répondre à #551 , je propose ces correctifs.
Je suis confiant dans ce que je propose.
Toutefois, je me dis, que @mrflos tu souhaites éventuellement suivre ce qui concerne les installations avant déploiement.
Qu'en dis-tu ?

Ce que ça fait:
1. améliorer le formulaire d'installation pour être plus stable pour les cases à cocher en fonction des paramètres par défaut (cohérence vrai/faux)
2. détecter si la case allow_robots est cochée.
3. si ça n'est pas le cas, mettre à jour robots.txt et définir le paramètre confg['meta']['robots']