### PR TITLE
feat(facettes): add reset filters button

### DIFF
--- a/docs/actions/bazarliste.yaml
+++ b/docs/actions/bazarliste.yaml
@@ -157,6 +157,14 @@ actions:
         min: 1
         max: 12
         showif: facettes
+      resetfiltersbutton:
+        label: _t(AB_bazar_commons2_resetfiltersbutton_label)
+        advanced: true
+        type: checkbox
+        default: 0
+        checkedvalue: 1
+        uncheckedvalue: 0
+        showif: facettes
       datefilter:
         label: _t(AB_bazar_commons2_filter_on_date)
         type: list

--- a/docs/actions/lang/actionsbuilder_fr.inc.php
+++ b/docs/actions/lang/actionsbuilder_fr.inc.php
@@ -16,6 +16,7 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations'], array(
     'AB_bazar_commons2_filter_on_date_for_two_years' => "depuis deux ans",
     'AB_bazar_commons2_filter_on_date_one_week_more_and_less' => "+/- une semaine",
     'AB_bazar_commons2_filter_index' => "'bf_date_debut_evenement' doit être défini.",
+    'AB_bazar_commons2_resetfiltersbutton_label' => 'Ajouter un bouton pour réinitialiser les filtres',
     // BazarAction
     'AB_bazar_action_label' => "Afficher un formulaire de création de fiche",
     'AB_bazar_action_description' => "Permet d'afficher le formulaire pour créer une fiche.",

--- a/tools/bazar/lang/bazar_fr.inc.php
+++ b/tools/bazar/lang/bazar_fr.inc.php
@@ -289,6 +289,8 @@ $GLOBALS['translations'] = array_merge(
 
         'BAZ_ALL_DAY' => 'Toute la journ&eacute;e',
         'BAZ_ENTER_HOUR' => 'Entrer l\'heure',
+
+        'BAZ_RESET_FILTERS' => 'Réinitialiser les filtres',
         
         //================ Drag & Drop for Checkbox fiche =======================================
         'BAZ_DRAG_n_DROP_CHECKBOX_AVAILABLE_ITEM' => '&Eacute;l&eacute;ments disponibles',

--- a/tools/bazar/libs/bazar.js
+++ b/tools/bazar/libs/bazar.js
@@ -711,6 +711,11 @@ $(document).ready(function () {
       $(this).parents('.facette-container').find('.results-label').hide();
     }
   });
+
+  // gestion du bouton de réinitialisation des filtres
+  $('.facette-container .filters .reset-filters').on('click', function(){
+    $('.facette-container .filters input.filter-checkbox:checked').click();
+  });
 })
 
 function exportTableToCSV(filename) {

--- a/tools/bazar/templates/entries/list.twig
+++ b/tools/bazar/templates/entries/list.twig
@@ -61,6 +61,11 @@
             <span class="result-label">{{ _t('BAZ_FICHE_CORRESPONDANT_FILTRES') }}</span>
             <span class="results-label" style="display: none;">{{ _t('BAZ_FICHES_CORRESPONDANTES_FILTRES') }}</span>
           {% endif %}
+          {% if params.resetfiltersbutton %}
+            <div class="btn btn-xs btn-info reset-filters pull-right">
+              <i>{{ _t('BAZ_RESET_FILTERS') }}</i>
+            </div><div class="clearfix"></div>
+          {% endif %}
         </div>
         {% if params.filtertext %}
         <div class="input-group filtertext">


### PR DESCRIPTION
_Contexte : une prestation avec Zoomacom_

Je souhaite partager dans le coeur la fonctionnalité suivante : **ajouter un bouton pour réinitialiser les filtres**
J'ai hésité à faire un commit direct, mais vu que ça concerne aussi l'affichage, je le mets en PR pendant quelques jours.

**Ce que ça fait**:
 - ajouter un bouton dans le template dédié
 - ajout du paramètre dans les composants
 - ajout du javascript nécessaire dans bazar.js
 - ajout des clés dans les fichiers de traductions
