### PR TITLE
Add an explicit label to the syntax help button

### DIFF
--- a/tools/aceditor/presentation/javascripts/aceditor.js
+++ b/tools/aceditor/presentation/javascripts/aceditor.js
@@ -226,8 +226,10 @@ var SYNTAX = {
 
       // help
       toolbar.append( '<div class="btn-group pull-right">' +
-              '<a class="btn btn-default aceditor-btn aceditor-btn-help" data-remote="true" href="wakka.php?wiki=ReglesDeFormatage" title="'+this.lang['ACEDITOR_HELP']+'">' +
-                '<i class="fa fa-question-circle"></i></a>' +
+              '<a class="btn btn-info aceditor-btn aceditor-btn-help" data-remote="true" href="wakka.php?wiki=ReglesDeFormatage" title="'+this.lang['ACEDITOR_HELP']+'">' +
+                this.lang['ACEDITOR_HELP'] +
+                '<i class="fa fa-question-circle"></i>' +
+              '</a>' +
             '</div>');
 
 


### PR DESCRIPTION
<img width="1166" alt="image" src="https://user-images.githubusercontent.com/138627/132089533-efd832b0-50c9-4d5d-9209-0affa014a57d.png">
