### PR TITLE
feat(CSP/frame-ancestors): define it in YesWikiInit

### DIFF
--- a/actions/EditConfigAction.php
+++ b/actions/EditConfigAction.php
@@ -13,6 +13,7 @@ class EditConfigAction extends YesWikiAction
         'default_language' => 'core',
         'debug' => 'core',
         'timezone' => 'core',
+        'allowed_methods_in_iframe' => 'core',
 
         'default_read_acl' => 'access',
         'default_write_acl' => 'access',

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -473,6 +473,7 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations']??[], array(
 'EDIT_CONFIG_HINT_PASSWORD_FOR_EDITING_MESSAGE' => 'Message informatif pour demander le mot de passe',
 'EDIT_CONFIG_HINT_ALLOW_DOUBLECLIC' => 'Autoriser le doubleclic pour éditer les menus et pages spéciales',
 'EDIT_CONFIG_HINT_TIMEZONE' => 'Fuseau horaire du site (ex. UCT, Europe/Paris, Europe/London, GMT = utiliser celui du serveur,)',
+'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisés à être affichées dans les iframe (all = autoriser tout)',
 'EDIT_CONFIG_GROUP_CORE' => 'Paramètres Principaux',
 'EDIT_CONFIG_GROUP_ACCESS' => "Droit d'accès",
 'EDIT_CONFIG_GROUP_EMAIL' => 'Emails',


### PR DESCRIPTION
@mrflos je propose ceci pour donner la bonne configuration de `CSP`

**Ce que ça fait**:
 - ajouter dans `YesWiniInit` les bonnes en-têtes pour `Content-Security-Policy` pour permettre l'affichage dans les iframes pour les serveurs qui ajoutent automatiquement `X-frame-options: SAMEORIGIN` ce qui est le cas pour Ynuhost
 - ajouter un paramètre dans config `allowed_methods_in_iframe` qui permet de définir la liste des méthodes autorisées (`all` = tout autoriser) ceci permet aux extensions de le modifier en fonction des handlers sui ont besoin d'être autorisés.