### PR TITLE
Enable `redirecturl` using a link

### DIFF
--- a/tools/bazar/actions/BazarAction.php
+++ b/tools/bazar/actions/BazarAction.php
@@ -52,7 +52,7 @@ class BazarAction extends YesWikiAction
             // Identifiant du formulaire (plusieures valeurs possibles, séparées par des virgules)
             'idtypeannonce' => $this->formatArray($_REQUEST['id_typeannonce'] ?? $arg['id'] ?? $arg['idtypeannonce'] ?? $_GET['id'] ?? null),
             // Permet de rediriger vers une url après saisie de fiche
-            'redirecturl' => $arg['redirecturl'] ?? ''
+            'redirecturl' => $_GET['redirecturl'] ?? $arg['redirecturl'] ?? ''
         ]);
     }
 


### PR DESCRIPTION
Currently, `redirecturl` only works when used in the action, like `{{ bazar redirecturl="http://example.com" }}`.

My intent is to enable redirecting using hyperlinks leading to the form, to make it more dynamic.

```
{{ button link="?InscriptionAnnuaire&redirecturl=Annuaire" }}
```

leads to

```
""<!-- ?InscriptionAnnuaire -->""

{{ bazar id="1" }}
```

