### PR TITLE
Connect bearer for api

### DIFF
--- a/includes/services/ApiService.php
+++ b/includes/services/ApiService.php
@@ -23,7 +23,7 @@ class ApiService
         $bearerToken = $this->getBearerToken();
         // connect user from api_allowed_keys (format 'userName' => 'key')
         // to be admin, the userName should exist and be in @admins group
-        if ($bearerToken){
+        if ($bearerToken) {
             $this->connectBearer($bearerToken);
         }
 
@@ -108,23 +108,29 @@ class ApiService
      */
     private function connectBearer(?string $bearerToken):bool
     {
-        if (!$bearerToken || !$this->params->has('api_allowed_keys')){
+        if (!$bearerToken || !$this->params->has('api_allowed_keys')) {
             return false;
         }
 
         $apiAllowedKeys = $this->params->get('api_allowed_keys');
-        if (!in_array($bearerToken,$apiAllowedKeys)){
+        if (!is_array($apiAllowedKeys)) {
             return false;
         }
+        $flippedApiAllowedKeys = array_flip($apiAllowedKeys);
+        if (isset($flippedApiAllowedKeys[$bearerToken])) {
+            $userName = $flippedApiAllowedKeys[$bearerToken];
+        }
+        if (!empty($userName)) {
+            // get user from key
+            $user = $this->userManager->getOneByName($userName);
+        }
 
-        $key = array_search($bearerToken,$apiAllowedKeys);
-        // get user from key
-        $user = $this->userManager->getOneByName($key);
-
-        if (empty($user)){
+        if (empty($user)) {
             return false;
         }
         // login
+        $this->userManager->logout();
         $this->userManager->login($user);
+        return true;
     }
 }

--- a/includes/services/ApiService.php
+++ b/includes/services/ApiService.php
@@ -116,16 +116,14 @@ class ApiService
         if (!is_array($apiAllowedKeys)) {
             return false;
         }
-        $flippedApiAllowedKeys = array_flip($apiAllowedKeys);
-        if (isset($flippedApiAllowedKeys[$bearerToken])) {
-            $userName = $flippedApiAllowedKeys[$bearerToken];
-        }
+        $userName = array_search($bearerToken, $apiAllowedKeys);
         if (!empty($userName)) {
             // get user from key
             $user = $this->userManager->getOneByName($userName);
         }
 
         if (empty($user)) {
+            $this->userManager->logout();
             return false;
         }
         // login

--- a/includes/services/ApiService.php
+++ b/includes/services/ApiService.php
@@ -123,7 +123,6 @@ class ApiService
         }
 
         if (empty($user)) {
-            $this->userManager->logout();
             return false;
         }
         // login

--- a/includes/services/ApiService.php
+++ b/includes/services/ApiService.php
@@ -23,9 +23,7 @@ class ApiService
         $bearerToken = $this->getBearerToken();
         // connect user from api_allowed_keys (format 'userName' => 'key')
         // to be admin, the userName should exist and be in @admins group
-        if ($bearerToken) {
-            $this->connectBearer($bearerToken);
-        }
+        $bearerIsConnected = $this->connectBearer($bearerToken);
 
         // acl
         $acl = $this->loadACL($requestParams, $routes);
@@ -42,11 +40,11 @@ class ApiService
             (
                 $this->params->has('api_allowed_keys') &&
                 (
+                    $bearerIsConnected ||
                     (
                         isset($this->params->get('api_allowed_keys')['public']) &&
                         $this->params->get('api_allowed_keys')['public'] === true
-                    ) ||
-                    in_array($bearerToken, $this->params->get('api_allowed_keys'))
+                    )
                 )
             )
         );
@@ -103,12 +101,12 @@ class ApiService
 
     /**
      * connect user from bearer token
-     * @param ?string $bearerToken
+     * @param null|string $bearerToken
      * @return bool
      */
-    private function connectBearer(?string $bearerToken):bool
+    private function connectBearer(?string $bearerToken = null):bool
     {
-        if (!$bearerToken || !$this->params->has('api_allowed_keys')) {
+        if (empty($bearerToken) || !$this->params->has('api_allowed_keys')) {
             return false;
         }
 

--- a/includes/services/ApiService.php
+++ b/includes/services/ApiService.php
@@ -113,7 +113,7 @@ class ApiService
         }
 
         $apiAllowedKeys = $this->params->get('api_allowed_keys');
-        if (!in_array($bearerToken,$apiAllowedKeys){
+        if (!in_array($bearerToken,$apiAllowedKeys)){
             return false;
         }
 


### PR DESCRIPTION
@mrflos ça y est j'ai réussi à réparer ce qui ne fonctionnait pas.

**Ce que ça fait**:
 - si pas de `api_allowed_keys`:
   - il faut l'option acls `public` pour pouvoir accéder à la route api
   - usage des cookies pour savoir si on est connecté
 - avec `api_allowed_keys`:
   - si il y a dans wakka.config.php `'api_allowed_keys' => ['public' => true],` toutes les routes api sont accessibles
   - si un Bearer est fourni et que la clé associé à ce Bearer est le nom d'un user, ce dernier est connecté pour réaliser la requête api.
   - si la clé ne correspond pas à un nom de user, l'utilisateur actuel n'est pas déconnecté (usage des cookies)
   - si `api_allowed_keys => ['public' => false],` il y a vérification de l'existence du Bearer en question pour autoriser l'usage de l'api

Bref, en résumé, il faudrait avoir ceci dans wakka.config.php
```php
  'api_allowed_keys' =>  [
      'WikiAdmin' => 'HJHGJ68HD7TDGDKhehgjehg',
      'User1' => 'HJHGJ68HD7TDGDKhecccccdddzz*hgjehg',
      'Bearer not associated to a user' => 'HJHGJ68HD7TDGDKhehgjehg', // need usage of cookies to be connected as WikiAdmin for example
     ],
```
**Ce que ça ne fait pas**:
 - déconnecter l'utilisateur de la session php après une connexion réussie avec le Bearer
 - proposer automatiquement un Bearer de connexion via une api (mais c'est une bonne piste pour y arriver)

Intention : faciliter les transferts de contenu entre Wiki (LMS) via CLI en permettant des Bearer d'admin connectés

@acheype souhaites-tu être reviewer de cette PR ? ce serait ave plaisir (en fonction de ta dispo)