### PR TITLE
refact(autoupdate): use curl everywhere in autoupdate

### DIFF
--- a/tools/autoupdate/app/Files.php
+++ b/tools/autoupdate/app/Files.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace AutoUpdate;
 
 class Files
@@ -65,10 +66,9 @@ class Files
         return false;
     }
 
-    protected function download($sourceUrl)
+    public function download($sourceUrl, $destPath = null, $returnContent = false)
     {
-        $this->downloadedFile = tempnam(realpath('cache'), $this::PREFIX_FILENAME);
-        //file_put_contents($this->downloadedFile, fopen($sourceUrl, 'r'));
+        $this->downloadedFile = $destPath ?? tempnam(realpath('cache'), $this::PREFIX_FILENAME);
         $ch = curl_init($sourceUrl);
         $fp = fopen($this->downloadedFile, 'wb');
         curl_setopt($ch, CURLOPT_FILE, $fp);
@@ -76,6 +76,9 @@ class Files
         curl_exec($ch);
         curl_close($ch);
         fclose($fp);
+        if ($returnContent === true) {
+            return file_get_contents($this->downloadedFile);
+        }
     }
 
     private function isWritableFolder($path)

--- a/tools/autoupdate/app/Files.php
+++ b/tools/autoupdate/app/Files.php
@@ -68,16 +68,26 @@ class Files
 
     public function download($sourceUrl, $destPath = null, $returnContent = false)
     {
-        $this->downloadedFile = $destPath ?? tempnam(realpath('cache'), $this::PREFIX_FILENAME);
-        $ch = curl_init($sourceUrl);
-        $fp = fopen($this->downloadedFile, 'wb');
-        curl_setopt($ch, CURLOPT_FILE, $fp);
-        curl_setopt($ch, CURLOPT_HEADER, 0);
-        curl_exec($ch);
-        curl_close($ch);
-        fclose($fp);
-        if ($returnContent === true) {
-            return file_get_contents($this->downloadedFile);
+        try {
+            $this->downloadedFile = $destPath;
+            if ($this->downloadedFile !== null) {
+                $fp = fopen($this->downloadedFile, 'wb');
+            } else {
+                $fp = tmpfile();
+                $metaData = stream_get_meta_data($fp);
+                $this->downloadedFile = $metaData["uri"];
+            }
+            $ch = curl_init($sourceUrl);
+            curl_setopt($ch, CURLOPT_FILE, $fp);
+            curl_setopt($ch, CURLOPT_HEADER, 0);
+            curl_exec($ch);
+            curl_close($ch);
+            if ($returnContent === true) {
+                return file_get_contents($this->downloadedFile);
+            }
+            fclose($fp);
+        } catch (Throwable $t) {
+            return $t;
         }
     }
 

--- a/tools/autoupdate/app/Files.php
+++ b/tools/autoupdate/app/Files.php
@@ -68,27 +68,23 @@ class Files
 
     public function download($sourceUrl, $destPath = null, $returnContent = false)
     {
-        try {
-            $this->downloadedFile = $destPath;
-            if ($this->downloadedFile !== null) {
-                $fp = fopen($this->downloadedFile, 'wb');
-            } else {
-                $fp = tmpfile();
-                $metaData = stream_get_meta_data($fp);
-                $this->downloadedFile = $metaData["uri"];
-            }
-            $ch = curl_init($sourceUrl);
-            curl_setopt($ch, CURLOPT_FILE, $fp);
-            curl_setopt($ch, CURLOPT_HEADER, 0);
-            curl_exec($ch);
-            curl_close($ch);
-            if ($returnContent === true) {
-                return file_get_contents($this->downloadedFile);
-            }
-            fclose($fp);
-        } catch (Throwable $t) {
-            return $t;
+        $this->downloadedFile = $destPath;
+        if ($this->downloadedFile !== null) {
+            $fp = fopen($this->downloadedFile, 'wb');
+        } else {
+            $fp = tmpfile();
+            $metaData = stream_get_meta_data($fp);
+            $this->downloadedFile = $metaData["uri"];
         }
+        $ch = curl_init($sourceUrl);
+        curl_setopt($ch, CURLOPT_FILE, $fp);
+        curl_setopt($ch, CURLOPT_HEADER, 0);
+        curl_exec($ch);
+        curl_close($ch);
+        if ($returnContent === true) {
+            return file_get_contents($this->downloadedFile);
+        }
+        fclose($fp);
     }
 
     private function isWritableFolder($path)

--- a/tools/autoupdate/app/Package.php
+++ b/tools/autoupdate/app/Package.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace AutoUpdate;
 
 abstract class Package extends Files
 {
-    const PREFIX_FILENAME = 'yeswiki_';
+    public const PREFIX_FILENAME = 'yeswiki_';
 
     // URL vers le fichier dans le dépôt.
     protected $address;
@@ -106,7 +107,7 @@ abstract class Package extends Files
             throw new \Exception("Le paquet n'a pas été téléchargé.", 1);
         }
 
-        $zip = new \ZipArchive;
+        $zip = new \ZipArchive();
         if (true !== $zip->open($this->downloadedFile)) {
             return false;
         }
@@ -141,21 +142,18 @@ abstract class Package extends Files
 
     private function getMD5()
     {
-        $disMd5File = file_get_contents($this->address . '.md5');
+        $disMd5File = $this->download(
+            $this->address . '.md5',
+            'cache/temp-'.$this->name().'.md5',
+            true
+        );
         return explode(' ', $disMd5File)[0];
     }
 
     private function downloadFile($sourceUrl)
     {
         $this->downloadedFile = tempnam(realpath('cache'), $this::PREFIX_FILENAME);
-        //file_put_contents($this->downloadedFile, fopen($sourceUrl, 'r'));
-        $ch = curl_init($sourceUrl);
-        $fp = fopen($this->downloadedFile, 'wb');
-        curl_setopt($ch, CURLOPT_FILE, $fp);
-        curl_setopt($ch, CURLOPT_HEADER, 0);
-        curl_exec($ch);
-        curl_close($ch);
-        fclose($fp);
+        return $this->download($sourceUrl, $this->downloadedFile);
     }
 
     protected function updateAvailable()

--- a/tools/autoupdate/app/Package.php
+++ b/tools/autoupdate/app/Package.php
@@ -144,7 +144,7 @@ abstract class Package extends Files
     {
         $disMd5File = $this->download(
             $this->address . '.md5',
-            'cache/temp-'.$this->name().'.md5',
+            null,
             true
         );
         return explode(' ', $disMd5File)[0];
@@ -152,7 +152,7 @@ abstract class Package extends Files
 
     private function downloadFile($sourceUrl)
     {
-        $this->downloadedFile = tempnam(realpath('cache'), $this::PREFIX_FILENAME);
+        $this->downloadedFile = null;
         return $this->download($sourceUrl, $this->downloadedFile);
     }
 

--- a/tools/autoupdate/app/Repository.php
+++ b/tools/autoupdate/app/Repository.php
@@ -22,11 +22,10 @@ class Repository extends PackageCollection
         if (filter_var($this->address, FILTER_VALIDATE_URL) === false) {
             return false;
         }
-        $localRepoFile = 'cache/repository-packages.json';
         $repoInfosFile = $this->address . $this::INDEX_FILENAME;
         $data = $this->fileHandler->download(
             $repoInfosFile,
-            $localRepoFile,
+            null,
             true
         );
         $data = json_decode($data, true);

--- a/tools/autoupdate/app/Repository.php
+++ b/tools/autoupdate/app/Repository.php
@@ -1,15 +1,18 @@
 <?php
+
 namespace AutoUpdate;
 
 class Repository extends PackageCollection
 {
-    const INDEX_FILENAME = 'packages.json';
+    public const INDEX_FILENAME = 'packages.json';
 
     private $address;
+    private $fileHandler;
 
     public function __construct($address)
     {
         $this->address = $address . '/';
+        $this->fileHandler = new \AutoUpdate\Files();
     }
 
     public function load()
@@ -19,20 +22,18 @@ class Repository extends PackageCollection
         if (filter_var($this->address, FILTER_VALIDATE_URL) === false) {
             return false;
         }
-
+        $localRepoFile = 'cache/repository-packages.json';
         $repoInfosFile = $this->address . $this::INDEX_FILENAME;
-
-        if (($repoInfos = @file_get_contents($repoInfosFile)) === false) {
-            return false;
-        }
-
-        $data = json_decode($repoInfos, true);
+        $data = $this->fileHandler->download(
+            $repoInfosFile,
+            $localRepoFile,
+            true
+        );
+        $data = json_decode($data, true);
 
         if (is_null($data)) {
             return false;
         }
-
-
 
         foreach ($data as $packageInfos) {
             if (!isset($packageInfos['description'])) {


### PR DESCRIPTION
## Description of pull request / Description de la demande d'ajout

Use only curl to download and extract content in autoupdate tool.
I quickly checked for other file_get_content() in the wiki code, it seems to me that all other references are local ones, so no problem!

Issue references (if exists)/ Demande associée (si elle existe)
cf. Nicolas Geigeir sur le tchat Mattermost
