### PR TITLE
Improve listefiche ext json

### DIFF
--- a/lang/yeswiki_en.php
+++ b/lang/yeswiki_en.php
@@ -437,5 +437,6 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations']??[], array(
 'EDIT_CONFIG_HINT_password_for_editing' => 'Asked password to modify forms (empty = no restriction)',
 'EDIT_CONFIG_HINT_password_for_editing_message' => 'Message displayed above the password asked password to modify forms',
 'EDIT_CONFIG_HINT_actionbuilder_textarea_name' => 'Textarea field\'s name for which components are activated',
+'EDIT_CONFIG_HINT_baz_enum_field_time_cache_for_json' => 'Time (s) between two cache\'s refreshes for JSON\'s requests in listefiche',
     
 ));

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -470,5 +470,6 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations']??[], array(
 'EDIT_CONFIG_HINT_password_for_editing' => 'Mot de passe demandé pour modifier les formulaires (vide = pas de restriction)',
 'EDIT_CONFIG_HINT_password_for_editing_message' => 'Message qui s\'affiche au dessus de champ mot de passe demandé pour modifier les formulaires',
 'EDIT_CONFIG_HINT_actionbuilder_textarea_name' => 'Nom du champ texte long pour lequel les composants sont activés',
+'EDIT_CONFIG_HINT_baz_enum_field_time_cache_for_json' => 'Temps (s) entre deux rafraîchissements du cache pour les requêtes JSON pour listefiche',
     
 ));

--- a/tools/bazar/config.yaml
+++ b/tools/bazar/config.yaml
@@ -105,6 +105,7 @@ parameters:
   # ExternalBazarService
   baz_external_service_time_cache_for_entries: 60 # seconds
   baz_external_service_time_cache_for_forms: 1200 # seconds
+  baz_enum_field_time_cache_for_json: 7200 # seconds = 2 hours
   # for edit config action
   bazar_editable_config_params:
     - 'baz_map_center_lat'
@@ -113,6 +114,7 @@ parameters:
     - 'baz_map_height'
     - 'BAZ_ADRESSE_MAIL_ADMIN'
     - 'BAZ_ENVOI_MAIL_ADMIN'
+    - 'baz_enum_field_time_cache_for_json'
 
 services:
   _defaults:

--- a/tools/bazar/controllers/ApiController.php
+++ b/tools/bazar/controllers/ApiController.php
@@ -62,6 +62,19 @@ class ApiController extends YesWikiController
             $entries = $this->getService(GeoJSONFormatter::class)->formatToGeoJSON($entries);
         } elseif ($output == 'ical') {
             return $this->getService(IcalFormatter::class)->apiResponse($entries, $formId, $_GET);
+        } elseif ($output == 'only-titles') {
+            $titles = [];
+            if (!empty($entries)) {
+                foreach($entries as $id => $entry) {
+                    if (!empty($entry['bf_titre']) || $entry['bf_titre'] === 0)  {
+                        $titles[$id] = [
+                                'bf_titre' => $entry['bf_titre'],
+                                'id_fiche' => $id,
+                            ] + (!empty($entry['url']) ? ['url' => $entry['url']] : []);
+                    }
+                }
+            }
+            return new ApiResponse(empty($titles) ? null : $titles);
         }
         return new ApiResponse(empty($entries) ? null : $entries);
     }
@@ -239,6 +252,12 @@ class ApiController extends YesWikiController
 
         $output .= '
         <p>
+        <b><code>GET ' . $this->wiki->href('', 'api/forms/{formId}/entries/only-titles') . '</code></b><br />
+        Obtenir la liste de toutes les fiches du formulaire <code>formId</code> en ne gardant que les titres (et l\'url)<br />
+        </p>';
+
+        $output .= '
+        <p>
         <b><code>POST ' . $this->wiki->href('', 'api/entries/{formId}') . '</code></b><br />
         Créer une nouvelle fiche en utilisant le formulaire <code>formId</code><br />
         Si le header <code>Content-Type</code> est <code>application/ld+json</code>, un JSON sémantique est attendu.
@@ -266,6 +285,12 @@ class ApiController extends YesWikiController
         <p>
         <b><code>GET ' . $this->wiki->href('', 'api/entries/{formId}/ical') . '</code></b><br />
         Obtenir la liste de toutes les fiches du formulaire <code>formId</code> au format ical<br />
+        </p>';
+
+        $output .= '
+        <p>
+        <b><code>GET ' . $this->wiki->href('', 'api/entries/{formId}/only-titles') . '</code></b><br />
+        Obtenir la liste de toutes les fiches du formulaire <code>formId</code> en ne gardant que les titres (et l\'url)<br />
         </p>';
 
         $output .= '


### PR DESCRIPTION
@mrflos je fais cette proposition pour optimiser les performances de listefiche dans le cas d'url externes pour obtenir la liste des fiches.

**Ce que ça fait**:
 - définir un paramètre `baz_enum_field_time_cache_for_json` pour pouvoir régler le temps de cache pour cette requête JSON dans listefiche (réglage possible dans `{{editconfig}}`
 - temps par défaut de 2h
 - ajout d'un format pour la route api `api/forms/1/entries/only-titles` afin de réduire la quantité de données échangées (c'est utile pour les `listefiche`) ça permet de réduire le volume de données de 24 Mo à 192 Ko dans le cas de 1000 grosses fiches mais le temps de chargement ne passe que de 5.46s à 4.3 s
 
 Qu'en penses-tu ?