### PR TITLE
échape le délimiteur de regexp dans la construction de regexp

### DIFF
--- a/includes/urlutils.inc.php
+++ b/includes/urlutils.inc.php
@@ -83,7 +83,7 @@ function detectRewriteMode()
 function replaceLinksWithIframe(string $body): string
 {
     // pattern qui rajoute le /iframe pour les liens au bon endroit, merci raphael@tela-botanica.org
-    $pattern = '~(<a.*?href.*?)' . preg_quote($GLOBALS['wiki']->config['base_url']) . '([\w\-_]+)([&#?].*?)?(["\'])([^>]*?>)~i';
+    $pattern = '~(<a.*?href.*?)' . preg_quote($GLOBALS['wiki']->config['base_url'], '~') . '([\w\-_]+)([&#?].*?)?(["\'])([^>]*?>)~i';
     $pagebody = preg_replace_callback(
         $pattern,
         function ($matches) {
@@ -104,7 +104,7 @@ function replaceLinksWithIframe(string $body): string
     );
 
     // pattern qui rajoute le /editiframe pour les liens au bon endroit
-    $pattern = '~(<a.*?href.*?)' . preg_quote($GLOBALS['wiki']->config['base_url']) . '([\w\-_]+)\/edit([&#?].*?)?(["\'])([^>]*?>)~i';
+    $pattern = '~(<a.*?href.*?)' . preg_quote($GLOBALS['wiki']->config['base_url'], '~') . '([\w\-_]+)\/edit([&#?].*?)?(["\'])([^>]*?>)~i';
     $pagebody = preg_replace_callback(
         $pattern,
         function ($matches) {

--- a/tools/templates/actions/include__.php
+++ b/tools/templates/actions/include__.php
@@ -32,7 +32,7 @@ if (!empty($actif) && $actif == '1') {
     }
     // d'abord les liens avec des attributs class
     $plugin_output_new = preg_replace(
-        '~<a href="'.preg_quote($this->config['base_url'].$page_active).'" class="(.*)"~Ui',
+        '~<a href="'.preg_quote($this->config['base_url'].$page_active, '~').'" class="(.*)"~Ui',
         '<a class="active-link $1" href="'.$this->config['base_url'].$page_active.'"',
         $plugin_output_new
     );


### PR DESCRIPTION
## corrige le bug  #787

le délimiteur de regexp est maintenant échappé lors de la construction d'une regexp utilisant une variable dont le contenu n'est pas sous le contrôle de yeswiki.

Je serai heureux d'ajouter des tests unitaires pour cette situation. Pouvez vous m'indiquer la manière de procéder, je n'ai rien trouvé.

