### PR TITLE
feat(translation/js): use cache via api

### DIFF
--- a/includes/controllers/ApiController.php
+++ b/includes/controllers/ApiController.php
@@ -38,7 +38,7 @@ class ApiController extends YesWikiController
         $output .= '<h2>'._t('PAGES').'</h2>'."\n".
             'GET <code><a href="'.$urlPages.'">'.$urlPages.'</a></code><br />';
 
-        $urlTranslationJs = $this->wiki->Href('', 'api/translations/js');
+        $urlTranslationJs = $this->wiki->Href('', 'api/translations');
         $output .= '<h2>'._t('TRANSLATION_FOR_JS').'</h2>'."\n".
             'GET <code><a href="'.$urlTranslationJs.'">'.$urlTranslationJs.'</a></code><br />';
 
@@ -171,7 +171,7 @@ class ApiController extends YesWikiController
     }
 
     /**
-     * @Route("/api/translations/js", methods={"GET"}, options={"acl":{"public"}})
+     * @Route("/api/translations", methods={"GET"}, options={"acl":{"public"}})
      */
     public function getTranslationJs()
     {

--- a/includes/controllers/ApiController.php
+++ b/includes/controllers/ApiController.php
@@ -38,6 +38,10 @@ class ApiController extends YesWikiController
         $output .= '<h2>'._t('PAGES').'</h2>'."\n".
             'GET <code><a href="'.$urlPages.'">'.$urlPages.'</a></code><br />';
 
+        $urlTranslationJs = $this->wiki->Href('', 'api/translations/js');
+        $output .= '<h2>'._t('TRANSLATION_FOR_JS').'</h2>'."\n".
+            'GET <code><a href="'.$urlTranslationJs.'">'.$urlTranslationJs.'</a></code><br />';
+
         // TODO use annotations to document the API endpoints
         $extensions = $this->wiki->extensions;
         foreach ($this->wiki->extensions as $extension => $pluginBase) {
@@ -164,5 +168,31 @@ class ApiController extends YesWikiController
         $errors = ob_get_contents();
         ob_end_clean();
         return new ApiResponse((empty($errors) ? [] : ['errors' => $errors])+$page);
+    }
+
+    /**
+     * @Route("/api/translations/js", methods={"GET"}, options={"acl":{"public"}})
+     */
+    public function getTranslationJs()
+    {
+        try {
+            ob_start(); // to catch error messages
+            $errormsg = ob_get_contents();
+            header_remove('Cache-Control');
+            header_remove('pragma');
+            ob_end_clean();
+            return new ApiResponse(
+                ['translation'=>$GLOBALS['translations_js'] ?? []],
+                Response::HTTP_OK,
+                [
+                    'Cache-Control' => [
+                        'public',
+                        'max-age=10800' // 3h
+                    ]
+                ]
+            );
+        } catch (\Exception $e) {
+            return new ApiResponse($e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/javascripts/yeswiki-base-no-defer.js
+++ b/javascripts/yeswiki-base-no-defer.js
@@ -3,7 +3,7 @@ function _t(message,replacements = {}){
     // init translation
     if (wiki.lang !== null && typeof wiki.lang === "object" && Object.keys(wiki.lang) == 0){
         try {
-            let translation = $.ajax({method:"GET",url:wiki.url("api/translations/js",{lang:wiki.locale}),async:false,cache:true}).responseJSON.translation;
+            let translation = $.ajax({method:"GET",url:wiki.url("api/translations",{lang:wiki.locale}),async:false,cache:true}).responseJSON.translation;
             if (translation !== null && typeof translation === "object" && Object.keys(translation) != 0){
                 wiki.lang = translation;
             }

--- a/javascripts/yeswiki-base-no-defer.js
+++ b/javascripts/yeswiki-base-no-defer.js
@@ -1,5 +1,15 @@
 
 function _t(message,replacements = {}){
+    // init translation
+    if (wiki.lang !== null && typeof wiki.lang === "object" && Object.keys(wiki.lang) == 0){
+        try {
+            let translation = $.ajax({method:"GET",url:wiki.url("api/translations/js",{lang:wiki.locale}),async:false,cache:true}).responseJSON.translation;
+            if (translation !== null && typeof translation === "object" && Object.keys(translation) != 0){
+                wiki.lang = translation;
+            }
+        } catch (error) {
+        }
+    }
     var translation = wiki.lang[message] ?? null ;
     if (!translation){
         translation = message;

--- a/lang/yeswiki_ca.php
+++ b/lang/yeswiki_ca.php
@@ -388,6 +388,7 @@ return [
     // API
     // 'USERS' => 'Utilisateurs',
     // 'GROUPS' => 'Groupes',
+    // 'TRANSLATION_FOR_JS' => 'Traductions pour le javascript',
 
     // YesWiki\User class
     // 'USER_CONFIRM_DELETE' => 'Êtes-vous sûr·e de vouloir supprimer l’utilisateur·ice ?',

--- a/lang/yeswiki_en.php
+++ b/lang/yeswiki_en.php
@@ -380,6 +380,7 @@ return [
     // API
     'USERS' => 'Users',
     'GROUPS' => 'Groups',
+    'TRANSLATION_FOR_JS' => 'Translations for javascript',
     
     // YesWiki\User class
     'USER_DELETE_QUERY_FAILED' => 'User deletion query failed',

--- a/lang/yeswiki_es.php
+++ b/lang/yeswiki_es.php
@@ -390,6 +390,7 @@ return [
     // API
     // 'USERS' => 'Utilisateurs',
     // 'GROUPS' => 'Groupes',
+    // 'TRANSLATION_FOR_JS' => 'Traductions pour le javascript',
 
     // YesWiki\User class
     // 'USER_CONFIRM_DELETE' => 'Êtes-vous sûr·e de vouloir supprimer l’utilisateur·ice ?',

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -386,6 +386,7 @@ return [
     // API
     'USERS' => 'Utilisateurs',
     'GROUPS' => 'Groupes',
+    'TRANSLATION_FOR_JS' => 'Traductions pour le javascript',
 
     // YesWiki\User class
     'USER_CONFIRM_DELETE' => 'Êtes-vous sûr·e de vouloir supprimer l’utilisateur·ice ?',

--- a/lang/yeswiki_nl.php
+++ b/lang/yeswiki_nl.php
@@ -387,6 +387,7 @@ return [
     // API
     // 'USERS' => 'Utilisateurs',
     // 'GROUPS' => 'Groupes',
+    // 'TRANSLATION_FOR_JS' => 'Traductions pour le javascript',
 
     // YesWiki\User class
     // 'USER_CONFIRM_DELETE' => 'Êtes-vous sûr·e de vouloir supprimer l’utilisateur·ice ?',

--- a/lang/yeswiki_pt.php
+++ b/lang/yeswiki_pt.php
@@ -388,6 +388,7 @@ return [
     // API
     // 'USERS' => 'Utilisateurs',
     // 'GROUPS' => 'Groupes',
+    // 'TRANSLATION_FOR_JS' => 'Traductions pour le javascript',
 
     // YesWiki\User class
     // 'USER_CONFIRM_DELETE' => 'Êtes-vous sûr·e de vouloir supprimer l’utilisateur·ice ?',

--- a/tools/templates/actions/linkjavascript.php
+++ b/tools/templates/actions/linkjavascript.php
@@ -90,10 +90,7 @@ echo "<script>
         ...{
     locale: '{$GLOBALS['prefered_language']}',
     baseUrl: '{$this->config['base_url']}',
-    lang: {
-        ...((typeof wiki !== 'undefined') ? (wiki.lang ?? null) : null),
-        ...".json_encode($GLOBALS['translations_js'] ?? null)."
-    },
+    lang: ((typeof wiki !== 'undefined') ? (wiki.lang ?? {}) : {}),
     pageTag: '{$this->getPageTag()}',
     isDebugEnabled: ".($this->GetConfigValue('debug') =='yes' ? 'true' : 'false')."
 }};


### PR DESCRIPTION
permettre de mettre en cache les 15 ko correspond aux traductions pour le javascript plutôt que de les recopier en bas de chaque page

**Ce que ça fait**:
 - nouvelle route api `GET` `api/translation`
 - modifier la méthode javascript `_t()` pour charger lors de son premier appel les données de traduction via `$.ajax({async:false})` 
 - attention particulière dans l'api pour définir les bonnes en-têtes permettant le cache pendant 3h

**Remarque**:
 - génère une ligne dans la console js car il y a usage synchrone de `xhr` ce qui est un comportement déprécié