### PR TITLE
refactor(LinkTracker) : create method registerLinks

### DIFF
--- a/actions/redirect.php
+++ b/actions/redirect.php
@@ -25,23 +25,27 @@
 Parametres : page : nom wiki de la page vers laquelle ont doit rediriger (obligatoire)
 exemple : {{redirect page="BacASable"}}
 */
+use YesWiki\Core\Service\LinkTracker;
 
 $redirPageName = $this->GetParameter('page');
 
 if (!$redirPageName) {
     echo '<div class="alert alert-danger"><strong>'._t('ERROR_ACTION_REDIRECT').'</strong> : '._t('MISSING_PAGE_PARAMETER').'.</div>'."\n";
-} elseif ($this->GetMethod() == 'show') {
-    if (!isset($_SESSION['redirects'])) {
-        $_SESSION['redirects'] = array();
-    }
-    $_SESSION['redirects'][] = strtolower($this->GetPageTag());
-
-    if (in_array(strtolower($redirPageName), $_SESSION['redirects'])) {
-        echo "<div class=\"alert alert-danger\"><strong>"._t('ERROR_ACTION_REDIRECT')."</strong> : "._t('CIRCULAR_REDIRECTION_FROM_PAGE')." $redirPageName ( "
-         . $this->ComposeLinkToPage($redirPageName, 'edit', call_user_func('_t', 'CLICK_HERE')) . ')</div>'."\n";
-    } else {
-        $this->Redirect($this->Href('', $redirPageName));
-    }
 } else {
-    echo '<span style="color: red; weight: bold">'._t('PRESENCE_OF_REDIRECTION_TO').' "' . $this->Link($redirPageName) . '"</span>';
+    if ($this->GetMethod() == 'show') {
+        $this->services->get(LinkTracker::class)->forceAddIfNotIncluded($redirPageName);
+        if (!isset($_SESSION['redirects'])) {
+            $_SESSION['redirects'] = array();
+        }
+        $_SESSION['redirects'][] = strtolower($this->GetPageTag());
+
+        if (in_array(strtolower($redirPageName), $_SESSION['redirects'])) {
+            echo "<div class=\"alert alert-danger\"><strong>"._t('ERROR_ACTION_REDIRECT')."</strong> : "._t('CIRCULAR_REDIRECTION_FROM_PAGE')." $redirPageName ( "
+            . $this->ComposeLinkToPage($redirPageName, 'edit', call_user_func('_t', 'CLICK_HERE')) . ')</div>'."\n";
+        } else {
+            $this->Redirect($this->Href('', $redirPageName));
+        }
+    } else {
+        echo '<span style="color: red; weight: bold">'._t('PRESENCE_OF_REDIRECTION_TO').' "' . $this->Link($redirPageName) . '"</span>';
+    }
 }

--- a/handlers/UpdateHandler.php
+++ b/handlers/UpdateHandler.php
@@ -2,6 +2,7 @@
 
 use YesWiki\Bazar\Service\EntryManager;
 use YesWiki\Core\Service\DbService;
+use YesWiki\Core\Service\LinkTracker;
 use YesWiki\Core\Service\PageManager;
 use YesWiki\Security\Controller\SecurityController;
 use YesWiki\Core\YesWikiHandler;
@@ -161,6 +162,7 @@ class UpdateHandler extends YesWikiHandler
             }
         }
         $output = '';
+        $linkTracker = $this->getService(LinkTracker::class);
         foreach ($adminPagesToUpdate as $page) {
             if (isset($defaultSQLSplitted[$page])) {
                 if (preg_match('/'.$page.'\',\s*(?:now\(\))?\s*,\s*\'([\S\s]*)\',\s*\'\'\s*,\s*\'{{WikiName}}\',\s*\'{{WikiName}}\', \'(?:Y|N)\', \'page\', \'\'/U', $defaultSQLSplitted[$page], $matches)) {
@@ -170,6 +172,9 @@ class UpdateHandler extends YesWikiHandler
                     $pageContent = str_replace('{{url}}', $this->params->get('base_url'), $pageContent);
                     if ($this->getService(PageManager::class)->save($page, $pageContent) !== 0) {
                         $output .= (!empty($output) ? ', ':'')._t('NO_RIGHT_TO_WRITE_IN_THIS_PAGE').$page;
+                    } else {
+                        // save links
+                        $linkTracker->registerLinks($this->getService(PageManager::class)->getOne($page));
                     }
                 }
             } else {

--- a/handlers/page/edit.php
+++ b/handlers/page/edit.php
@@ -1,5 +1,6 @@
 <?php
 
+use YesWiki\Core\Service\LinkTracker;
 use YesWiki\Security\Controller\SecurityController;
 
 /*
@@ -109,21 +110,7 @@ if ($this->HasAccess('write') && $this->HasAccess('read') && !$isWikiHibernated)
                     $this->SavePage($this->tag, $body);
 
                     // now we render it internally so we can write the updated link table.
-                    $this->ClearLinkTable();
-                    $this->StartLinkTracking();
-                    $temp = $this->SetInclusions(); // a priori, éa ne sert é rien, mais on ne sait jamais...
-                    $this->RegisterInclusion($this->GetPageTag()); // on simule totalement un affichage normal
-                    $this->Format($body);
-                    $this->SetInclusions($temp);
-                    if ($user = $this->GetUser()) {
-                        $this->TrackLinkTo($user['name']);
-                    }
-                    if ($owner = $this->GetPageOwner()) {
-                        $this->TrackLinkTo($owner);
-                    }
-                    $this->StopLinkTracking();
-                    $this->WriteLinkTable();
-                    $this->ClearLinkTable();
+                    $this->services->get(LinkTracker::class)->registerLinks($this->page, false, false);
 
                     // forward
                     if ($this->page['comment_on']) {

--- a/handlers/page/edit.php
+++ b/handlers/page/edit.php
@@ -1,6 +1,7 @@
 <?php
 
 use YesWiki\Core\Service\LinkTracker;
+use YesWiki\Core\Service\PageManager;
 use YesWiki\Security\Controller\SecurityController;
 
 /*
@@ -99,7 +100,7 @@ if ($this->HasAccess('write') && $this->HasAccess('read') && !$isWikiHibernated)
             } else { // store
                 $body = str_replace("\r", '', $body);
                 // teste si la nouvelle page est differente de la précédente
-                if (rtrim($body) == rtrim($this->page['body'])) {
+                if (isset($this->page['body']) && rtrim($body) == rtrim($this->page['body'])) {
                     $this->SetMessage('Cette page n\'a pas &eacute;t&eacute; enregistr&eacute;e car elle n\'a subi aucune modification.');
                     $this->Redirect($this->href(testUrlInIframe()));
                 } else {
@@ -110,7 +111,8 @@ if ($this->HasAccess('write') && $this->HasAccess('read') && !$isWikiHibernated)
                     $this->SavePage($this->tag, $body);
 
                     // now we render it internally so we can write the updated link table.
-                    $this->services->get(LinkTracker::class)->registerLinks($this->page, false, false);
+                    $page = $this->services->get(PageManager::class)->getOne($this->tag);
+                    $this->services->get(LinkTracker::class)->registerLinks($page,false,false);
 
                     // forward
                     if ($this->page['comment_on']) {

--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -276,22 +276,7 @@ class Wiki
             $this->SavePage($page, $body, '', $bypass_acls);
 
             // now we render it internally so we can write the updated link table.
-            $linkTracker->clear();
-            $linkTracker->start();
-            // on simule totalement un affichage normal
-            $temp = $this->SetInclusions();
-            $this->RegisterInclusion($this->GetPageTag());
-            $this->Format($body);
-            $this->SetInclusions($temp);
-            if ($user = $this->GetUser()) {
-                $linkTracker->add($user['name']);
-            }
-            if ($owner = $this->GetPageOwner()) {
-                $linkTracker->add($owner);
-            }
-            $linkTracker->stop();
-            $linkTracker->persist();
-            $linkTracker->clear();
+            $linkTracker->registerLinks(['tag'=>$page,'body'=>$body], false, false);
 
             // Retourne 0 seulement si tout c'est bien passe
             return 0;

--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -256,8 +256,6 @@ class Wiki
      */
     public function AppendContentToPage($content, $page, $bypass_acls = false)
     {
-        $linkTracker = $this->services->get(LinkTracker::class);
-
         // Si un contenu est specifie
         if (isset($content)) {
             // -- Determine quelle est la page :
@@ -276,7 +274,8 @@ class Wiki
             $this->SavePage($page, $body, '', $bypass_acls);
 
             // now we render it internally so we can write the updated link table.
-            $linkTracker->registerLinks(['tag'=>$page,'body'=>$body], false, false);
+            $page = $this->services->get(PageManager::class)->getOne($this->tag);
+            $this->services->get(LinkTracker::class)->registerLinks($page,false,false);
 
             // Retourne 0 seulement si tout c'est bien passe
             return 0;

--- a/includes/services/LinkTracker.php
+++ b/includes/services/LinkTracker.php
@@ -147,8 +147,10 @@ class LinkTracker
         $this->clear();
 
         if ($refreshPreviousTag) {
-            $this->wiki->tag = $previousTag;
-            $this->wiki->setPage($previousPage);
+            if (!empty($previousTag) && !empty($previousPage)){
+                $this->wiki->tag = $previousTag;
+                $this->wiki->setPage($previousPage);
+            }
             $this->wiki->SetInclusions($previousInclusions);
         }
 
@@ -157,11 +159,13 @@ class LinkTracker
 
     private function preventTrackingActions(string $body): string
     {
-        if (preg_match('/{{(?:include\s*page="|redirect\s*page="|listpages\s*tree=")([^"]*)"\\s*}}/i', $body, $matches)) {
-            $body = str_replace($matches[0], '', $body);
-            $page = $this->pageManager->getOne($matches[1]);
-            if (!empty($page)) {
-                $this->add($page["tag"]);
+        if (preg_match_all('/{{(?:include\\s*page="|redirect\\s*page="|listpages\\s*tree="|bazar [^}]*redirecturl="(?<!http:\\/\\/|https:\\/\\/))([^"]*)"\\s*[^}]*}}/i', $body, $matches)) {
+            foreach ($matches[0] as $key => $value) {
+                $body = str_replace($matches[0][$key], '', $body);
+                $page = $this->pageManager->getOne($matches[1][$key]);
+                if (!empty($page)) {
+                    $this->add($page["tag"]);
+                }
             }
         }
         return $body;
@@ -169,8 +173,10 @@ class LinkTracker
 
     private function preventNotTrackingActions(string $body): string
     {
-        if (preg_match('/{{(?:gerertheme|setwikidefaulttheme|admintag|editgroups|userstable|editconfig|gererdroits|update\\s*(?:version="[^"]*")?|listpages(?:[^}]|\\s)*))\\s*}}/i', $body, $matches)) {
-            $body = str_replace($matches[0], '', $body);
+        if (preg_match_all('/{{(?:gerertheme|setwikidefaulttheme|admintag|editgroups|userstable|editconfig|gererdroits|update\\s*(?:version="[^"]*")?|listpages(?:[^}]|\\s)*|bazarliste(?:[^}]|\\s)*|bazarcarto(?:[^}]|\\s)*|bazar(?:[^}]|\\s)*)\\s*}}/i', $body, $matches)) {
+            foreach ($matches[0] as $key => $value) {
+                $body = str_replace($matches[0][$key], '', $body);
+            }
         }
         return $body;
     }

--- a/tools/tags/handlers/page/ajaxedit.php
+++ b/tools/tags/handlers/page/ajaxedit.php
@@ -1,6 +1,7 @@
 <?php
 
 use YesWiki\Core\Service\LinkTracker;
+use YesWiki\Core\Service\PageManager;
 
 /*
 $Id: ajaxedit.php,v 1.3 2010-01-27 15:19:41 mrflos Exp $
@@ -81,7 +82,8 @@ if (isset($_GET['jsonp_callback'])) {
                         $this->SavePage($this->tag, $body);
         
                         // now we render it internally so we can write the updated link table.
-                        $this->services->get(LinkTracker::class)->registerLinks($this->page, false, false);
+                        $page = $this->services->get(PageManager::class)->getOne($this->tag);
+                        $this->services->get(LinkTracker::class)->registerLinks($page,false,false);
         
                         // on recupere le commentzire bien formatte
                         $comment = $this->LoadPage($this->tag);

--- a/tools/tags/handlers/page/ajaxedit.php
+++ b/tools/tags/handlers/page/ajaxedit.php
@@ -1,4 +1,7 @@
 <?php
+
+use YesWiki\Core\Service\LinkTracker;
+
 /*
 $Id: ajaxedit.php,v 1.3 2010-01-27 15:19:41 mrflos Exp $
 Copyright (c) 2002, Hendrik Mans <hendrik@mans.de>
@@ -78,21 +81,7 @@ if (isset($_GET['jsonp_callback'])) {
                         $this->SavePage($this->tag, $body);
         
                         // now we render it internally so we can write the updated link table.
-                        $this->ClearLinkTable();
-                        $this->StartLinkTracking();
-                        $temp = $this->SetInclusions(); // a priori, ca ne sert à rien, mais on ne sait jamais...
-                        $this->RegisterInclusion($this->GetPageTag()); // on simule totalement un affichage normal
-                        $this->Format($body);
-                        $this->SetInclusions($temp);
-                        if ($user = $this->GetUser()) {
-                            $this->TrackLinkTo($user['name']);
-                        }
-                        if ($owner = $this->GetPageOwner()) {
-                            $this->TrackLinkTo($owner);
-                        }
-                        $this->StopLinkTracking();
-                        $this->WriteLinkTable();
-                        $this->ClearLinkTable();
+                        $this->services->get(LinkTracker::class)->registerLinks($this->page, false, false);
         
                         // on recupere le commentzire bien formatte
                         $comment = $this->LoadPage($this->tag);


### PR DESCRIPTION
@mrflos en cherchant à régénérer de façon automatisée les liens entre les pages d'un wiki, je me suis rendu compte que l'action pour sauvegarder les liens d'une page d'un wiki n'était pas factorisée.

Je propose ceci au sein du LinkTracker

**Ce que ça fait**:
 - créer une méthode dans LinkTracker->registerLinks
 - ajout de deux options à cette méthode : 
   - une pour choisir de ne pas recharger la page précédent en fin de sauvegarde des liens
   - une pour permettre de sauvegarder les pages définies dans `$page['metadata']`
 - remplacement des bouts de code dans YesWiki par cette nouvelle fonction
 - il y a aussi ajout de deux fonctions dans LinkTracker pour nettoyer le contenu de la page avant rendu afin d'accélérer l'analyse

@mrflos qu'en dis-tu ?
