### PR TITLE
feat(attach): ajax upload available at entry creation

### DIFF
--- a/tools/attach/handlers/page/ajaxupload.php
+++ b/tools/attach/handlers/page/ajaxupload.php
@@ -3,7 +3,10 @@ if (!WIKINI_VERSION) {
     die('acc&egrave;s direct interdit');
 }
 
-if ($this->HasAccess('write') || ($this->HasAccess('read') && isset($_GET['tempTag']) && substr($_GET['tempTag'], 0, strlen($this->config['temp_tag_for_entry_creation'])) === $this->config['temp_tag_for_entry_creation'])) {
+$hasTempTag = (isset($_GET['tempTag'])
+    && preg_match("/^{$this->config['temp_tag_for_entry_creation']}_[A-Fa-f0-9]+$/m", $_GET['tempTag']));
+
+if ($this->HasAccess('write') || ($this->HasAccess('read') && $hasTempTag)) {
     /**
      * Handle file uploads via XMLHttpRequest
      */
@@ -167,7 +170,7 @@ if ($this->HasAccess('write') || ($this->HasAccess('read') && isset($_GET['tempT
             $replace = array('e','a','i','u','o','c','_','');
             $filename = preg_replace($search, $replace, utf8_decode($filename));
 
-            if (!empty($_GET['tempTag'])) {
+            if ($hasTempTag) {
                 $previousTag = $GLOBALS['wiki']->tag;
                 $previousPage = $GLOBALS['wiki']->page;
                 $GLOBALS['wiki']->tag = $_GET['tempTag'];
@@ -185,7 +188,7 @@ if ($this->HasAccess('write') || ($this->HasAccess('read') && isset($_GET['tempT
             $GLOBALS['wiki']->setParameter("file", $filename . '.' . $ext);
 
             // dans le cas d'une nouvelle page, on donne une valeur a la date de création
-            if (!empty($_GET['tempTag']) || $GLOBALS['wiki']->page['time'] == '') {
+            if ($hasTempTag || $GLOBALS['wiki']->page['time'] == '') {
                 $GLOBALS['wiki']->page['time'] = date('YmdHis');
             }
 
@@ -193,7 +196,7 @@ if ($this->HasAccess('write') || ($this->HasAccess('read') && isset($_GET['tempT
             ob_start();
             $attach->doAttach();
             $fullfilename = $attach->GetFullFilename(true);
-            if (!empty($_GET['tempTag'])) {
+            if ($hasTempTag) {
                 $GLOBALS['wiki']->tag = $previousTag;
                 $GLOBALS['wiki']->page = $previousPage;
             }

--- a/tools/attach/handlers/page/ajaxupload.php
+++ b/tools/attach/handlers/page/ajaxupload.php
@@ -3,7 +3,7 @@ if (!WIKINI_VERSION) {
     die('acc&egrave;s direct interdit');
 }
 
-if ($this->HasAccess('write') || ($this->HasAccess('read') && ($_GET['tempTag'] ?? null) === $this->config['temp_tag_for_entry_creation'])) {
+if ($this->HasAccess('write') || ($this->HasAccess('read') && isset($_GET['tempTag']) && substr($_GET['tempTag'], 0, strlen($this->config['temp_tag_for_entry_creation'])) === $this->config['temp_tag_for_entry_creation'])) {
     /**
      * Handle file uploads via XMLHttpRequest
      */
@@ -170,7 +170,7 @@ if ($this->HasAccess('write') || ($this->HasAccess('read') && ($_GET['tempTag'] 
             if (!empty($_GET['tempTag'])) {
                 $previousTag = $GLOBALS['wiki']->tag;
                 $previousPage = $GLOBALS['wiki']->page;
-                $GLOBALS['wiki']->tag = $GLOBALS['wiki']->config['temp_tag_for_entry_creation'];
+                $GLOBALS['wiki']->tag = $_GET['tempTag'];
                 $GLOBALS['wiki']->page = [
                     'tag' => $GLOBALS['wiki']->tag,
                     'body' => '{##}',

--- a/tools/attach/handlers/page/ajaxupload.php
+++ b/tools/attach/handlers/page/ajaxupload.php
@@ -79,8 +79,9 @@ if ($this->HasAccess('write') || ($this->HasAccess('read') && $hasTempTag)) {
         private $allowedExtensions = array();
         private $sizeLimit = '10000';
         private $file;
+        private $hasTempTag;
 
-        public function __construct(array $allowedExtensions = array(), $sizeLimit = '10000')
+        public function __construct(array $allowedExtensions = array(), $sizeLimit = '10000', $hasTempTag = false)
         {
             $allowedExtensions = array_map("strtolower", $allowedExtensions);
 
@@ -96,6 +97,7 @@ if ($this->HasAccess('write') || ($this->HasAccess('read') && $hasTempTag)) {
             } else {
                 $this->file = false;
             }
+            $this->hasTempTag = $hasTempTag;
         }
 
         private function checkServerSettings()
@@ -170,7 +172,7 @@ if ($this->HasAccess('write') || ($this->HasAccess('read') && $hasTempTag)) {
             $replace = array('e','a','i','u','o','c','_','');
             $filename = preg_replace($search, $replace, utf8_decode($filename));
 
-            if ($hasTempTag) {
+            if ($this->hasTempTag) {
                 $previousTag = $GLOBALS['wiki']->tag;
                 $previousPage = $GLOBALS['wiki']->page;
                 $GLOBALS['wiki']->tag = $_GET['tempTag'];
@@ -188,7 +190,7 @@ if ($this->HasAccess('write') || ($this->HasAccess('read') && $hasTempTag)) {
             $GLOBALS['wiki']->setParameter("file", $filename . '.' . $ext);
 
             // dans le cas d'une nouvelle page, on donne une valeur a la date de création
-            if ($hasTempTag || $GLOBALS['wiki']->page['time'] == '') {
+            if ($this->hasTempTag || $GLOBALS['wiki']->page['time'] == '') {
                 $GLOBALS['wiki']->page['time'] = date('YmdHis');
             }
 
@@ -196,7 +198,7 @@ if ($this->HasAccess('write') || ($this->HasAccess('read') && $hasTempTag)) {
             ob_start();
             $attach->doAttach();
             $fullfilename = $attach->GetFullFilename(true);
-            if ($hasTempTag) {
+            if ($this->hasTempTag) {
                 $GLOBALS['wiki']->tag = $previousTag;
                 $GLOBALS['wiki']->page = $previousPage;
             }
@@ -227,7 +229,7 @@ if ($this->HasAccess('write') || ($this->HasAccess('read') && $hasTempTag)) {
     // max file size in bytes
     $sizeLimit = $att->attachConfig['max_file_size'];
 
-    $uploader = new qqFileUploader($allowedExtensions, $sizeLimit);
+    $uploader = new qqFileUploader($allowedExtensions, $sizeLimit, $hasTempTag);
     $result = $uploader->handleUpload($att->attachConfig['upload_path']);
 
 

--- a/tools/attach/lang/attach_en.inc.php
+++ b/tools/attach/lang/attach_en.inc.php
@@ -44,7 +44,6 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations'], array(
 // handler edit
 'ACTIVATE_JS_TO_UPLOAD_FILES' => 'Activate JavaScript to upload files',
 'UPLOAD_A_FILE' => 'Upload a file',
-'SAVE_ENTRY_THEN_MODIFY_TO_UPLOAD_FILE' => 'Save entry then modify it to upload a file',
 'UPLOAD_A_FILE_SHORT' => 'File',
 'UPLOAD_FILE' => 'Upload file',
 'CANCEL_THIS_UPLOAD' => 'Cancel this upload',

--- a/tools/attach/lang/attach_fr.inc.php
+++ b/tools/attach/lang/attach_fr.inc.php
@@ -60,7 +60,6 @@ $GLOBALS['translations'] = array_merge(
         // handler edit
         'ACTIVATE_JS_TO_UPLOAD_FILES' => 'Activer JavaScript pour joindre des fichiers',
         'UPLOAD_A_FILE' => 'Joindre / Ins&eacute;rer un fichier',
-        'SAVE_ENTRY_THEN_MODIFY_TO_UPLOAD_FILE' => 'Enregistrer la fiche puis la modifier pour joindre un fichier',
         'UPLOAD_A_FILE_SHORT' => 'Fichier',
         'UPLOAD_FILE' => 'T&eacute;l&eacute;charger le fichier',
         'CANCEL_THIS_UPLOAD' => 'Annuler cet envoi',

--- a/tools/attach/libs/fileuploader.js
+++ b/tools/attach/libs/fileuploader.js
@@ -1291,6 +1291,7 @@ qq.extend(qq.UploadHandlerXhr.prototype, {
     var position;
     let textAreaId = $(this.element).data('textarea');
     var body = (textAreaId && textAreaId.length > 0) ? $(textAreaId) : $('#body');
+    var tempTag = $(this.element).data('temptag');
     var uploadurl = wiki.url(wiki.pageTag+'/ajaxupload');
     var downloadlist = $this.find('.qq-upload-list');
     var UploadModal = $('#UploadModal');
@@ -1344,7 +1345,7 @@ qq.extend(qq.UploadHandlerXhr.prototype, {
       if (typeof desctxt == 'undefined' || desctxt == '') {
         desctxt = getParameterByName(formvals, 'attach_link_text');
       }
-      var actionattach = '{{attach file="' + getParameterByName(formvals, 'filename') + '" desc="' + desctxt + '"';
+      var actionattach = '{{attach file="' + (tempTag ? tempTag+'/': '') + getParameterByName(formvals, 'filename') + '" desc="' + desctxt + '"';
 
       var displaypdf = getParameterByName(formvals, 'attach_action_display_pdf');
       if (typeof displaypdf != 'undefined' && displaypdf == '1') {
@@ -1398,6 +1399,7 @@ qq.extend(qq.UploadHandlerXhr.prototype, {
       element: this.element,
       action: uploadurl,
       debug: false,
+      params: {...{},...(tempTag ? {tempTag:tempTag}:{})},
 
       onSubmit: function(id, fileName) {
         // upload modal is cleaned and showed

--- a/tools/attach/templates/attach-file-uploader-button.twig
+++ b/tools/attach/templates/attach-file-uploader-button.twig
@@ -1,6 +1,6 @@
 <div class="btn-group attach-file-uploader"
     {% if fileUploaderAnchor %} data-anchor="{{ fileUploaderAnchor }}"{% endif %}
-    {% if fileUploaderTextarea %} data-textarea="{{ fileUploaderTextarea }}"{% endif %}
+    {% if fileUploaderSelector %} data-textarea="{{ fileUploaderSelector }}"{% endif %}
     {% if tempTag %} data-temptag="{{ tempTag }}"{% endif %}>
   <noscript>
     <span class="alert alert-danger alert-error">{{ _t('ACTIVATE_JS_TO_UPLOAD_FILES') }}.</span>

--- a/tools/attach/templates/attach-file-uploader-button.twig
+++ b/tools/attach/templates/attach-file-uploader-button.twig
@@ -1,14 +1,12 @@
 <div class="btn-group attach-file-uploader"
     {% if fileUploaderAnchor %} data-anchor="{{ fileUploaderAnchor }}"{% endif %}
     {% if fileUploaderTextarea %} data-textarea="{{ fileUploaderTextarea }}"{% endif %}
-    {% if disableUploadButton %} data-disabledUploadButton="true"{% endif %}>
+    {% if tempTag %} data-temptag="{{ tempTag }}"{% endif %}>
   <noscript>
     <span class="alert alert-danger alert-error">{{ _t('ACTIVATE_JS_TO_UPLOAD_FILES') }}.</span>
   </noscript>
   <div class="qq-uploader">
-    <div class="qq-upload-button btn btn-default" {% if not disableUploadButton %}title="{{ _t('UPLOAD_A_FILE') }}"
-        {%- else -%}title="{{ _t('SAVE_ENTRY_THEN_MODIFY_TO_UPLOAD_FILE') }}" disabled="disabled" data-toggle="tooltip" data-placement="bottom"
-        {% endif %}>
+    <div class="qq-upload-button btn btn-default" title="{{ _t('UPLOAD_A_FILE') }}">
       <i class="fa fa-upload icon-upload"></i>&nbsp;{{ _t('UPLOAD_A_FILE_SHORT') }}
     </div>
     <ul class="qq-upload-list"></ul>

--- a/tools/bazar/config.yaml
+++ b/tools/bazar/config.yaml
@@ -112,6 +112,8 @@ parameters:
   baz_enum_field_time_cache_for_json: 7200 # seconds = 2 hours
   # option only for configs with 500 errors when not admin connected
   baz_check_owner_acl_only_for_field_can_edit: false
+  # tag used to upload file at entry creation
+  temp_tag_for_entry_creation: 'unknown_entry_id'
   # for edit config action
   bazar_editable_config_params:
     - 'baz_map_center_lat'

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -219,13 +219,21 @@ class EntryController extends YesWikiController
             ]);
         }
 
+        $renderedInputs = $this->getRenderedInputs($form);
         return $this->render("@bazar/entries/form.twig", [
             'form' => $form,
-            'renderedInputs' => $this->getRenderedInputs($form),
+            'renderedInputs' => $renderedInputs,
             'showConditions' => $form['bn_condition'] !== '' && !isset($_POST['accept_condition']),
             'passwordForEditing' => isset($this->config['password_for_editing']) && !empty($this->config['password_for_editing']) && isset($_POST['password_for_editing']) ? $_POST['password_for_editing'] : '',
             'error' => $error,
             'captchaField' => $this->securityController->renderCaptchaField(),
+            'containUpload' => $this->inputsAreContainingUpload($renderedInputs),
+            'imageSmallWidth' => $this->config['image-small-width'],
+            'imageSmallHeight' => $this->config['image-small-height'],
+            'imageMediumWidth' => $this->config['image-medium-width'],
+            'imageMediumHeight' => $this->config['image-medium-height'],
+            'imageBigWidth' => $this->config['image-big-width'],
+            'imageBigHeight' => $this->config['image-big-height'],
         ]);
     }
 

--- a/tools/bazar/fields/TextareaField.php
+++ b/tools/bazar/fields/TextareaField.php
@@ -96,7 +96,8 @@ class TextareaField extends BazarField
 
         return $this->render("@bazar/inputs/textarea.twig", [
             'value' => $this->getValue($entry),
-            'entryId' => $entry['id_fiche'] ?? null
+            'entryId' => $entry['id_fiche'] ?? null,
+            'tempTag' => !isset($entry['id_fiche']) ? ($wiki->config['temp_tag_for_entry_creation'] ?? null) : null,
         ]);
     }
 
@@ -104,8 +105,10 @@ class TextareaField extends BazarField
     {
         $value = $this->getValue($entry);
 
-        if ($this->syntax == self::SYNTAX_HTML) {
+        if ($this->syntax === self::SYNTAX_HTML) {
             $value = strip_tags($value, self::ACCEPTED_TAGS);
+        } elseif ($this->syntax === self::SYNTAX_WIKI) {
+            $value = $this->sanitizeAttach($value, $entry);
         }
 
         return [$this->propertyName => $value];
@@ -164,5 +167,50 @@ class TextareaField extends BazarField
     public function getSyntax()
     {
         return $this->syntax;
+    }
+
+    private function sanitizeAttach(string $text, array $entry): string
+    {
+        $wiki = $this->getWiki();
+        $temp_tag_for_entry_creation = $wiki->config['temp_tag_for_entry_creation'];
+
+        if (preg_match_all("/({{attach[^}]*file=\")($temp_tag_for_entry_creation\/([^\"]*))(\"[^}]*}})/m", $text, $matches)) {
+            if (!class_exists('attach')) {
+                include('tools/attach/libs/attach.lib.php');
+            }
+            foreach ($matches[0] as $key => $value) {
+                $attach = new \Attach($wiki);
+                $attach->file = $matches[2][$key];
+                $previousTag = $wiki->tag;
+                $previousPage = $wiki->page;
+                $wiki->tag = $temp_tag_for_entry_creation;
+                $wiki->page = [
+                    'tag' => $wiki->tag,
+                    'body' => '{##}',
+                    'time' => date('YmdHis'),
+                    'owner' => '',
+                    'user' => '',
+                ];
+                $previousFileName = $attach->GetFullFilename();
+                $attach->file = $matches[3][$key];
+                $wiki->tag = $entry['id_fiche'];
+                $wiki->page = [
+                    'tag' => $entry['id_fiche'],
+                    'page' => json_encode($entry),
+                    'time' => $entry['date_creation_fiche'],
+                    'owner' => '',
+                    'user' => '',
+                ];
+                $newFileName = $attach->GetFullFilename(true);
+                rename($previousFileName, $newFileName);
+                $text =  str_replace($matches[0][$key], $matches[1][$key].$matches[3][$key].$matches[4][$key], $text);
+                unset($attach);
+                $wiki->tag = $previousTag;
+                $wiki->page = $previousPage;
+            }
+        }
+
+        
+        return $text;
     }
 }

--- a/tools/bazar/templates/inputs/textarea.twig
+++ b/tools/bazar/templates/inputs/textarea.twig
@@ -28,7 +28,7 @@
         {# do not display button before moving in aceditor bar#}
         <div style="display:none;">{{ include('@attach/attach-file-uploader-button.twig',
             {fileUploaderAnchor:'#' ~ field.name ~ 'Container .aceditor-toolbar',
-            fileUploaderTextarea:'#' ~ field.name }) }}</div>
+            fileUploaderSelector:'#' ~ field.name }) }}</div>
         {{ include_javascript('tools/attach/libs/fileuploader.js') }}
         <!-- include_javascript('tools/attach/libs/fileuploader.js') -->
     {% endif %}

--- a/tools/bazar/templates/inputs/textarea.twig
+++ b/tools/bazar/templates/inputs/textarea.twig
@@ -28,8 +28,7 @@
         {# do not display button before moving in aceditor bar#}
         <div style="display:none;">{{ include('@attach/attach-file-uploader-button.twig',
             {fileUploaderAnchor:'#' ~ field.name ~ 'Container .aceditor-toolbar',
-            fileUploaderTextarea:'#' ~ field.name ,
-            disableUploadButton: (entryId) ? false : true}) }}</div>
+            fileUploaderTextarea:'#' ~ field.name }) }}</div>
         {{ include_javascript('tools/attach/libs/fileuploader.js') }}
         <!-- include_javascript('tools/attach/libs/fileuploader.js') -->
     {% endif %}


### PR DESCRIPTION
et voici la modification pour charger directement des fichiers dans les champs texte longs mode wiki à la création d'une fiche.

ce que ça fait .. cf . https://github.com/YesWiki/yeswiki/pull/833#issuecomment-958829523

hormis que la requête ajaxupload est faite sur la page courante afin de pouvoir vérifier que l'utilisateur courant à les droits de lecture sur cette page et on passe un paramètre `GET['tempTag']` pour activer la sauvegarde avec un nom temporaire de fiche.