### PR TITLE
Export geo json

### DIFF
--- a/tools/bazar/controllers/ApiController.php
+++ b/tools/bazar/controllers/ApiController.php
@@ -45,9 +45,6 @@ class ApiController extends YesWikiController
      */
     public function getAllFormEntries($formId, $output = null, $selectedEntries = null)
     {
-        /* start buffer for api */
-        ob_start();
-
         $entries = $this->getService(EntryManager::class)->search([
             'formsIds' => $formId,
             'queries' => $this->getService(EntryController::class)
@@ -64,20 +61,7 @@ class ApiController extends YesWikiController
         } elseif ($output == 'geojson') {
             $entries = $this->getService(GeoJSONFormatter::class)->formatToGeoJSON($entries);
         }
-        // error + fetch trigger_errors on message
-        $triggerErrorMessages = ob_get_contents() ;
-        ob_get_clean();
-        $code = (empty($triggerErrorMessages))
-            ? Response::HTTP_OK
-            : Response::HTTP_INTERNAL_SERVER_ERROR;
-
-        return new ApiResponse(
-            (!empty($triggerErrorMessages)
-            ? ['trigger_error_messages'=>$triggerErrorMessages]
-            :[])
-            +$entries,
-            $code
-        );
+        return new ApiResponse($entries);
     }
 
     /**

--- a/tools/bazar/controllers/FormController.php
+++ b/tools/bazar/controllers/FormController.php
@@ -2,6 +2,7 @@
 
 namespace YesWiki\Bazar\Controller;
 
+use YesWiki\Bazar\Field\MapField;
 use YesWiki\Bazar\Service\FormManager;
 use YesWiki\Bazar\Service\Guard;
 use YesWiki\Core\YesWikiController;
@@ -46,6 +47,9 @@ class FormController extends YesWikiController
                 $values[$form['bn_id_nature']]['canEdit'] = $this->getService(Guard::class)->isAllowed('saisie_formulaire');
                 $values[$form['bn_id_nature']]['canDelete'] = $this->wiki->UserIsAdmin();
                 $values[$form['bn_id_nature']]['isSemantic'] = isset($form['bn_sem_type']) && $form['bn_sem_type'] !== "";
+                $values[$form['bn_id_nature']]['isGeo'] = !empty(array_filter($form['prepared'], function ($field) {
+                    return ($field instanceof MapField);
+                }));
             }
         }
 

--- a/tools/bazar/controllers/GeoJSONFormatter.php
+++ b/tools/bazar/controllers/GeoJSONFormatter.php
@@ -29,8 +29,10 @@ class GeoJSONFormatter extends YesWikiController
             if (empty($geo)) {
                 return [];
             } else {
-                $entry = array_merge($entry, $geo);
-                return $entry;
+                return [
+                    'entry' => $entry,
+                    'geo' => $geo
+                    ];
             }
         }, $entries), function ($entry) {
             return !empty($entry) ;
@@ -40,12 +42,13 @@ class GeoJSONFormatter extends YesWikiController
         if (!empty($entriesWithGeo)) {
             $data['type'] = 'FeatureCollection';
             $data['features'] = [];
-            foreach ($entriesWithGeo as $id => $entry) {
+            foreach ($entriesWithGeo as $id => $extendedEntry) {
+                $entry = $extendedEntry['entry'];
                 $data['features'][] = [
                     'type' => 'Feature',
                     'geometry' => [
                         'type' => 'Point',
-                        'coordinates' => [$entry['longitude'],$entry['latitude']]
+                        'coordinates' => [$extendedEntry['geo']['longitude'],$extendedEntry['geo']['latitude']]
                     ],
                     'id' => $entry['id_fiche'],
                     'title' => $entry['bf_titre'],

--- a/tools/bazar/controllers/GeoJSONFormatter.php
+++ b/tools/bazar/controllers/GeoJSONFormatter.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace YesWiki\Bazar\Controller;
+
+use YesWiki\Core\YesWikiController;
+use YesWiki\Bazar\Field\MapField;
+use YesWiki\Bazar\Service\FormManager;
+
+class GeoJSONFormatter extends YesWikiController
+{
+    protected $formManager;
+
+    public function __construct(
+        FormManager $formManager
+    ) {
+        $this->formManager = $formManager;
+    }
+
+    /**
+     * get data grom entries in GeoJSON format
+     * @param array $entries
+     * @return array data
+     */
+    public function formatToGeoJSON(array $entries): array
+    {
+        $cache = [];
+        $entriesWithGeo = array_filter(array_map(function ($entry) use ($cache) {
+            $geo = $this->getGeoData($entry, $cache);
+            if (empty($geo)) {
+                return [];
+            } else {
+                $entry = array_merge($entry, $geo);
+                return $entry;
+            }
+        }, $entries), function ($entry) {
+            return !empty($entry) ;
+        });
+
+        $data = [];
+        if (!empty($entriesWithGeo)) {
+            $data['type'] = 'FeatureCollection';
+            $data['features'] = [];
+            foreach ($entriesWithGeo as $id => $entry) {
+                $data['features'][] = [
+                    'type' => 'Feature',
+                    'geometry' => [
+                        'type' => 'Point',
+                        'coordinates' => [$entry['longitude'],$entry['latitude']]
+                    ],
+                    'id' => $entry['id_fiche'],
+                    'title' => $entry['bf_titre'],
+                    'properties' => $entry,
+                ];
+            }
+        }
+
+        return $data;
+    }
+
+    
+    /**
+     * extract geoData
+     * @param array $entry
+     * @param array &$cache
+     * @return array ['latitude'=>000,'longitude'=>00] or []
+     */
+    private function getGeoData(array $entry, array &$cache):array
+    {
+        if (!empty($entry['id_typeannonce']) && $entry['id_typeannonce'] == intval($entry['id_typeannonce'])) {
+            $propertyName = $this->getFirstMapFieldPropertyName($entry['id_typeannonce'], $cache);
+        }
+        if (!empty($entry[$propertyName])
+                && !empty($entry[$propertyName]['bf_latitude'])
+                && !empty($entry[$propertyName]['bf_longitude'])) {
+            $latitude = $entry[$propertyName]['bf_latitude'];
+            $longitude = $entry[$propertyName]['bf_longitude'];
+        } elseif (!empty($entry['bf_latitude']) && !empty($entry['bf_longitude'])) {
+            $latitude = $entry['bf_latitude'];
+            $longitude = $entry['bf_longitude'];
+        } elseif (!empty($entry['carte_google'])
+                && !empty(explode('|', $entry['carte_google'])[0])
+                && !empty(explode('|', $entry['carte_google'])[1])) {
+            $geo = explode('|', $entry['carte_google']);
+            $latitude = $geo[0];
+            $longitude = $geo[1];
+        } else {
+            return [];
+        }
+
+        return [
+            'latitude' => $latitude,
+            'longitude' => $longitude,
+        ];
+    }
+
+    /**
+     * get first field propertyName corresponding to a MapField in a form
+     * @param int $formId
+     * @param array &$cache cache of correspondance of propertynames and forms id
+     * @return string|null $propertyName
+     */
+    private function getFirstMapFieldPropertyName(int $formId, array &$cache):?string
+    {
+        if (!isset($cache[$formId])) {
+            $form = $this->formManager->getOne($formId);
+            $cache[$formId] = null;
+            if (!empty($form['prepared'])) {
+                $found = false;
+                foreach ($form['prepared'] as $field) {
+                    if (!$found && $field instanceof MapField) {
+                        $cache[$formId] = $field->getPropertyName();
+                        $found = true;
+                    }
+                }
+            }
+        }
+        return $cache[$formId];
+    }
+}

--- a/tools/bazar/lang/bazar_fr.inc.php
+++ b/tools/bazar/lang/bazar_fr.inc.php
@@ -66,6 +66,7 @@ $GLOBALS['translations'] = array_merge(
         'BAZ_CSV' => 'CSV',
         'BAZ_JSON' => 'JSON',
         'BAZ_JSON_LD' => 'JSON-LD (Sémantique)',
+        'BAZ_GEOJSON' => 'GeoJSON',
         'BAZ_ACTIONS_FICHES' => 'Fiches',
         'BAZ_LOADING' => 'Chargement',
         'BAZ_IMPORT_SELECTION' => 'Importer la sélection',

--- a/tools/bazar/templates/forms/forms_table.twig
+++ b/tools/bazar/templates/forms/forms_table.twig
@@ -52,6 +52,11 @@
                 JSON-LD
               </a>
             {% endif %}
+            {% if form.isGeo %}
+              <a class="btn btn-default btn-mini btn-xs" target="_blank" title="{{ _t('BAZ_GEOJSON') }}" href="{{ url({ tag: 'api',handler:'forms/' ~ key ~'/entries/geojson'}) }}" data-toggle="tooltip" data-placement="bottom">
+                GeoJSON
+              </a>
+            {% endif %}
             <a class="btn btn-default btn-mini btn-xs" title="{{ _t('BAZ_WIDGET') }}" href="{{ url({ handler: 'widget', params: { id: key }}) }}" data-toggle="tooltip" data-placement="bottom">
               {{ _t('BAZ_WIDGET') }}
             </a>


### PR DESCRIPTION
Pull-request pour permettre l'export des fiches d'un formulaire au format GeoJSON via l'api.

**Ce que ça fait**:
- gestion d'un nouveau format de données 'geojson' pour la route api `?api/forms/1/entries/geojson`
- refactor de la méthode `BazaR/ApiController->getAllEntries` pour utiliser directement le code de `BazaR/ApiController->getAllFormEntries`
- mise à jour de la documentation api associée
- ajout d'un bouton dans la table des formulaires de la page BazaR pour avoir un lien direct vers cette api pour les formulaires avec un MapField
- création d'un contrôleur secondaire Bazar/GeoJSONFormatter