### PR TITLE
Display "Custom HTML" as a textarea field

### DIFF
--- a/tools/bazar/presentation/javascripts/form-edit-template.js
+++ b/tools/bazar/presentation/javascripts/form-edit-template.js
@@ -663,7 +663,18 @@ function initializeFormbuilder(formAndListIds) {
     existingFieldsNames = []
     $(".fld-name").each(function() { existingFieldsNames.push($(this).val()) })
     
-    
+    // Transform input[textarea] in real textarea
+    $('input[type="textarea"]').replaceWith(function() {
+      const textarea = document.createElement('textarea')
+      textarea.id = this.id
+      textarea.name = this.name
+      textarea.value = this.value
+      textarea.classList = this.classList
+      textarea.title = this.title
+      textarea.rows = $(this).attr('rows')
+      return textarea
+    })
+
     // Slugiy field names
     $(".fld-name").each(function () {
       var newValue = $(this)

--- a/tools/bazar/presentation/javascripts/form-edit-template.js
+++ b/tools/bazar/presentation/javascripts/form-edit-template.js
@@ -346,8 +346,9 @@ var typeUserAttrs = {
     },
   },
   labelhtml: {
+    type: "textarea",
     label: { value: "Custom HTML" },
-    content_saisie: { label: "Contenu lors la saisie" },
+    content_saisie: { label: "Contenu lors de la saisie" },
     content_display: { label: "Contenu lors de l'affichage d'une fiche" },
   },
   utilisateur_wikini: {

--- a/tools/bazar/presentation/javascripts/form-edit-template.js
+++ b/tools/bazar/presentation/javascripts/form-edit-template.js
@@ -346,10 +346,9 @@ var typeUserAttrs = {
     },
   },
   labelhtml: {
-    type: "textarea",
     label: { value: "Custom HTML" },
-    content_saisie: { label: "Contenu lors de la saisie" },
-    content_display: { label: "Contenu lors de l'affichage d'une fiche" },
+    content_saisie: { label: "Contenu lors de la saisie", type: "textarea", rows: "4" },
+    content_display: { label: "Contenu lors de l'affichage d'une fiche", type: "textarea", rows: "4"  },
   },
   utilisateur_wikini: {
     name_field: { label: "Champ pour le nom d'utilisateur", value: "bf_titre" },


### PR DESCRIPTION
Et corrige une typo.

Je voudrais que ça ressemble à ça :

![image](https://user-images.githubusercontent.com/138627/133275702-cd0c0db6-8779-47b0-911d-dfd4445f9ded.png)
