### PR TITLE
Remove "GLOB_BRACE"

### DIFF
--- a/tools/aceditor/actions/actions_builder.php
+++ b/tools/aceditor/actions/actions_builder.php
@@ -8,7 +8,7 @@ use Symfony\Component\Yaml\Yaml;
 $data = baz_forms_and_lists_ids();
 // Bazar actions documentation, read from Yaml file
 $docFiles = glob('docs/actions/*.yaml');
-$extensionDocFiles = glob('tools/**/actions/documentation.yaml', GLOB_BRACE);
+$extensionDocFiles = glob('tools/*/actions/documentation.yaml');
 $customDocFiles = glob('custom/actions/documentation.yaml');
 $docFiles = array_merge($docFiles, $extensionDocFiles);
 $docFiles = array_merge($docFiles, $customDocFiles);


### PR DESCRIPTION
GLOB_BRACE n'est pas compatible avec les systèmes utilisant une autre librairie que la GNU libc (Alpine par exemple utilise musl libc).

J'utilise Alpine dans des containers pour héberger YesWiki, et l'usage de GLOB_BRACE provoque une erreur et renvois un résultat null. Le menu "composant" de Aceditor est alors vide.
 
D’après la doc de PHP : GLOB_BRACE : Remplace {a,b,c} par 'a', 'b' ou 'c'  (cf https://www.php.net/manual/fr/function.glob.php). Dans ce cas elle ne me semble pas utile, et la fonction retourne le même résultat avec ou sans GLOB_BRACE.

Je n'ai pas compris non plus l’intérêt de la double étoile "**"
