### PR TITLE
fix(PageManager): apply guard for each getter

### DIFF
--- a/includes/services/PageManager.php
+++ b/includes/services/PageManager.php
@@ -60,10 +60,9 @@ class PageManager
                 $page["metadatas"] = $this->getMetadata($tag);
             }
 
-            // not possible to init the EntryManager in the constructor because of circular reference problem
-            if ($this->wiki->services->get(EntryManager::class)->isEntry($tag) && !$bypassAcls) {
-                // not possible to init the Guard in the constructor because of circular reference problem
-                $page = $this->wiki->services->get(Guard::class)->checkAcls($page, $tag);
+            if (!$bypassAcls) {
+                $page['tag'] = $tag;
+                $page = $this->checkEntriesACL([$page])[0];
             }
 
             // cache result
@@ -110,19 +109,15 @@ class PageManager
     public function getById($id): ?array
     {
         $page = $this->dbService->loadSingle('select * from' . $this->dbService->prefixTable('pages') . "where id = '" . $this->dbService->escape($id) . "' limit 1");
-        $tag = $page['tag'] ?? null;
-        // not possible to init the EntryManager in the constructor because of circular reference problem
-        if (!empty($tag) && $this->wiki->services->get(EntryManager::class)->isEntry($tag)) {
-            // not possible to init the Guard in the constructor because of circular reference problem
-            $page = $this->wiki->services->get(Guard::class)->checkAcls($page, $tag);
-        }
-
+        $page = $this->checkEntriesACL([$page])[0];
         return $page;
     }
 
     public function getRevisions($page)
     {
-        return $this->dbService->loadAll('select * from' . $this->dbService->prefixTable('pages') . "where tag = '" . $this->dbService->escape($page) . "' order by time desc");
+        $revisions = $this->dbService->loadAll('select * from' . $this->dbService->prefixTable('pages') . "where tag = '" . $this->dbService->escape($page) . "' order by time desc");
+        $revisions = $this->checkEntriesACL($revisions);
+        return $revisions ;
     }
 
     public function getLinkingTo($tag)
@@ -153,7 +148,9 @@ class PageManager
 
     public function getAll(): array
     {
-        return $this->dbService->loadAll('select * from' . $this->dbService->prefixTable('pages') . "where latest = 'Y' order by tag");
+        $pages = $this->dbService->loadAll('select * from' . $this->dbService->prefixTable('pages') . "where latest = 'Y' order by tag");
+        $pages = $this->checkEntriesACL($pages);
+        return $pages ;
     }
 
     public function getCreateTime($pageTag)
@@ -333,5 +330,26 @@ class PageManager
         }
 
         return $this->tripleStore->create($tag, 'http://outils-reseaux.org/_vocabulary/metadata', $metadata, '', '');
+    }
+
+    /**
+     * use Guard to checkACL for entries
+     * @param array $pages
+     * @return array $pages
+     */
+    private function checkEntriesACL(array $pages): array
+    {
+        if ($this->wiki->UserIsAdmin()) {
+            // do not check following tests to be faster because admins can see anything
+            return $pages;
+        }
+        // not possible to init the EntryManager or Guard in the constructor because of circular reference problem
+        $entryManager = $this->wiki->services->get(EntryManager::class);
+        $guard = $this->wiki->services->get(Guard::class);
+        $pages = array_map(function ($page) use ($entryManager, $guard) {
+            return (!$entryManager->isEntry($page['tag'] ?? null)) ? $page
+                : $guard->checkAcls($page, $page['tag'] ?? null);
+        }, $pages);
+        return $pages;
     }
 }

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -70,6 +70,25 @@ class EntryManager
     }
 
     /**
+     * return array with list of page's tag for all entries
+     * @return array
+     */
+    public function getAllEntriesTags(): array
+    {
+        $result = $this->tripleStore->getMatching(null, TripleStore::TYPE_URI, self::TRIPLES_ENTRY_ID);
+        if (is_array($result)) {
+            $result = array_filter(array_map(function ($item) {
+                return $item['resource'] ?? null;
+            }, $result), function ($item) {
+                return !empty($item);
+            });
+        } else {
+            $result = [];
+        }
+        return $result;
+    }
+
+    /**
      * Get one specified fiche
      * @param $tag
      * @param bool $semantic


### PR DESCRIPTION
_@acheype sans urgence pour cette PR_

En regardant les fuites potentielles de données que pouvait faire le handler `/hello`, mais c'est corrigé, je me suis dit qu'il était possible de contourner le Guard pour les fiches bazar avec `PageManager->getRevisions` et `PageManager->getAll`

Je propose ce correctif pour éviter les fuites potentielles de données.

Qu'en penses-tu ?
