### PR TITLE
Improve diff handler may21

### DIFF
--- a/handlers/page/diff.php
+++ b/handlers/page/diff.php
@@ -111,9 +111,21 @@ if ($this->HasAccess("read")) {
         $pageA = $this->LoadPageById($_REQUEST["b"]);
         $pageB = $this->LoadPageById($_REQUEST["a"]);
 
-        // extract text from bodies
-        $textA = _convert($pageA["body"], "ISO-8859-15");
-        $textB = _convert($pageB["body"], "ISO-8859-15");
+        $tag = $this->getPageTag();
+        $isEntry = !empty($tag) && $this->services
+            ->get(YesWiki\Bazar\Service\EntryManager::class)
+            ->isEntry($tag);
+        if ($isEntry) {
+            $entryController = $this->services
+                ->get(YesWiki\Bazar\Controller\EntryController::class);
+            // extract text from bodies
+            $textA = '""'.$entryController->view($tag, $pageA['time'], false).'""';
+            $textB = '""'.$entryController->view($tag, $pageB['time'], false).'""';
+        } else {
+            // extract text from bodies
+            $textA = _convert($pageA["body"], "ISO-8859-15");
+            $textB = _convert($pageB["body"], "ISO-8859-15");
+        }
 
         $sideA = new Side($textA);
         $sideB = new Side($textB);
@@ -176,19 +188,19 @@ if ($this->HasAccess("read")) {
 
                 if (($letter=='d') || ($letter=='c')) {
                     $sideA->copy_whitespace($output);
-                    $output .="@@";
+                    $output .= ($isEntry) ? '<span class="del">' : "@@";
                     $sideA->copy_word($output);
                     $sideA->copy_until_ordinal($argument[1], $output);
-                    $output .="@@";
+                    $output .=($isEntry) ? '</span>' :"@@";
                 }
 
                 // inserted word
                 if ($letter == 'a' || $letter == 'c') {
                     $sideB->copy_whitespace($output);
-                    $output .="££";
+                    $output .=($isEntry) ? '<span class="add">' :"££";
                     $sideB->copy_word($output);
                     $sideB->copy_until_ordinal($argument[3], $output);
-                    $output .="££";
+                    $output .=($isEntry) ? '</span>' :"££";
                 }
             }
         }

--- a/includes/diff/diff.class.php
+++ b/includes/diff/diff.class.php
@@ -412,7 +412,7 @@ class _DiffEngine
         $i = 0;
         $j = 0;
 
-        assert('sizeof($lines) == sizeof($changed)');
+        assert(sizeof($lines) == sizeof($changed));
         $len = sizeof($lines);
         $other_len = sizeof($other_changed);
 
@@ -433,7 +433,7 @@ class _DiffEngine
             }
 
             while ($i < $len && !$changed[$i]) {
-                assert('$j < $other_len && ! $other_changed[$j]');
+                assert($j < $other_len && ! $other_changed[$j]);
                 $i++;
                 $j++;
                 while ($j < $other_len && $other_changed[$j]) {
@@ -470,11 +470,11 @@ class _DiffEngine
                     while ($start > 0 && $changed[$start -1]) {
                         $start--;
                     }
-                    assert('$j > 0');
+                    assert($j > 0);
                     while ($other_changed[-- $j]) {
                         continue;
                     }
-                    assert('$j >= 0 && !$other_changed[$j]');
+                    assert($j >= 0 && !$other_changed[$j]);
                 }
 
                 /*
@@ -498,7 +498,7 @@ class _DiffEngine
                         $i++;
                     }
 
-                    assert('$j < $other_len && ! $other_changed[$j]');
+                    assert($j < $other_len && ! $other_changed[$j]);
                     $j++;
                     if ($j < $other_len && $other_changed[$j]) {
                         $corresponding = $i;
@@ -516,11 +516,11 @@ class _DiffEngine
             while ($corresponding < $i) {
                 $changed[-- $start] = 1;
                 $changed[-- $i] = 0;
-                assert('$j > 0');
+                assert($j > 0);
                 while ($other_changed[-- $j]) {
                     continue;
                 }
-                assert('$j >= 0 && !$other_changed[$j]');
+                assert($j >= 0 && !$other_changed[$j]);
             }
         }
     }

--- a/includes/diff/side.class.php
+++ b/includes/diff/side.class.php
@@ -13,7 +13,7 @@ class Side
     public $argument;
     public $length;
 
-    public function Side($content)
+    public function __construct($content)
     {
         $this->content = $content;
         $this->position = 0;

--- a/includes/services/PageManager.php
+++ b/includes/services/PageManager.php
@@ -103,7 +103,15 @@ class PageManager
 
     public function getById($id): ?array
     {
-        return $this->dbService->loadSingle('select * from' . $this->dbService->prefixTable('pages') . "where id = '" . $this->dbService->escape($id) . "' limit 1");
+        $page = $this->dbService->loadSingle('select * from' . $this->dbService->prefixTable('pages') . "where id = '" . $this->dbService->escape($id) . "' limit 1");
+        $tag = $page['tag'] ?? null;
+        // not possible to init the EntryManager in the constructor because of circular reference problem
+        if (!empty($tag) && $this->wiki->services->get(EntryManager::class)->isEntry($tag)) {
+            // not possible to init the Guard in the constructor because of circular reference problem
+            $page = $this->wiki->services->get(Guard::class)->checkAcls($page, $tag);
+        }
+
+        return $page;
     }
 
     public function getRevisions($page)

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -76,7 +76,7 @@ class EntryManager
             return null;
         }
 
-        $page = $this->pageManager->getOne($tag, $time || null, $cache, $bypassAcls);
+        $page = $this->pageManager->getOne($tag, $time, $cache, $bypassAcls);
         $debug = ($this->wiki->GetConfigValue('debug') == 'yes');
         $data = $this->getDataFromPage($page, $semantic, $debug);
 

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -76,7 +76,7 @@ class EntryManager
             return null;
         }
 
-        $page = $this->pageManager->getOne($tag, $time, $cache, $bypassAcls);
+        $page = $this->pageManager->getOne($tag, empty($time) ? null : $time, $cache, $bypassAcls);
         $debug = ($this->wiki->GetConfigValue('debug') == 'yes');
         $data = $this->getDataFromPage($page, $semantic, $debug);
 

--- a/tools/bazar/services/Guard.php
+++ b/tools/bazar/services/Guard.php
@@ -84,6 +84,7 @@ class Guard
                         if ($field instanceof EmailField
                                 && $field->getShowContactForm() == 'form'
                                 && ($this->wiki->getMethod() == 'raw'
+                                || $this->wiki->getMethod() == 'diff'
                                 || $this->wiki->getMethod() == 'json'
                                 || $this->wiki->GetPageTag() == 'api')
                                 ) {


### PR DESCRIPTION
J'ai identifié que le handler /diff permet une fuite des informations car il ne sollicite pas le Guard pour les fiches bazar.
Je propose ce correctif dans ce ses.

**Ce que ça fait**:
- corriger EntryManager pour afficher sans erreur les fiches bazar avec le paramètre `$time`
- petits correctifs dans diff.class et side.class pour retirer les notations dépréciées avec les dernières versions de PHP
- modification de **PageManager->getById**  pour utiliser le Guard pour les fiches bazar
- modification de Guard pour filtrer les adresses e-mails pour le handler diff
- et, _mais ceci est plus un ajout_, modification de l'affichage des différences pour les fiches pour que ce soit plus facile à lire (car le contenu brut de la page, c'est rude)

**Ce que ça ne fait pas**:
- pas de refacto du code en question
- pas d'optimisation du code en question