### PR TITLE
fix(YesWiki): better merge parameters when array is list

### DIFF
--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -1414,11 +1414,12 @@ class Wiki
      * @param $array1 the first array that is merged
      * @param $array2 the second array that give the value for indexed array
      */
-    public function replaceRecursivelyIndexedArrays(&$array1, &$array2) {
+    public function replaceRecursivelyIndexedArrays(&$array1, &$array2)
+    {
         foreach ($array2 as $key => $val) {
             if (is_array($val)) {
-                if(!$this->isAssocArray($val)) {
-                    if($array1[$key] != $val) {
+                if (!$this->isAssocArray($val)) {
+                    if(!isset($array1[$key]) || $array1[$key] != $val) {
                         $array1[$key] = $val;
                     }
                 } else {


### PR DESCRIPTION
@acheype J'ai trouvé que la fusion des paramètres entre `$wiki->config`et `$wiki->services->params` ne permettait pas de fusionner les tableaux.

**Exemple**:
 - je modifie `'admin_pages_to_update' => ['BazaR'],` ça ne fonctionne pas.
 - raison, `array_replace_recursive` pour les tableaux non associatifs va recopier les valeurs pour les clés en commun puis ajouter celles qui restent.
```php
var_dump(array_replace_recursive(['tag1','tag2','tag3','tag4'],['nouveauTag']))
```
donne
`['nouveauTag','tag2','tag3','tag4']` alors qu'en attend `['nouveauTag']`

Bien sûr ceci 
```php
var_dump(array_replace_recursive(['tag1' => 'toto','tag2' => 'tutu','tag3' => 'tata','tag4' => 'test'],['tag3' =>'nouveauTag']))
```
donne
`['tag1' => 'toto','tag2' => 'tutu','tag3' =>'nouveauTag','tag4' => 'test']` ce qui est OK pour nous.


Je propose donc de ne pas utiliser `array_replace_recursive` quand `$wiki->config`et `$wiki->services->params` sont des tableaux non associatifs.

Qu'en dis-tu .
