### PR TITLE
Mise à jour des packages `apt` avant installation

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,15 +2,17 @@ name: PHP Composer
 
 on:
   push:
-    branches: [ doryphore ]
+    branches: [ doryphore, ectoplasme ]
     paths:
     - 'composer.lock'
     - '*.php'
+    - '.github/workflows/*.yml'
   pull_request:
-    branches: [ doryphore ]
+    branches: [ doryphore, ectoplasme ]
     paths:
     - 'composer.lock'
     - '*.php'
+    - '.github/workflows/*.yml'
 
 env:
   DB_NAME: yeswiki_test

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -50,7 +50,8 @@ jobs:
           </Directory>
         </VirtualHost>" | sudo tee /etc/apache2/sites-enabled/000-default.conf
         sudo chown www-data:www-data -R ${{ github.workspace }}
-        sudo apt install libapache2-mod-php7.3
+        sudo apt update
+        sudo apt install --no-install-recommends --assume-yes libapache2-mod-php7.3
         sudo /etc/init.d/apache2 start
 
     - name: Set up MySQL


### PR DESCRIPTION
A package is 404 after a new release, as Ubuntu policy is to not keep obsolete versions.

The solution is to refresh `apt` cache before to try a package install.

refs #810
refs #794