### PR TITLE
Import service (1rst step) : url helper

### DIFF
--- a/includes/services/ImportService.php
+++ b/includes/services/ImportService.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace YesWiki\Core\Service;
+
+// use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+// use YesWiki\Wiki;
+
+class ImportService
+{
+    // protected $wiki;
+    // protected $params;
+
+    public function __construct(/*Wiki $wiki, ParameterBagInterface $params*/)
+    {
+        // $this->wiki = $wiki;
+        // $this->params = $params;
+    }
+    
+    /**
+     * extract baseUrl and rootPage for external url
+     * @param string $inputUrl
+     * @return array [$baseUrl,$rootPage,$rewriteModeEnabled]
+     */
+    public function extractBaseUrlAndRootPage(string $inputUrl): array
+    {
+        $redirectedInputUrl = $this->retrieveUrlAfterRedirect($inputUrl);
+        $extraction = $this->extractBaseUrlModeAndTag($redirectedInputUrl);
+        if (empty($extraction)) {
+            return [];
+        }
+        list($baseUrl, $rewriteModeEnabled, $tag) = $extraction;
+        $redirectedRootUrl = $this->retrieveUrlAfterRedirect($baseUrl.'/');
+        $extraction = $this->extractBaseUrlModeAndTag($redirectedInputUrl);
+        if (empty($extraction)) {
+            return [];
+        }
+        list($baseUrl, $rewriteModeEnabled, $rootPage) = $extraction;
+        return [$baseUrl,$rootPage,$rewriteModeEnabled];
+    }
+
+    /**
+     * extract baseUrl, rewriteModeEnabled and tag
+     * @param string $inputUrl
+     * @return array [$baseUrl, $rewriteModeEnabled, $tag]
+     */
+    private function extractBaseUrlModeAndTag($inputUrl): array
+    {
+        if (preg_match('/wiki=('.WN_CAMEL_CASE_EVOLVED.')/u', $inputUrl, $matches)) {
+            $tag = $matches[1];
+            if (preg_match('/(.*)\/wakka.php\?.*wiki='.$tag.'/u', $inputUrl, $matches)) {
+                $rewriteModeEnabled = false;
+                $baseUrl = $matches[1];
+            } elseif (preg_match('/(.*)\/\?.*wiki='.$tag.'/u', $inputUrl, $matches)) {
+                $rewriteModeEnabled = false;
+                $baseUrl = $matches[1];
+            } elseif (preg_match('/(.*)\/[^\/]*wiki='.$tag.'/u', $inputUrl, $matches)) {
+                $rewriteModeEnabled = true;
+                $baseUrl = $matches[1];
+            }
+        } elseif (preg_match('/(.*)\/wakka.php\?('.WN_CAMEL_CASE_EVOLVED.')/u', $inputUrl, $matches)) {
+            $rewriteModeEnabled = false;
+            $tag = $matches[2];
+            $baseUrl = $matches[1];
+        } elseif (preg_match('/(.*)\/\?('.WN_CAMEL_CASE_EVOLVED.')/u', $inputUrl, $matches)) {
+            $rewriteModeEnabled = false;
+            $tag = $matches[2];
+            $baseUrl = $matches[1];
+        } elseif (preg_match('/(https?:\/\/(?:localhost|[0-9]{3}:[0-9]{3}:[0-9]{3}:[0-9]{3}|(?:[^\/]*\.[a-z]{3})).*)\/('.WN_CAMEL_CASE_EVOLVED.')(?:\/)?$/u', $inputUrl, $matches)) {
+            $rewriteModeEnabled = true;
+            $tag = $matches[2];
+            $baseUrl = $matches[1];
+        }
+        if (empty($baseUrl) || is_null($rewriteModeEnabled) || empty($tag)) {
+            return [];
+        } else {
+            return [$baseUrl,$rewriteModeEnabled,$tag];
+        }
+    }
+
+    /**
+     * retrieve url after redirection
+     * @param string $inputUrl
+     * @return string $outputUrl
+     */
+    private function retrieveUrlAfterRedirect(string $inputUrl): string
+    {
+        $headers = get_headers($inputUrl, true);
+        $outputUrl = $inputUrl;
+        if (!empty($headers['Location'])) {
+            if (is_array($headers['Location'])) {
+                $outputUrl = $headers['Location'][count($headers['Location'])-1];
+            } elseif (is_string($headers['Location'])) {
+                $outputUrl = $headers['Location'];
+            }
+        }
+        return $outputUrl;
+    }
+}

--- a/includes/services/ImportService.php
+++ b/includes/services/ImportService.php
@@ -18,6 +18,7 @@ class ImportService
     
     /**
      * extract baseUrl and rootPage for external url
+     * TODO check if this function should be in UrlService after refactor
      * @param string $inputUrl
      * @return array [$baseUrl,$rootPage,$rewriteModeEnabled]
      */
@@ -40,6 +41,7 @@ class ImportService
 
     /**
      * extract baseUrl, rewriteModeEnabled and tag
+     * TODO check if this function should be in UrlService after refactor
      * @param string $inputUrl
      * @return array [$baseUrl, $rewriteModeEnabled, $tag]
      */
@@ -79,6 +81,7 @@ class ImportService
 
     /**
      * retrieve url after redirection
+     * TODO check if this function should be in UrlService after refactor
      * @param string $inputUrl
      * @return string $outputUrl
      */

--- a/tools/bazar/lang/bazar_fr.inc.php
+++ b/tools/bazar/lang/bazar_fr.inc.php
@@ -313,6 +313,7 @@ $GLOBALS['translations'] = array_merge(
 
         // ==== ExternalBazarService ====
         'BAZ_EXTERNAL_SERVICE_BAD_RECEIVED_FORM' => 'contenu du formulaire reçu mal formaté.',
+        'BAZ_EXTERNAL_SERVICE_BAD_URL' => 'url non accessible.',
         'BAZ_EXTERNAL_SERVICE_BAD_RECEIVED_ENTRIES' => 'contenu des fiches reçues mal formaté.',
         'BAZ_EXTERNAL_SERVICE_QUERIES_NOT_AVAILABLE' => 'Vous utilisez la paramètre \'query\' pour des fiches externes. Il n\'est pas encore fonctionnel.',
 


### PR DESCRIPTION
J'aimerais disposer dans le coeur d'un bout de code que j'ai mis dans l'extension fermer il n'y a pas longtemps.

Ca permettrait de retrouver url de base, rewrite_mode et nom de la page d'accueil pour un wiki distant.
Ce serait utile à:
- `tools/ferme/actions/generatemodelActions.php`
- `tool/bazar/services/ExternalBazarService.php`

d'où ma proposition de le mutualiser dans le coeur.
Est-ce que le 'ImportService' est le bon endroit ?

_Cette PR n'a pas prétention à mutualiser en une seule fois tous les services d'import service_.