### PR TITLE
More options for forms can create

### DIFF
--- a/tools/bazar/config.yaml
+++ b/tools/bazar/config.yaml
@@ -111,7 +111,7 @@ parameters:
   # option only for configs with 500 errors when not admin connected
   baz_check_owner_acl_only_for_field_can_edit: false
   # to define allowed groups to edit forms
-  baz_allowed_group_to_edit_forms: [] 
+  baz_allowed_groups_to_edit_forms: [] 
   # for edit config action
   bazar_editable_config_params:
     - 'baz_map_center_lat'
@@ -123,7 +123,7 @@ parameters:
     - 'baz_enum_field_time_cache_for_json'
     - 'baz_check_owner_acl_only_for_field_can_edit'
     - 'bazarIgnoreAcls'
-    - baz_allowed_group_to_edit_forms
+    - baz_allowed_groups_to_edit_forms
 
 services:
   _defaults:

--- a/tools/bazar/config.yaml
+++ b/tools/bazar/config.yaml
@@ -110,6 +110,8 @@ parameters:
   baz_enum_field_time_cache_for_json: 7200 # seconds = 2 hours
   # option only for configs with 500 errors when not admin connected
   baz_check_owner_acl_only_for_field_can_edit: false
+  # to define allowed groups to edit forms
+  baz_allowed_group_to_edit_forms: [] 
   # for edit config action
   bazar_editable_config_params:
     - 'baz_map_center_lat'
@@ -121,6 +123,7 @@ parameters:
     - 'baz_enum_field_time_cache_for_json'
     - 'baz_check_owner_acl_only_for_field_can_edit'
     - 'bazarIgnoreAcls'
+    - baz_allowed_group_to_edit_forms
 
 services:
   _defaults:

--- a/tools/bazar/controllers/FormController.php
+++ b/tools/bazar/controllers/FormController.php
@@ -60,14 +60,14 @@ class FormController extends YesWikiController
         return $this->render("@bazar/forms/forms_table.twig", [
             'message' => $message,
             'forms' => $values,
-            'userIsAdmin' => $this->wiki->UserIsAdmin(),
+            'canEditForms' => !$this->securityController->isWikiHibernated() && $this->getService(Guard::class)->isAllowed('saisie_formulaire'),
             'isWikiHibernated' => $this->securityController->isWikiHibernated()
         ]);
     }
 
     public function create()
     {
-        if ($this->wiki->UserIsAdmin()) {
+        if ($this->getService(Guard::class)->isAllowed('saisie_formulaire')) {
             if (isset($_POST['valider'])) {
                 $this->formManager->create($_POST);
 

--- a/tools/bazar/controllers/FormController.php
+++ b/tools/bazar/controllers/FormController.php
@@ -47,8 +47,8 @@ class FormController extends YesWikiController
             foreach ($forms as $form) {
                 $values[$form['bn_id_nature']]['title'] = $form['bn_label_nature'];
                 $values[$form['bn_id_nature']]['description'] = $form['bn_description'];
-                $values[$form['bn_id_nature']]['canEdit'] = !$this->securityController->isWikiHibernated() && $this->getService(Guard::class)->isAllowed('saisie_formulaire');
-                $values[$form['bn_id_nature']]['canDelete'] = !$this->securityController->isWikiHibernated() &&$this->wiki->UserIsAdmin();
+                $values[$form['bn_id_nature']]['canEdit'] = $this->getService(Guard::class)->isAllowed('saisie_formulaire');
+                $values[$form['bn_id_nature']]['canDelete'] = !$this->securityController->isWikiHibernated() && $this->wiki->UserIsAdmin();
                 $values[$form['bn_id_nature']]['isSemantic'] = isset($form['bn_sem_type']) && $form['bn_sem_type'] !== "";
                 $values[$form['bn_id_nature']]['isGeo'] = !empty(array_filter($form['prepared'], function ($field) {
                     return ($field instanceof MapField);
@@ -60,7 +60,7 @@ class FormController extends YesWikiController
         return $this->render("@bazar/forms/forms_table.twig", [
             'message' => $message,
             'forms' => $values,
-            'canEditForms' => !$this->securityController->isWikiHibernated() && $this->getService(Guard::class)->isAllowed('saisie_formulaire'),
+            'canEditForms' => $this->getService(Guard::class)->isAllowed('saisie_formulaire'),
             'isWikiHibernated' => $this->securityController->isWikiHibernated()
         ]);
     }
@@ -79,7 +79,7 @@ class FormController extends YesWikiController
                 'groupsList' => $this->getGroupsListIfEnabled()
             ]);
         } else {
-            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_AUTH_NEEDED'], false));
+            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => ($this->securityController->isWikiHibernated() ?'WIKI_IN_HIBERNATION':'BAZ_NEED_ADMIN_RIGHTS')], false));
         }
     }
 
@@ -98,30 +98,30 @@ class FormController extends YesWikiController
                 'groupsList' => $this->getGroupsListIfEnabled()
             ]);
         } else {
-            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_NEED_ADMIN_RIGHTS'], false));
+            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => ($this->securityController->isWikiHibernated() ?'WIKI_IN_HIBERNATION':'BAZ_NEED_ADMIN_RIGHTS')], false));
         }
     }
 
     public function delete($id)
     {
-        if ($this->wiki->UserIsAdmin()) {
+        if (!$this->securityController->isWikiHibernated() && $this->wiki->UserIsAdmin()) {
             $this->formManager->clear($id);
             $this->formManager->delete($id);
 
             return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_FORMULAIRE_ET_FICHES_SUPPRIMES'], false));
         } else {
-            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_NEED_ADMIN_RIGHTS'], false));
+            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => ($this->securityController->isWikiHibernated() ?'WIKI_IN_HIBERNATION':'BAZ_NEED_ADMIN_RIGHTS')], false));
         }
     }
 
     public function empty($id)
     {
-        if ($this->wiki->UserIsAdmin()) {
+        if (!$this->securityController->isWikiHibernated() && $this->wiki->UserIsAdmin()) {
             $this->formManager->clear($id);
 
             return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_FORMULAIRE_VIDE'], false));
         } else {
-            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_NEED_ADMIN_RIGHTS'], false));
+            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => ($this->securityController->isWikiHibernated() ?'WIKI_IN_HIBERNATION':'BAZ_NEED_ADMIN_RIGHTS')], false));
         }
     }
 
@@ -132,7 +132,7 @@ class FormController extends YesWikiController
 
             return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_FORM_CLONED'], false));
         } else {
-            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_AUTH_NEEDED'], false));
+            return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => ($this->securityController->isWikiHibernated() ?'WIKI_IN_HIBERNATION':'BAZ_NEED_ADMIN_RIGHTS')], false));
         }
     }
 

--- a/tools/bazar/lang/bazar_fr.inc.php
+++ b/tools/bazar/lang/bazar_fr.inc.php
@@ -324,6 +324,7 @@ $GLOBALS['translations'] = array_merge(
         'EDIT_CONFIG_HINT_baz_check_owner_acl_only_for_field_can_edit' => 'Tester les droits de lecture de type \'%\' uniquement pour l\'écriture des champs bazar (faux par défaut)',
         'EDIT_CONFIG_HINT_baz_enum_field_time_cache_for_json' => 'Temps (s) entre deux rafraîchissements du cache pour les requêtes JSON pour listefiche',
         'EDIT_CONFIG_HINT_bazarIgnoreAcls' => 'Permettre la création de fiches même si le wiki est fermé en écriture (true ou false)',
+        'EDIT_CONFIG_HINT_baz_allowed_group_to_edit_forms' => 'Liste des groupes autorisés à modifier les formulaires',
         'EDIT_CONFIG_GROUP_BAZAR' => 'Base de données',
 
     )

--- a/tools/bazar/lang/bazar_fr.inc.php
+++ b/tools/bazar/lang/bazar_fr.inc.php
@@ -324,7 +324,7 @@ $GLOBALS['translations'] = array_merge(
         'EDIT_CONFIG_HINT_baz_check_owner_acl_only_for_field_can_edit' => 'Tester les droits de lecture de type \'%\' uniquement pour l\'écriture des champs bazar (faux par défaut)',
         'EDIT_CONFIG_HINT_baz_enum_field_time_cache_for_json' => 'Temps (s) entre deux rafraîchissements du cache pour les requêtes JSON pour listefiche',
         'EDIT_CONFIG_HINT_bazarIgnoreAcls' => 'Permettre la création de fiches même si le wiki est fermé en écriture (true ou false)',
-        'EDIT_CONFIG_HINT_baz_allowed_group_to_edit_forms' => 'Liste des groupes autorisés à modifier les formulaires',
+        'EDIT_CONFIG_HINT_baz_allowed_groups_to_edit_forms' => 'Liste des groupes autorisés à modifier les formulaires (ex. [\'@groupe1\',\'@groupe2\']\')',
         'EDIT_CONFIG_GROUP_BAZAR' => 'Base de données',
 
     )

--- a/tools/bazar/services/Guard.php
+++ b/tools/bazar/services/Guard.php
@@ -7,6 +7,7 @@ use YesWiki\Bazar\Field\BazarField;
 use YesWiki\Bazar\Field\EmailField;
 use YesWiki\Core\Service\AclService;
 use YesWiki\Core\Service\UserManager;
+use YesWiki\Security\Controller\SecurityController;
 use YesWiki\Wiki;
 
 class Guard
@@ -17,9 +18,16 @@ class Guard
     protected $aclService;
     protected $params;
     protected $authorizedGroupsToEditForms;
+    protected $securityController;
 
-    public function __construct(Wiki $wiki, FormManager $formManager, UserManager $userManager, AclService $aclService, ParameterBagInterface $params)
-    {
+    public function __construct(
+        Wiki $wiki,
+        FormManager $formManager,
+        UserManager $userManager,
+        AclService $aclService,
+        ParameterBagInterface $params,
+        SecurityController $securityController
+    ) {
         $this->wiki = $wiki;
         $this->formManager = $formManager;
         $this->userManager = $userManager;
@@ -27,16 +35,20 @@ class Guard
         $this->userManager = $userManager;
         $this->params = $params;
         $this->authorizedGroupsToEditForms = null;
+        $this->securityController = $securityController;
     }
 
     // TODO remove this method and use YesWiki::HasAccess
     public function isAllowed($action = 'saisie_fiche', $ownerId = '') : bool
     {
+        if ($this->securityController->isWikiHibernated()) {
+            return false;
+        }
         $loggedUserName = $this->userManager->getLoggedUserName();
         $isOwner = $ownerId === $loggedUserName || $ownerId === '';
 
         // Admins are allowed all actions
-        if ($GLOBALS['wiki']->UserIsInGroup('admins')) {
+        if ($this->wiki->UserIsInGroup('admins')) {
             return true;
         }
 

--- a/tools/bazar/services/Guard.php
+++ b/tools/bazar/services/Guard.php
@@ -141,7 +141,7 @@ class Guard
             return false;
         }
         if (is_null($this->authorizedGroupsToEditForms)) {
-            $authorizedGroups = $this->params->get('baz_allowed_group_to_edit_forms');
+            $authorizedGroups = $this->params->get('baz_allowed_groups_to_edit_forms');
         
             if (empty($authorizedGroups) || !is_array($authorizedGroups)) {
                 $this->authorizedGroupsToEditForms = [];

--- a/tools/bazar/templates/forms/forms_table.twig
+++ b/tools/bazar/templates/forms/forms_table.twig
@@ -124,14 +124,14 @@
 </div>
 {% endif %}
 
-{% if userIsAdmin and not isWikiHibernated %}
+{% if canEditForms %}
   <a class="btn btn-primary" href="{{ url({ params: { vue: 'formulaire', action: 'new' }}) }}">
 {% else %}
   <button type="button" class="btn btn-primary" disabled="disabled" data-toggle="tooltip" data-placement="bottom" title="{{ tooltipMessage  }}">
 {% endif %}
   <i class="fa fa-plus icon-plus icon-white"></i>
   {{ _t('BAZ_NOUVEAU_FORMULAIRE') }}
-{% if userIsAdmin and not isWikiHibernated %}</a>{% else %}</button>{% endif %}
+{% if canEditForms %}</a>{% else %}</button>{% endif %}
 
 <hr>
 
@@ -141,9 +141,9 @@
 		<span class="add-on input-group-addon">
       <i class="fa fa-link icon-globe"></i>
     </span>
-		<input id="url-import-forms" class="form-control input-xxlarge" {% if not userIsAdmin or isWikiHibernated %}disabled  data-toggle="tooltip" data-placement="bottom" title="{{ tooltipMessage }}"{% endif %} placeholder="{{ _t('BAZ_URL_IMPORT_LISTS_INFO') }}" type="url" />
+		<input id="url-import-forms" class="form-control input-xxlarge" {% if not canEditForms %}disabled  data-toggle="tooltip" data-placement="bottom" title="{{ tooltipMessage }}"{% endif %} placeholder="{{ _t('BAZ_URL_IMPORT_LISTS_INFO') }}" type="url" />
 		<span class="input-group-btn">
-      <button id="btn-import-forms" {% if not userIsAdmin or isWikiHibernated %}disabled  disabled="disabled" data-toggle="tooltip" data-placement="bottom" title="{{ tooltipMessage }}"{% endif %} class="btn btn-primary" type="submit">{{ _t('BAZ_GO') }} !</button>
+      <button id="btn-import-forms" {% if not canEditForms %}disabled  disabled="disabled" data-toggle="tooltip" data-placement="bottom" title="{{ tooltipMessage }}"{% endif %} class="btn btn-primary" type="submit">{{ _t('BAZ_GO') }} !</button>
     </span>
 	</div>
   <p class="text-info">Exemple d'url pour obtenir des formulaires types: <code>https://yeswiki.net</code></p>


### PR DESCRIPTION
Je propose cette PR pour permettre de définir la liste des groupes qui sont autorisés à créer ou modifier les formulaires.

L'idée est que sur un wiki fraichement installé il faille rester administrateurs pour faire ceci.
toutefois, sur des wikis avec des usages avancés (LMS), il serait préférable de permettre à des non admins de créer des formulaires.

**Ce que ça fait**:
 - créer une variable accessible via editconfig pour définir la liste des groupes autorisés
 - définir dans FormController l'usage du Guard pour vérifier si la saisie de formulaire est autorisée
 - il y a un cache sur la liste des groupes autorisés pour éviter de la recalculer à chaque fois.


//Si @acheype tu n'as pas le temps pour la revue// signale-toi que je te retire des reviewers