### PR TITLE
fix(LoadPage): force time for main page

### DIFF
--- a/tools/attach/actions/__include.php
+++ b/tools/attach/actions/__include.php
@@ -4,5 +4,7 @@
     }
 
     $oldpage = $this->GetPageTag();
+    $this->CachePage($this->page);
     $this->tag = trim($this->GetParameter('page'));
-    $this->setPage($this->LoadPage($this->tag));
+    $includedPage = $this->GetCachedPage($this->tag);
+    $this->setPage(!empty($includedPage) ? $includedPage : $this->LoadPage($this->tag));

--- a/tools/attach/actions/include__.php
+++ b/tools/attach/actions/include__.php
@@ -4,4 +4,5 @@
     }
 
     $this->tag = $oldpage;
-    $this->page = $this->LoadPage($oldpage);
+    $includedPage = $this->GetCachedPage($this->tag);
+    $this->page = !empty($includedPage) ? $includedPage : $this->LoadPage($this->tag);

--- a/tools/templates/actions/__include.php
+++ b/tools/templates/actions/__include.php
@@ -17,7 +17,8 @@ if (isset($this->metadatas[$pageincluded])) {
     if ($this->tag == trim($oldpageincluded)) { // case /attach/actions/___include before this
         // redo tools\attach\actions\__include.php without changing oldpage
         $this->tag = trim($pageincluded);
-        $this->page = $this->LoadPage($this->tag);
+        $includedPage = $this->GetCachedPage($this->tag);
+        $this->page = !empty($includedPage) ? $includedPage : $this->LoadPage($this->tag);
     }
 }
 $clear = $this->GetParameter('clear');


### PR DESCRIPTION
@mrflos avec @seballot nous avons identifié que le handler iframe ne permet de correctement afficher la version demandée d'une page (time=...)

Nous avons identifié que de nombreuses fois, l'action `{{include}}` recharge la page courante via `wiki->LoadPage` sans le paramètre time.

~~plutôt que de réussir à trouver tous les endroits où on appelle LoadPage pour la page courante, .... je préfère ajouter ce correctif au sein même de la méthode LoadPage (qui est de moins en moins utilisée).~~

**Finalement j'ai fait un rebase en mettant les modifications directement dans les include__.php et __include.php de façon à stocker la page en cache et à recharger la page depuis le cache plutôt que de refaire un appel à la base de données**

Qu'en dis-tu ?

(ce correctif sera utile pour la PR #810)
