### PR TITLE
Improve pref bazar for owner

### DIFF
--- a/includes/services/AclService.php
+++ b/includes/services/AclService.php
@@ -13,6 +13,7 @@ class AclService
     protected $params;
 
     protected $cache;
+    private $checkOwnerReadAcl;
 
     public function __construct(Wiki $wiki, DbService $dbService, UserManager $userManager, ParameterBagInterface $params)
     {
@@ -22,6 +23,8 @@ class AclService
         $this->params = $params;
         
         $this->cache = [];
+        $this->checkOwnerReadAcl = !($this->params->has('baz_check_owner_acl_only_for_field_can_edit')
+            && $this->params->get('baz_check_owner_acl_only_for_field_can_edit'));
     }
     
     /**
@@ -226,7 +229,7 @@ class AclService
                                 // to manage retrocompatibility without usage of CheckACL without $tag
                                 // and no management of '%'
                                 $result = false;
-                            } elseif ($mode == 'edit') {
+                            } elseif ($this->checkOwnerReadAcl || $mode == 'edit') {
                                 $result = ($this->wiki->UserIsOwner($tag)) ? $std_response : !$std_response ;
                             }
                             break;

--- a/includes/services/AclService.php
+++ b/includes/services/AclService.php
@@ -229,7 +229,7 @@ class AclService
                                 // to manage retrocompatibility without usage of CheckACL without $tag
                                 // and no management of '%'
                                 $result = false;
-                            } elseif ($this->checkOwnerReadAcl || $mode == 'edit') {
+                            } elseif ($this->checkOwnerReadAcl || ($mode == 'edit')) {
                                 $result = ($this->wiki->UserIsOwner($tag)) ? $std_response : !$std_response ;
                             }
                             break;

--- a/includes/services/AclService.php
+++ b/includes/services/AclService.php
@@ -227,7 +227,7 @@ class AclService
                                 // and no management of '%'
                                 $result = false;
                             } else {
-                                $result = ($this->wiki->UserIsOwner($tag)) ? $std_response : !$std_response ;
+                                // $result = ($this->wiki->UserIsOwner($tag)) ? $std_response : !$std_response ;
                             }
                             break;
                         case '@': // groups

--- a/includes/services/AclService.php
+++ b/includes/services/AclService.php
@@ -226,8 +226,8 @@ class AclService
                                 // to manage retrocompatibility without usage of CheckACL without $tag
                                 // and no management of '%'
                                 $result = false;
-                            } else {
-                                // $result = ($this->wiki->UserIsOwner($tag)) ? $std_response : !$std_response ;
+                            } elseif ($mode == 'edit') {
+                                $result = ($this->wiki->UserIsOwner($tag)) ? $std_response : !$std_response ;
                             }
                             break;
                         case '@': // groups

--- a/includes/services/PageManager.php
+++ b/includes/services/PageManager.php
@@ -42,6 +42,8 @@ class PageManager
         if (!$bypassAcls && !$time && $cache && (($cachedPage = $this->getCached($tag)) !== false)) {
             if ($cachedPage and !isset($cachedPage["metadatas"])) {
                 $cachedPage["metadatas"] = $this->getMetadata($tag);
+                // save page with metadatas
+                $this->cache($cachedPage, $tag);
             }
             $page = $cachedPage;
         } else { // load page

--- a/lang/yeswiki_en.php
+++ b/lang/yeswiki_en.php
@@ -438,5 +438,6 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations']??[], array(
 'EDIT_CONFIG_HINT_password_for_editing_message' => 'Message displayed above the password asked password to modify forms',
 'EDIT_CONFIG_HINT_actionbuilder_textarea_name' => 'Textarea field\'s name for which components are activated',
 'EDIT_CONFIG_HINT_baz_enum_field_time_cache_for_json' => 'Time (s) between two cache\'s refreshes for JSON\'s requests in listefiche',
+'EDIT_CONFIG_HINT_baz_check_owner_acl_only_for_field_can_edit' => 'Check owner read acl \'%\' only when editing bazar fields (false by default)',
     
 ));

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -471,5 +471,6 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations']??[], array(
 'EDIT_CONFIG_HINT_password_for_editing_message' => 'Message qui s\'affiche au dessus de champ mot de passe demandé pour modifier les formulaires',
 'EDIT_CONFIG_HINT_actionbuilder_textarea_name' => 'Nom du champ texte long pour lequel les composants sont activés',
 'EDIT_CONFIG_HINT_baz_enum_field_time_cache_for_json' => 'Temps (s) entre deux rafraîchissements du cache pour les requêtes JSON pour listefiche',
+'EDIT_CONFIG_HINT_baz_check_owner_acl_only_for_field_can_edit' => 'Tester les droits de lecture de type \'%\' uniquement pour l\'écriture des champs bazar (faux par défaut)',
     
 ));

--- a/tools/bazar/actions/BazarListeAction.php
+++ b/tools/bazar/actions/BazarListeAction.php
@@ -211,11 +211,7 @@ class BazarListeAction extends YesWikiAction
                 true // filter on read ACL
             );
 
-            // Add display data to all entries
-            $entries = array_map(function ($fiche) use ($entryManager) {
-                $entryManager->appendDisplayData($fiche, false, $this->arguments['correspondance']);
-                return $fiche;
-            }, $entries);
+            // call to appendDisplayData removed because already done in EntryManager->search
         }
 
         // filter entries on datefilter parameter

--- a/tools/bazar/config.yaml
+++ b/tools/bazar/config.yaml
@@ -106,6 +106,8 @@ parameters:
   baz_external_service_time_cache_for_entries: 60 # seconds
   baz_external_service_time_cache_for_forms: 1200 # seconds
   baz_enum_field_time_cache_for_json: 7200 # seconds = 2 hours
+  # option only for configs with 500 errors when not admin connected
+  baz_check_owner_acl_only_for_field_can_edit: false
   # for edit config action
   bazar_editable_config_params:
     - 'baz_map_center_lat'
@@ -115,6 +117,7 @@ parameters:
     - 'BAZ_ADRESSE_MAIL_ADMIN'
     - 'BAZ_ENVOI_MAIL_ADMIN'
     - 'baz_enum_field_time_cache_for_json'
+    - 'baz_check_owner_acl_only_for_field_can_edit'
 
 services:
   _defaults:

--- a/tools/bazar/fields/BazarField.php
+++ b/tools/bazar/fields/BazarField.php
@@ -139,7 +139,7 @@ abstract class BazarField implements \JsonSerializable
     {
         $writeAcl = empty($this->writeAccess) ? '' : $this->writeAccess;
         $isCreation = !$entry;
-        return empty($writeAcl) || $this->getService(AclService::class)->check($writeAcl, null, true, $isCreation ? '' : $entry['id_fiche'], $isCreation ? 'creation' : '');
+        return empty($writeAcl) || $this->getService(AclService::class)->check($writeAcl, null, true, $isCreation ? '' : $entry['id_fiche'], $isCreation ? 'creation' : 'edit');
     }
 
     protected function render($templatePath, $data = [])

--- a/tools/bazar/libs/bazar.fonct.retrocompatibility.php
+++ b/tools/bazar/libs/bazar.fonct.retrocompatibility.php
@@ -97,7 +97,7 @@ function searchResultstoArray($pages, $params, $formtab = '')
 
     foreach ($pages as $page) {
         $fiche = $GLOBALS['wiki']->services->get(EntryManager::class)->decode($page['body']);
-        $GLOBALS['wiki']->services->get(EntryManager::class)->appendDisplayData($fiche, false, $params['correspondance']);
+        $GLOBALS['wiki']->services->get(EntryManager::class)->appendDisplayData($fiche, false, $params['correspondance'],$page);
         $fiches[$fiche['id_fiche']] = $fiche;
     }
 

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -110,7 +110,7 @@ class EntryManager
                 $data['id_fiche'] = $page['tag'];
             }
             // TODO call this function only when necessary
-            $this->appendDisplayData($data, $semantic);
+            $this->appendDisplayData($data, $semantic, '', $page);
         } elseif ($debug) {
             trigger_error('empty \'body\'  in EntryManager::getDataFromPage for page \''. $page['tag'] .'\'', E_USER_WARNING);
         }
@@ -734,9 +734,11 @@ class EntryManager
      * @param $fiche
      * @param bool $semantic
      * @param string $correspondance
+     * @param array $page , appendDisplayData is called in environement with access to $page
+     *      helping to get owner without asking a new Time to Page manager to get it
      * @throws Exception
      */
-    public function appendDisplayData(&$fiche, $semantic = false, $correspondance = '')
+    public function appendDisplayData(&$fiche, $semantic = false, $correspondance = '', array $page)
     {
         // champs correspondants
         if (!empty($correspondance)) {
@@ -762,7 +764,7 @@ class EntryManager
         $fiche['html_data'] = getHtmlDataAttributes($fiche);
 
         // owner
-        $fiche['owner'] = $this->pageManager->getOwner($fiche['id_fiche']);
+        $fiche['owner'] = $page['owner'] ?? null;
 
         // Fiche URL
         if (!isset($fiche['url'])) {


### PR DESCRIPTION
@acheype @mrflos je crée cette PR pour laisser des traces et permettre une gestion aisée des commentaires associées après fusion

**La raison de cette PR**:
 - les dernières versions doryphore peuvent être malade et présenter une erreur 500 pour les utilisateurs connectés non admin dès qu'il y a utilisation de bazarliste avec des templates utilisant `bazar_voir_fiche` ou pour juste l'utilisation de bazarliste (sur certains serveurs OVH)
 - ce souci n'arrive pas pour les administrateurs ni pour les personnes non connectées

**Processus** :
 - je publie cette PR sans revue
 - je fusionne la branche associée
 - je diffuse la modification de suite (car ça commence à se propager)
 - je vous laisse le lien vers cette page pour recueillir vos éventuels commentaires
 - je procéderai aux correctifs suite à vos commentaires

**Ce que ça fait**:
 - éviter de solliciter à nouveau PageManager pour obtenir `owner` alors qu'on possède déjà la tableau `page` dans le périmètre lors de l'appel de la fonction => optimisation de la pile des appels
 - dans AclService->check : **désactivation** du test concernant `%` sauf pour les champs en écriture
   - cette option n'est activée que si `baz_check_owner_acl_only_for_field_can_edit = true`
 - permettre de changer cette option dans editconfig

**Ce que ça ne fait pas**:
 - trouver la vraie raison de ce bug. **J'ai conscience que ça n'est qu'un patch de secours** à améliorer par la suite.
