### PR TITLE
fix(UserField): prevent creating user if email or same wikiname is existing

### DIFF
--- a/includes/services/UserManager.php
+++ b/includes/services/UserManager.php
@@ -90,4 +90,21 @@ class UserManager
             "password = md5('" . $this->dbService->escape($password) . "')"
         );
     }
+
+    public function updateEmail($wikiName, $email)
+    {
+        if ($this->securityController->isWikiHibernated()) {
+            throw new \Exception(_t('WIKI_IN_HIBERNATION'));
+        }
+        $user = $this->getOneByName($wikiName);
+        if (!empty($user)) {
+            $query =
+                'UPDATE ' . $this->dbService->prefixTable('users') . 'SET ' .
+                'email = "' . $this->dbService->escape($email) . '"'.
+                ' WHERE name = "'.$this->dbService->escape($user['name']).'" '.
+                'AND email= "'.$this->dbService->escape($user['email']).'" '.
+                'AND password= "'.$this->dbService->escape($user['password']).'";';
+            $this->dbService->query($query);
+        }
+    }
 }

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -227,18 +227,25 @@ class EntryController extends YesWikiController
         $form = $this->formManager->getOne($entry['id_typeannonce']);
 
         list($state, $error) = $this->securityController->checkCaptchaBeforeSave('entry');
-        if ($state && isset($_POST['bf_titre'])) {
-            $entry = $this->entryManager->update($entryId, $_POST);
-            if (empty($redirectUrl)) {
-                $redirectUrl = $this->wiki->Href(testUrlInIframe(), '', [
-                    'vue' => 'consulter',
-                    'action' => 'voir_fiche',
-                    'id_fiche' => $entry['id_fiche'],
-                    'message' => 'modif_ok'
-                ], false);
+        try {
+            if ($state && isset($_POST['bf_titre'])) {
+                $entry = $this->entryManager->update($entryId, $_POST);
+                if (empty($redirectUrl)) {
+                    $redirectUrl = $this->wiki->Href(testUrlInIframe(), '', [
+                        'vue' => 'consulter',
+                        'action' => 'voir_fiche',
+                        'id_fiche' => $entry['id_fiche'],
+                        'message' => 'modif_ok'
+                    ], false);
+                }
+                header('Location: ' . $redirectUrl);
+                exit;
             }
-            header('Location: ' . $redirectUrl);
-            exit;
+        } catch (UserFieldException $e) {
+            $error .= $this->render('@templates/alert-message.twig', [
+                'type' => 'warning',
+                'message' => $e->getMessage()
+            ]);
         }
 
         return $this->render("@bazar/entries/form.twig", [

--- a/tools/bazar/fields/UserField.php
+++ b/tools/bazar/fields/UserField.php
@@ -210,6 +210,9 @@ class UserField extends BazarField
                 if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
                     throw new UserFieldException(_t('USER_THIS_IS_NOT_A_VALID_EMAIL'));
                 }
+                if ($this->isUserByEmail($email)) {
+                    throw new UserFieldException(_t('BAZ_USER_FIELD_EXISTING_USER_BY_EMAIL'));
+                }
                 $userManager->updateEmail($user['name'], $email);
             }
         }

--- a/tools/bazar/fields/UserField.php
+++ b/tools/bazar/fields/UserField.php
@@ -6,6 +6,10 @@ use Psr\Container\ContainerInterface;
 use YesWiki\Core\Service\Mailer;
 use YesWiki\Core\Service\UserManager;
 
+class UserFieldException extends \Exception
+{
+}
+
 /**
  * @Field({"yeswiki_user", "utilisateur_wikini"})
  */
@@ -14,10 +18,14 @@ class UserField extends BazarField
     protected $nameField;
     protected $emailField;
     protected $mailingList;
+    protected $autoUpdateMail;
 
     protected const FIELD_NAME_FIELD = 1;
     protected const FIELD_EMAIL_FIELD = 2;
     protected const FIELD_MAILING_LIST = 5;
+    protected const FIELD_AUTO_UPDATE_MAIL = 9;
+
+    private const CONFIRM_NAME_SUFFIX = '_confirmNewName';
 
     public function __construct(array $values, ContainerInterface $services)
     {
@@ -26,9 +34,12 @@ class UserField extends BazarField
         $this->nameField = $values[self::FIELD_NAME_FIELD];
         $this->emailField = $values[self::FIELD_EMAIL_FIELD];
         $this->mailingList = $values[self::FIELD_MAILING_LIST];
+        $this->autoUpdateMail = in_array($values[self::FIELD_AUTO_UPDATE_MAIL], [true,"1",1], true);
 
         // We have no default value
         $this->default = null;
+        // not searchable
+        $this->searchable = null;
 
         $this->propertyName = 'nomwiki';
         $this->maxChars = 60;
@@ -47,25 +58,53 @@ class UserField extends BazarField
         $mailer = $this->getService(Mailer::class);
 
         $value = $this->getValue($entry);
+        $isImport = isset($GLOBALS['_BAZAR_']['provenance']) && $GLOBALS['_BAZAR_']['provenance'] === 'import';
 
-        if( $value ) {
+        if ($value) {
             $wikiName = $value;
+            $this->updateEmailIfNeeded($wikiName, $entry[$this->emailField] ?? null);
         } else {
             $wikiName = $entry[$this->nameField];
 
-            if (!$GLOBALS['wiki']->IsWikiName($wikiName)) {
+            $wiki = $this->getWiki();
+            if (!$wiki->IsWikiName($wikiName)) {
                 $wikiName = genere_nom_wiki($wikiName, 0);
+            }
+            if ($this->isUserByName($wikiName)) {
+                $currentWikiName = $wikiName;
                 // If user exist, add a number
-                while ($GLOBALS['wiki']->LoadUser($wikiName)) {
+                while ($this->isUserByName($wikiName)) {
                     $wikiName = genere_nom_wiki($wikiName);
                 }
+                if (!$isImport
+                        && !in_array($_POST[$this->propertyName.self::CONFIRM_NAME_SUFFIX] ?? false, [true,1,"1"], true)
+                        ) {
+                    throw new UserFieldException(
+                        $this->render("@bazar/inputs/user-confirm.twig", [
+                            'confirmName' => $this->propertyName.self::CONFIRM_NAME_SUFFIX,
+                            'wikiName' => $currentWikiName,
+                            'newWikiName' => $wikiName,
+                        ])
+                    );
+                }
+            }
+            if ($this->isUserByEmail($entry[$this->emailField])) {
+                throw new UserFieldException(_t('BAZ_USER_FIELD_EXISTING_USER_BY_EMAIL'));
+            }
+            if (!filter_var($entry[$this->emailField], FILTER_VALIDATE_EMAIL)) {
+                throw new UserFieldException(_t('USER_THIS_IS_NOT_A_VALID_EMAIL'));
+            }
+            if (!$isImport
+                    && $entry['mot_de_passe_wikini'] !== $entry['mot_de_passe_repete_wikini']) {
+                throw new UserFieldException(_t('USER_PASSWORDS_NOT_IDENTICAL'));
             }
 
+            // check existence of user with same
             $userManager->create($wikiName, $entry[$this->emailField], $entry['mot_de_passe_wikini']);
 
             // Do not send mails if we are importing
             // TODO improve import detection
-            if (!isset($GLOBALS['_BAZAR_']['provenance']) || $GLOBALS['_BAZAR_']['provenance'] !== 'import') {
+            if (!$isImport) {
                 $mailer->notifyNewUser($wikiName, $entry[$this->emailField]);
 
                 // Check if we need to subscribe the user to a mailing list
@@ -78,7 +117,14 @@ class UserField extends BazarField
         // indicateur pour la gestion des droits associee a la fiche.
         $GLOBALS['utilisateur_wikini'] = $wikiName;
         
-        return [$this->propertyName => $wikiName];
+        return [
+            $this->propertyName => $wikiName,
+            'fields-to-remove' => [
+                'mot_de_passe_wikini',
+                'mot_de_passe_repete_wikini',
+                $this->propertyName.self::CONFIRM_NAME_SUFFIX
+                ]
+        ];
     }
 
     protected function renderStatic($entry)
@@ -86,12 +132,12 @@ class UserField extends BazarField
         $value = $this->getValue($entry);
         $userManager = $this->getService(UserManager::class);
 
-        if( $value ) {
+        if ($value) {
             return $this->render("@bazar/fields/user.twig", [
                 'value' => $value,
                 'isLoggedUser' => $userManager->getLoggedUser() && $userManager->getLoggedUserName() === $value,
-                'editUrl' => $GLOBALS['wiki']->href('edit', $value),
-                'settingsUrl' => $GLOBALS['wiki']->href('', 'ParametresUtilisateur')
+                'editUrl' => $this->getWiki()->href('edit', $value),
+                'settingsUrl' => $this->getWiki()->href('', 'ParametresUtilisateur')
             ]);
         }
 
@@ -113,5 +159,59 @@ class UserField extends BazarField
     public function getMailingList()
     {
         return $this->mailingList;
+    }
+
+    public function getAutoUpdateMail()
+    {
+        return $this->autoUpdateMail;
+    }
+
+    public function jsonSerialize()
+    {
+        return array_merge(
+            parent::jsonSerialize(),
+            [
+                'nameField' => $this->getNameField(),
+                'emailField' => $this->getEmailField(),
+                'mailingList' => $this->getMailingList(),
+                'autoUpdateMail' => $this->getAutoUpdateMail(),
+            ]
+        );
+    }
+
+    private function isUserByName(string $userName): bool
+    {
+        $userManager = $this->getService(UserManager::class);
+        return !empty($userManager->getOneByName($userName));
+    }
+
+    private function isUserByEmail(string $email): bool
+    {
+        $userManager = $this->getService(UserManager::class);
+        return !empty($userManager->getOneByEmail($email));
+    }
+
+    private function updateEmailIfNeeded(string $userName, string $email)
+    {
+        if ($this->getAutoUpdateMail() && !empty($userName) && !empty($email)) {
+            $userManager = $this->getService(UserManager::class);
+            $user = $userManager->getOneByName($userName);
+            $loggedUser = $userManager->getLoggedUser();
+            if (!empty($user)
+                && (
+                    $this->getWiki()->UserIsAdmin()
+                        || (
+                            !empty($loggedUser)
+                            && $user['name'] === $loggedUser['name']
+                        )
+                )
+                && $user['email'] !== $email
+                ) {
+                if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                    throw new UserFieldException(_t('USER_THIS_IS_NOT_A_VALID_EMAIL'));
+                }
+                $userManager->updateEmail($user['name'], $email);
+            }
+        }
     }
 }

--- a/tools/bazar/lang/bazar_fr.inc.php
+++ b/tools/bazar/lang/bazar_fr.inc.php
@@ -332,6 +332,8 @@ $GLOBALS['translations'] = array_merge(
         // USER FIELD
         'BAZ_USER_FIELD_EXISTING_USER_BY_NAME' => "L'identifiant \"{currentName}\" existe déjà !\nCochez la case pour confirmer son remplacement par \"{proposedName}\" ou sinon modifiez votre identifiant dans le formulaire ci-dessous.",
         'BAZ_USER_FIELD_EXISTING_USER_BY_EMAIL' => "L'e-mail fourni est déjà associé à un compte YesWiki ! Veuillez entrer une autre adresse e-mail ou vous connecter à ce compte.",'USER_PASSWORDS_NOT_IDENTICAL' => "Le mot de passe saisi pour vérification n'est pas identique au premier !",
+        'BAZ_USER_FIELD_ALREADY_CONNECTED' => "Vous êtes déjà connecté avec l'identifiant \"{wikiname}\" et l'e-mail \"{email}\".\nLa fiche créé sera automatiquement liée à votre compte. Veuillez vous déconnecter pour créer un nouveau compte !",
+        'BAZ_USER_FIELD_ALREADY_CONNECTED_AUTOUPDATE' => "Pour changer l'adresse e-mail associée à votre compte, tapez-en une différente de \"{email}\".",
 
     )
 );

--- a/tools/bazar/lang/bazar_fr.inc.php
+++ b/tools/bazar/lang/bazar_fr.inc.php
@@ -329,5 +329,9 @@ $GLOBALS['translations'] = array_merge(
         'EDIT_CONFIG_HINT_BAZARIGNOREACLS' => 'Permettre la création de fiches même si le wiki est fermé en écriture (true ou false)',
         'EDIT_CONFIG_GROUP_BAZAR' => 'Base de données',
 
+        // USER FIELD
+        'BAZ_USER_FIELD_EXISTING_USER_BY_NAME' => "L'identifiant \"{currentName}\" existe déjà !\nCochez la case pour confirmer son remplacement par \"{proposedName}\" ou sinon modifiez votre identifiant dans le formulaire ci-dessous.",
+        'BAZ_USER_FIELD_EXISTING_USER_BY_EMAIL' => "L'e-mail fourni est déjà associé à un compte YesWiki ! Veuillez entrer une autre adresse e-mail ou vous connecter à ce compte.",'USER_PASSWORDS_NOT_IDENTICAL' => "Le mot de passe saisi pour vérification n'est pas identique au premier !",
+
     )
 );

--- a/tools/bazar/presentation/javascripts/form-edit-template.js
+++ b/tools/bazar/presentation/javascripts/form-edit-template.js
@@ -365,7 +365,6 @@ var typeUserAttrs = {
     },
     mailing_list_tool: {
       label: "Type de service de diffusion",
-      options: { "": "", ezmlm: "Ezmlm", sympa: "Sympa" },
     },
   },
   labelhtml: {
@@ -378,6 +377,13 @@ var typeUserAttrs = {
     email_field: {
       label: "Champ pour l'email de l'utilisateur",
       value: "bf_mail",
+    },
+    // mailing_list: {
+    //   label: "Inscrite à une liste de diffusion"
+    // },
+    autoupdate_email: {
+      label: "Auto. Sychro. e-mail",
+      options: { "": "Non", 1: "Oui" },
     },
   },
   acls: {
@@ -573,7 +579,7 @@ var yesWikiMapping = {
     4: "mailing_list_tool",
   },
   labelhtml: { 0: "type", 1: "content_saisie", 2: "", 3: "content_display" },
-  utilisateur_wikini: { 0: "type", 1: "name_field", 2: "email_field" },
+  utilisateur_wikini: { 0: "type", 1: "name_field", 2: "email_field",/*5:"mailing_list",*/9:"autoupdate_email" },
   titre: { 0: "type", 1: "value", 2: "label" },
   acls: { 0: "type", 1: "read", 2: "write", 3: "comment" },
   metadatas: { 0: "type", 1: "theme", 2: "squelette", 3: "style", 4: "image" },

--- a/tools/bazar/templates/inputs/user-confirm.twig
+++ b/tools/bazar/templates/inputs/user-confirm.twig
@@ -1,0 +1,18 @@
+<div class="input-group">
+    <label for="{{ confirmName }}">
+        <input 
+            class="element_checkbox" 
+            type="checkbox" 
+            id="{{ confirmName }}" 
+            value="1" 
+            name="{{ confirmName }}"
+            form="formulaire"
+        />
+        <span></span>
+    </label>
+  <div class="input-group-append">
+    <span class="input-group-text">
+        {{ _t('BAZ_USER_FIELD_EXISTING_USER_BY_NAME')|replace({'{currentName}':wikiName,'{proposedName}':newWikiName})|nl2br() }}
+    </span>
+  </div>
+</div>

--- a/tools/bazar/templates/inputs/user.twig
+++ b/tools/bazar/templates/inputs/user.twig
@@ -1,3 +1,9 @@
+{% if message %}
+    {{ include('@templates/alert-message.twig',{
+        type:'info',
+        message:message|nl2br()
+    })}}
+{% endif %}
 {% if value %}
     <input type="hidden" name="nomwiki" value="{{ value }}" />
 {% else %}


### PR DESCRIPTION
@mrflos @seballot @acheype est-ce qu'un de vous à le temps de relire rapidement cette PR.

**Ce que ça fait**:
 - introduire un test dans UserField pour ne pas créer d'utilisateur s'il y en a déjà un avec le même e-mail
 - vérifier l'existence d'un utilisateur avec le même identifiant et demander confirmation avant d'en créer un avec cet identifiant
 - vérifier que le mot de passe est saisie de façon identique dans les deux champs
 - ajout dans UserManager d'une méthode pour permettre la mise à jour de l'e-mail d'un utilisateur
 - définir un nouveau paramètre pour le champ UserField pour permettre la mise à jour de l'e-mail associé à l'utilisateur à partir du formulaire (uniquement possible par un admin ou l'utilisateur lui-même)

**Ce que ça ne fait pas**:
 - pas de refactor de `User.class.php`trop complexe