### PR TITLE
Use config default language

### DIFF
--- a/includes/i18n.inc.php
+++ b/includes/i18n.inc.php
@@ -125,6 +125,15 @@ function detectPreferedLanguage($wiki, $available_languages, $http_accept_langua
     // sanitize parameters
     $getLang = (isset($_GET['lang']) && in_array($_GET['lang'], $available_languages)) ? $_GET['lang'] : '';
 
+    $pageMetadataLang = "";
+    if ($page!='') {
+        // page's metadata lang
+        $wiki->metadatas = $wiki->GetMetaDatas($page);
+        if (isset($wiki->metadatas['lang']) && in_array($wiki->metadatas['lang'], $available_languages)) {
+            $pageMetadataLang = $wiki->metadatas['lang'];
+        }
+    }
+
     // first priority
     if (!empty($getLang)) {
         return $getLang;
@@ -169,17 +178,6 @@ function detectPreferedLanguage($wiki, $available_languages, $http_accept_langua
         return $postConfigLang;
     }
 
-    $pageMetadataLang = "";
-    if ($page!='') {
-        // page's metadata lang
-        $wiki->metadatas = $wiki->GetTripleValue($page, 'http://outils-reseaux.org/_vocabulary/metadata', '', '', '');
-        if (!empty($wiki->metadatas)) {
-            $wiki->metadatas =  json_decode($wiki->metadatas, true);
-        }
-        if (isset($wiki->metadatas['lang']) && in_array($wiki->metadatas['lang'], $available_languages)) {
-            $pageMetadataLang = $wiki->metadatas['lang'];
-        }
-    }
     // default language from config file
     $configLang = !empty($wiki) && isset($wiki->config['default_language']) && in_array($wiki->config['default_language'], $available_languages)
         ? $wiki->config['default_language'] : '';

--- a/includes/i18n.inc.php
+++ b/includes/i18n.inc.php
@@ -165,13 +165,13 @@ function detectPreferedLanguage($wiki, $available_languages, $http_accept_langua
         if (isset($wiki->metadatas['lang']) && in_array($wiki->metadatas['lang'], $available_languages)) {
             return $wiki->metadatas['lang'];
         }
-        if ($http_accept_language == "auto") {
-            // if $http_accept_language was left out, read it from the HTTP-Header of the browser
-            $http_accept_language = isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
-        }
         // default language from config file
         if ((empty($http_accept_language) || $http_accept_language == "auto") && isset($wiki->config['default_language']) && in_array($wiki->config['default_language'], $available_languages)) {
             return $wiki->config['default_language'];
+        }
+        if ($http_accept_language == "auto") {
+            // if $http_accept_language was left out, read it from the HTTP-Header of the browser
+            $http_accept_language = isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
         }
     } elseif ($http_accept_language == "auto") {
         // if $http_accept_language was left out, read it from the HTTP-Header of the browser

--- a/includes/i18n.inc.php
+++ b/includes/i18n.inc.php
@@ -122,10 +122,16 @@ function detectAvailableLanguages()
  */
 function detectPreferedLanguage($wiki, $available_languages, $http_accept_language = "auto", $page = '')
 {
-    if (isset($_GET['lang']) && in_array($_GET['lang'], $available_languages)) {
-        // first choice : if lang changed in url
-        return $_GET['lang'];
-    } elseif (isset($_POST["config"])) {
+    // sanitize parameters
+    $getLang = (isset($_GET['lang']) && in_array($_GET['lang'], $available_languages)) ? $_GET['lang'] : '';
+
+    // first priority
+    if (!empty($getLang)) {
+        return $getLang;
+    }
+
+    $postConfigLang = '' ;
+    if (isset($_POST["config"])) {
         // just for installation
         if (count($_POST["config"])==1) {
             if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
@@ -150,33 +156,47 @@ function detectPreferedLanguage($wiki, $available_languages, $http_accept_langua
                 $conf = unserialize($_POST["config"]);
             }
             if (isset($conf['default_language']) && in_array($conf['default_language'], $available_languages)) {
-                return $conf['default_language'];
+                $postConfigLang = $conf['default_language'];
             }
         } elseif (isset($_POST["config"]['default_language'])
             && in_array($_POST["config"]['default_language'], $available_languages)) {
-            return $_POST["config"]['default_language'];
+            $postConfigLang = $_POST["config"]['default_language'];
         }
-    } elseif ($page!='') {
+    }
+
+    // second priority
+    if (!empty($postConfigLang)) {
+        return $postConfigLang;
+    }
+
+    $pageMetadataLang = "";
+    if ($page!='') {
         // page's metadata lang
         $wiki->metadatas = $wiki->GetTripleValue($page, 'http://outils-reseaux.org/_vocabulary/metadata', '', '', '');
         if (!empty($wiki->metadatas)) {
             $wiki->metadatas =  json_decode($wiki->metadatas, true);
         }
         if (isset($wiki->metadatas['lang']) && in_array($wiki->metadatas['lang'], $available_languages)) {
-            return $wiki->metadatas['lang'];
+            $pageMetadataLang = $wiki->metadatas['lang'];
         }
-        // default language from config file
-        if ((empty($http_accept_language) || $http_accept_language == "auto") && isset($wiki->config['default_language']) && in_array($wiki->config['default_language'], $available_languages)) {
-            return $wiki->config['default_language'];
-        }
-        if ($http_accept_language == "auto") {
-            // if $http_accept_language was left out, read it from the HTTP-Header of the browser
-            $http_accept_language = isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
-        }
-    } elseif ($http_accept_language == "auto") {
-        // if $http_accept_language was left out, read it from the HTTP-Header of the browser
-        $http_accept_language = isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
     }
+    // default language from config file
+    $configLang = !empty($wiki) && isset($wiki->config['default_language']) && in_array($wiki->config['default_language'], $available_languages)
+        ? $wiki->config['default_language'] : '';
+
+    $httpAcceptLang = ($http_accept_language !== "auto") ? $http_accept_language: (isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '');
+
+    // third priority
+    if (!empty($pageMetadataLang)) {
+        return $pageMetadataLang;
+    }
+
+    // fourth priority if 'auto' or other word not representing an available lang, allow usage of http_accept_language
+    if (!empty($configLang)) {
+        return $configLang;
+    }
+
+    // fifth priority 'httpAcceptLang'
 
     // standard  for HTTP_ACCEPT_LANGUAGE is defined under
     // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
@@ -189,7 +209,7 @@ function detectPreferedLanguage($wiki, $available_languages, $http_accept_langua
     preg_match_all(
         "/([[:alpha:]]{1,8})(-([[:alpha:]|-]{1,8}))?"
         ."(\s*;\s*q\s*=\s*(1\.0{0,3}|0\.\d{0,3}))?\s*(,|$)/i",
-        $http_accept_language,
+        $httpAcceptLang,
         $hits,
         PREG_SET_ORDER
     );

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -247,6 +247,7 @@ $GLOBALS['translations'] = array_merge($GLOBALS['translations']??[], array(
 'CHECK_YOUR_CONFIG_INFORMATION_BELOW' => 'Veuillez revoir vos informations de configuration ci-dessous',
 'FILL_THE_FORM_BELOW' => 'Veuillez compl&eacute;ter le formulaire suivant',
 'DEFAULT_LANGUAGE' => 'Langue par d&eacute;faut',
+'NAVIGATOR_LANGUAGE' => 'Langue du navigateur',
 'DEFAULT_LANGUAGE_INFOS' => 'Langue utilis&eacute;e par d&eacute;faut pour l\'interface de YesWiki, il sera toujours possible de changer de langue pour chacune des pages cr&eacute;&eacute;es',
 'GENERAL_CONFIGURATION' => 'Configuration générale',
 'DATABASE_CONFIGURATION' => 'Base de donn&eacute;es',

--- a/setup/default.php
+++ b/setup/default.php
@@ -78,9 +78,9 @@ if (!defined('WIKINI_VERSION')) {
             <select required autocomplete="off" class="form-control" name="config[default_language]" onchange="$(this).parents('.form-yeswiki-install').attr('action', '<?php echo  myLocation() ?>?installAction=default&lang='+$(this).val()).submit();">
                 <?php
                 foreach ($GLOBALS['available_languages'] as $value) {
-                    echo '<option value="'.$value.'"'.(($value == $GLOBALS['prefered_language']) ? ' selected="selected"' : '').'>'.ucfirst(htmlentities($GLOBALS['languages_list'][$value]['nativeName'], ENT_COMPAT | ENT_HTML401, 'UTF-8'))."</option>\n";
+                    echo '<option value="'.$value.'"'.(($value == $GLOBALS['prefered_language'] && $_GET['lang'] !== 'auto') ? ' selected="selected"' : '').'>'.ucfirst(htmlentities($GLOBALS['languages_list'][$value]['nativeName'], ENT_COMPAT | ENT_HTML401, 'UTF-8'))."</option>\n";
                 }
-                echo "<option value=\"auto\">_t('NAVIGATOR_LANGUAGE')</option>\n";
+                echo "<option value=\"auto\"".($_GET['lang'] === 'auto' ? ' selected="selected"' : '').">"._t('NAVIGATOR_LANGUAGE')."</option>\n";
                 ?>
             </select>
           </div>

--- a/setup/default.php
+++ b/setup/default.php
@@ -80,6 +80,7 @@ if (!defined('WIKINI_VERSION')) {
                 foreach ($GLOBALS['available_languages'] as $value) {
                     echo '<option value="'.$value.'"'.(($value == $GLOBALS['prefered_language']) ? ' selected="selected"' : '').'>'.ucfirst(htmlentities($GLOBALS['languages_list'][$value]['nativeName'], ENT_COMPAT | ENT_HTML401, 'UTF-8'))."</option>\n";
                 }
+                echo "<option value=\"auto\">_t('NAVIGATOR_LANGUAGE')</option>\n";
                 ?>
             </select>
           </div>


### PR DESCRIPTION
Permettre l'usage de paramètre `default_language` dans le fichier de config 
+ permettre de le mettre à 'auto' pour choisir d'utiliser la langue du navigateur.

petit refactor de `detectPreferedLanguage` pour faciliter le choix des priorités

