### PR TITLE
Fix warning when showing entry

### DIFF
--- a/handlers/page/show.php
+++ b/handlers/page/show.php
@@ -32,6 +32,9 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+use YesWiki\Bazar\Controller\EntryController;
+use YesWiki\Bazar\Service\EntryManager;
+
 // V?rification de s?curit?
 if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
@@ -82,7 +85,13 @@ if ($HasAccessRead=$this->HasAccess("read")) {
 
         // display page
         $this->RegisterInclusion($this->GetPageTag());
-        echo $this->Format($this->page['body'], 'wakka', $this->GetPageTag());
+        $entryManager = $this->services->get(EntryManager::class);
+        if ($entryManager->isEntry($this->page['tag'])) {
+            $entryController = $this->services->get(EntryController::class);
+            echo $entryController->view($tag, 0);
+        } else {
+            echo $this->Format($this->page['body'], 'wakka', $this->GetPageTag());
+        }
         $this->UnregisterLastInclusion();
     }
 } else {
@@ -117,7 +126,7 @@ if ($HasAccessRead && (!$this->page || !$this->page["comment_on"])) {
 
     // display comments!
     if ($this->page && $_SESSION["show_comments"][$tag]) {
-        // display comments header ?>
+        // display comments header?>
 		<div class="commentsheader">
 			Commentaires [<a href="<?php echo  $this->href("", "", "show_comments=0") ?>">Cacher commentaires/formulaire</a>]
 		</div>

--- a/tools/bazar/handlers/page/__show.php
+++ b/tools/bazar/handlers/page/__show.php
@@ -26,7 +26,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-use YesWiki\Bazar\Controller\EntryController;
 use YesWiki\Bazar\Service\EntryManager;
 
 if (!defined("WIKINI_VERSION")) {
@@ -34,7 +33,6 @@ if (!defined("WIKINI_VERSION")) {
 }
 
 $entryManager = $this->services->get(EntryManager::class);
-$entryController = $this->services->get(EntryController::class);
 
 if ($entryManager->isEntry($this->GetPageTag()) && $this->HasAccess("read")) {
     if (strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false || strpos($_SERVER['HTTP_ACCEPT'], 'application/ld+json') !== false) {
@@ -48,6 +46,5 @@ if ($entryManager->isEntry($this->GetPageTag()) && $this->HasAccess("read")) {
         exit(json_encode($fiche));
     } else {
         $this->AddJavascriptFile('tools/bazar/libs/bazar.js');
-        $this->page["body"] = '""'.$entryController->view($this->GetPageTag(), 0).'""';
     }
 }

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -31,6 +31,8 @@ class EntryManager
     protected $params;
     protected $searchManager;
 
+    private $cachedEntriestags ;
+
     public const TRIPLES_ENTRY_ID = 'fiche_bazar';
 
     public function __construct(
@@ -57,6 +59,7 @@ class EntryManager
         $this->params = $params;
         $this->searchManager = $searchManager;
         $this->securityController = $securityController;
+        $this->cachedEntriestags = [];
     }
 
     /**
@@ -66,7 +69,10 @@ class EntryManager
      */
     public function isEntry($tag): bool
     {
-        return !is_null($this->tripleStore->exist($tag, TripleStore::TYPE_URI, self::TRIPLES_ENTRY_ID, '', ''));
+        if (!isset($this->cachedEntriestags[$tag])) {
+            $this->cachedEntriestags[$tag] = !is_null($this->tripleStore->exist($tag, TripleStore::TYPE_URI, self::TRIPLES_ENTRY_ID, '', ''));
+        }
+        return $this->cachedEntriestags[$tag];
     }
 
     /**
@@ -558,6 +564,8 @@ class EntryManager
             $this->mailer->notifyAdmins($data, true);
         }
 
+        $this->cachedEntriestags[$data['id_fiche']] = true;
+
         return $data;
     }
 
@@ -733,6 +741,8 @@ class EntryManager
             $this->userManager->getLoggedUserName(),
             "Suppression de la page ->\"\"" . $tag . "\"\""
         );
+        
+        unset($this->cachedEntriestags[$tag]);
     }
 
     /*


### PR DESCRIPTION
#839 met en avant un warning parce que `$this->wiki->page['body']` exécuté dans toutes les actions suivantes contient le rendu de la fiche au lieu du code brut.
 - `handlers/page/show.php`
 - `tools/templates/handlers/page/show__.php`
 - `tools/tags/handlers/page/show__.php`
 - `tools/security/handlers/page/show__.php`
 - `tools/bazar/handlers/page/show__.php`

Ceci est dû au fait que `tools/bazar/handlers/page/__show.php` remplace   `$this->wiki->page['body']`  par le rendu de la fiche.
Mais à cause de l'utilisation du cache par les actions, ré-actions, post-actions `{{include}}`
Il se trouve que l'appel de `EntryManager->getOne()`(https://github.com/YesWiki/yeswiki/blob/1d3acce5186f30d09aaa5ac703e830e263fcebd9/tools/bazar/handlers/page/show__.php#L40) va charger une page avec `$page['body']` qui contient le rendu de la fiche car ce sera chargé depuis le cache (et non à partir de la base de données).

Je propose :
 - ne plus modifier `$this->wiki->page['body']` dans `tools/bazar/handlers/page/__show.php`
 - utiliser un pré formatter `tools/bazar/formatters/__WakkaFormaters.php` qui détecte le cas où on essaie de faire le rendu de la page courante et sur c'est une fiche. Celui-ci modifiera alors le texte envoyé à `formatters/wakka.php` avant que le rendu soit réalisé.
 - ajouter un cache pour `EntryManager->isEntry` afin de diminuer la charge sur la base de données (même si dans les faits, ça ne réduit le temps SQL que de 2-3 ms)
Qu'en dis-tu @mrflos ?