### PR TITLE
fix(call of ->header): make it after rendering content

### DIFF
--- a/actions/linkstyle__.php
+++ b/actions/linkstyle__.php
@@ -4,6 +4,13 @@ if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
 }
 
+// This GLOBALS is populated from AddCSS and AddCSSFile, we add it at the end
+// Be careful to render Header AFTER rendering actions
+// do not use YesWiki:AddCSSFile(), YesWiki:LinkCSSFile() or YesWiki:AddCSS() in custom/linkstyle__.php (it will not work)
+if (isset($GLOBALS['css']) && !empty($GLOBALS['css'])) {
+    echo $GLOBALS['css'];
+}
+
 // if exists and not empty, add the 'PageCss' yeswiki page to the styles
 // (the PageCss content must respect the CSS syntax)
 // Same reason than for GLOBALS, we include it so we are sure it's included at the end

--- a/handlers/IframeHandler.php
+++ b/handlers/IframeHandler.php
@@ -5,11 +5,9 @@ use YesWiki\Core\YesWikiHandler;
 
 class IframeHandler extends YesWikiHandler
 {
-    function run()
+    public function run()
     {
-        // on recupere les entetes html mais pas ce qu'il y a dans le body
-        $header = explode('<body', $this->wiki->Header());
-        $output = $header[0];
+        $output = '';
 
         if ($this->wiki->HasAccess("read")) {
             $entryManager = $this->wiki->services->get(EntryManager::class);
@@ -56,6 +54,11 @@ class IframeHandler extends YesWikiHandler
         }
         $output .= '</div><!-- end .container -->' . "\n";
         $this->wiki->AddJavascriptFile('tools/templates/libs/vendor/iframeResizer.contentWindow.min.js');
+
+        
+        // on recupere les entetes html mais pas ce qu'il y a dans le body
+        $header = explode('<body', $this->wiki->Header());
+        $output = $header[0].$output;
         // on recupere juste les javascripts et la fin des balises body et html
         $output .= preg_replace('/^.+<script/Us', '<script', $this->wiki->Footer());
 

--- a/handlers/UpdateHandler.php
+++ b/handlers/UpdateHandler.php
@@ -16,9 +16,6 @@ class UpdateHandler extends YesWikiHandler
         };
 
         $output = '';
-        if (empty($this->wiki->config['is_cli']) || $this->wiki->config['is_cli'] !== true) {
-            $output = $this->wiki->header();
-        }
 
         if ($this->wiki->UserIsAdmin()) {
             $output .= '<strong>YesWiki core</strong><br />';
@@ -82,8 +79,8 @@ class UpdateHandler extends YesWikiHandler
         // BE CAREFULL this comment is used for extensions to add content above, don't delete it!
         $output .= '<!-- end handler /update -->';
 
-
         if (empty($this->wiki->config['is_cli']) || $this->wiki->config['is_cli'] !== true) {
+            $output = $this->wiki->header().$output;
             // add button to return to previous page
             $output .= '<div>
                 <a class="btn btn-sm btn-secondary-1" href="'.$this->wiki->Href().'">

--- a/handlers/page/edit.php
+++ b/handlers/page/edit.php
@@ -112,7 +112,7 @@ if ($this->HasAccess('write') && $this->HasAccess('read') && !$isWikiHibernated)
 
                     // now we render it internally so we can write the updated link table.
                     $page = $this->services->get(PageManager::class)->getOne($this->tag);
-                    $this->services->get(LinkTracker::class)->registerLinks($page,false,false);
+                    $this->services->get(LinkTracker::class)->registerLinks($page, false, false);
 
                     // forward
                     if ($this->page['comment_on']) {
@@ -159,18 +159,18 @@ if ($this->HasAccess('write') && $this->HasAccess('read') && !$isWikiHibernated)
     }
 }
 
-// Header
-if (!testUrlInIframe()) {
-    echo $this->Header();
-}
-
 // Main Page
-echo '<div class="page">'."\n".$output."\n".'<hr class="hr_clear" />'."\n".'</div>'."\n";
+$output = '<div class="page">'."\n".$output."\n".'<hr class="hr_clear" />'."\n".'</div>'."\n";
 
 // Popups for aceditor toolbar
+ob_start();
 include 'tools/aceditor/actions/actions_builder.php';
+$output .= ob_get_contents();
+ob_end_clean();
 
-// Footer
+// Header - // Footer
 if (!testUrlInIframe()) {
-    echo $this->Footer();
+    echo $this->Header().$output.$this->Footer();
+} else {
+    echo $output;
 }

--- a/handlers/page/render.php
+++ b/handlers/page/render.php
@@ -1,9 +1,6 @@
 <?php
 
-$output = '';
-// on recupere les entetes html mais pas ce qu'il y a dans le body
-$header = explode('<body', $this->Header());
-$output .= $header[0] . '<body class="yeswiki-render">'."\n"
+$output = '<body class="yeswiki-render">'."\n"
     .'<div class="container">'."\n"
     .'<div class="yeswiki-page-widget page-widget page" '.$this->Format('{{doubleclic iframe="1"}}').'>'."\n";
 
@@ -11,6 +8,11 @@ $this->page['body'] = strip_tags($_GET['content']); // fake Page for actions and
 
 $output .= $this->Format($this->page['body']);
 $output .= '</div><!-- end .page-widget -->'."\n";
+// ajout des en-têtes en pieds de page
+
+// on recupere les entetes html mais pas ce qu'il y a dans le body
+$header = explode('<body', $this->Header());
+$output = $header[0].$output ;
 // on recupere juste les javascripts et la fin des balises body et html
 $output .= preg_replace('/^.+<script/Us', '<script', $this->Footer());
 echo $output;

--- a/includes/controllers/ApiController.php
+++ b/includes/controllers/ApiController.php
@@ -22,9 +22,7 @@ class ApiController extends YesWikiController
      */
     public function getDocumentation()
     {
-        $output = $this->wiki->Header();
-
-        $output .= '<h1>YesWiki API</h1>';
+        $output = '<h1>YesWiki API</h1>';
 
         $urlUser = $this->wiki->Href('', 'api/user');
         $output .= '<h2>'._t('USERS').'</h2>'."\n".
@@ -65,7 +63,7 @@ class ApiController extends YesWikiController
             }
         }
 
-        $output .= $this->wiki->Footer();
+        $output = $this->wiki->Header().$output.$this->wiki->Footer();
 
         return new Response($output);
     }

--- a/includes/services/TemplateEngine.php
+++ b/includes/services/TemplateEngine.php
@@ -108,11 +108,10 @@ class TemplateEngine
 
     public function renderInSquelette($templatePath, $data = [])
     {
-        $result = '';
-        $result .= $this->wiki->Header();
-        $result .= '<div class="page">';
+        $result = '<div class="page">';
         $result .= $this->render($templatePath, $data);
         $result .= '</div>';
+        $result = $this->wiki->Header().$result;
         $result .= $this->wiki->Footer();
         return $result;
     }

--- a/tools/attach/handlers/page/filemanager.php
+++ b/tools/attach/handlers/page/filemanager.php
@@ -39,7 +39,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 if (!WIKINI_VERSION) {
     die("acc&egrave;s direct interdit");
 }
-echo $this->Header();
+ob_start();
 ?>
 <div class="page">
 <?php
@@ -51,8 +51,11 @@ if ($this->UserIsOwner()) {
     $att->doFilemanager();
     unset($att);
 } else {
-    echo $this->Format("//".t('FILEMANAGER_ACTION_NEED_ACCESS')."//");
+    echo $this->Format("//"._t('FILEMANAGER_ACTION_NEED_ACCESS')."//");
 }
 ?>
 </div>
-<?php echo $this->Footer(); ?>
+<?php
+$output = ob_get_contents();
+ob_end_clean();
+echo $this->Header().$output.$this->Footer(); ?>

--- a/tools/attach/handlers/page/upload.php
+++ b/tools/attach/handlers/page/upload.php
@@ -39,7 +39,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 if (!WIKINI_VERSION) {
     die("acc&egrave;s direct interdit");
 }
-echo $this->Header();
+ob_start();
 ?>
 <div class="page">
 <?php
@@ -52,4 +52,7 @@ $att->doUpload();
 unset($att);
 ?>
 </div>
-<?php echo $this->Footer(); ?>
+<?php
+$output = ob_get_contents();
+ob_end_clean();
+echo $this->Header().$output.$this->Footer(); ?>

--- a/tools/bazar/handlers/BazarIframeHandler.php
+++ b/tools/bazar/handlers/BazarIframeHandler.php
@@ -6,9 +6,7 @@ class BazarIframeHandler extends YesWikiHandler
 {
     public function run()
     {
-        // on recupere les entetes html mais pas ce qu'il y a dans le body
-        $header = explode('<body', $this->wiki->Header());
-        $output = $header[0];
+        $output = '';
 
         if ($this->wiki->HasAccess("read")) {
             if (empty($_GET['id'])) {
@@ -48,6 +46,11 @@ class BazarIframeHandler extends YesWikiHandler
         $output .= '</div>';
 
         $this->wiki->AddJavascriptFile('tools/templates/libs/vendor/iframeResizer.contentWindow.min.js');
+
+        
+        // on recupere les entetes html mais pas ce qu'il y a dans le body
+        $header = explode('<body', $this->wiki->Header());
+        $output = $header[0].$output;
         // on recupere juste les javascripts et la fin des balises body et html
         $output .= preg_replace('/^.+<script/Us', '<script', $this->wiki->Footer());
 

--- a/tools/bazar/handlers/__EditHandler.php
+++ b/tools/bazar/handlers/__EditHandler.php
@@ -14,15 +14,16 @@ class __EditHandler extends YesWikiHandler
         $entryController = $this->getService(EntryController::class);
 
         if ($this->wiki->HasAccess('write') && $entryManager->isEntry($this->wiki->GetPageTag())) {
+            $this->output = '<div class="page">';
             ob_start();
-            $this->output = $this->wiki->Header();
-            $this->output .= '<div class="page">';
             $this->output .= $this->isWikiHibernated()
                 ? $this->getMessageWhenHibernated()
                 : $entryController->update($this->wiki->GetPageTag());
             $this->output .= ob_get_contents();
             ob_end_clean();
             $this->output .= '</div>';
+            
+            $this->output = $this->wiki->Header().$this->output;
             $this->output .= $this->wiki->Footer();
 
             // we use die so that the script stop there and the default handler of wiki isn't called

--- a/tools/bazar/handlers/__WidgetHandler.php
+++ b/tools/bazar/handlers/__WidgetHandler.php
@@ -17,7 +17,7 @@ class __WidgetHandler extends YesWikiHandler
 
         $this->wiki->AddJavascriptFile('tools/bazar/libs/bazar.js');
 
-        echo $this->wiki->Header();
+        ob_start();
         echo '<div class="page">';
         echo '<h1>' . _t('BAZ_WIDGET_HANDLER_TITLE') . '</h1>' . "\n";
 
@@ -63,7 +63,9 @@ class __WidgetHandler extends YesWikiHandler
         ]);
 
         echo '</div>';
-        echo $this->wiki->Footer();
+        $output = ob_get_contents();
+        ob_end_clean();
+        echo $this->wiki->Header().$output.$this->wiki->Footer();
         exit();
     }
 };

--- a/tools/helloworld/controllers/ApiController.php
+++ b/tools/helloworld/controllers/ApiController.php
@@ -24,9 +24,8 @@ class ApiController extends YesWikiController
      */
     public function onlineDoc()
     {
-        $output = $this->wiki->Header();
-        $output .= $this->getDocumentation() ;
-        $output .= $this->wiki->Footer();
+        $output = $this->getDocumentation();
+        $output = $this->wiki->Header().$output.$this->wiki->Footer();
 
         return new Response($output);
     }

--- a/tools/templates/actions/linkjavascript.php
+++ b/tools/templates/actions/linkjavascript.php
@@ -102,11 +102,3 @@ echo "<script>
 
 // on affiche
 echo $yeswiki_javascripts;
-
-// This GLOBALS is populated from AddCSS and AddCSSFile, we add it at the end
-// It would be better to add it in linkstyles, but the problem is that actions are
-// called within WIKINI_PAGE, which is executed AFTER linkstyles (see squelette)
-// so we add the style after javascript, in the body instead of in the head
-if (isset($GLOBALS['css']) && !empty($GLOBALS['css'])) {
-    echo $GLOBALS['css'];
-}

--- a/tools/templates/handlers/page/diaporama.php
+++ b/tools/templates/handlers/page/diaporama.php
@@ -14,9 +14,7 @@ if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
 }
 
-// on recupere les entetes html mais pas ce qu'il y a dans le body
-$header =  explode('<body', $this->Header());
-echo str_replace('<html', '<html class="slideshow-html"', $header[0])."<body class=\"slideshow-body\">\n";
+ob_start();
 
 // on regarde si un template est passe en parametre GET, on passe celui par defaut sinon
 if (isset($_GET['template']) && file_exists(realpath('tools/templates/presentation/templates/'.$_GET['template']))) {
@@ -27,6 +25,14 @@ if (isset($_GET['template']) && file_exists(realpath('tools/templates/presentati
 
 // fonction de generation du diaporama (teste les droits et l'existence de la page)
 echo print_diaporama($this->tag, $template);
+
+$output = ob_get_contents();
+ob_end_clean();
+
+// on recupere les entetes html mais pas ce qu'il y a dans le body
+$header =  explode('<body', $this->Header());
+echo str_replace('<html', '<html class="slideshow-html"', $header[0])."<body class=\"slideshow-body\">\n";
+echo $output;
 
 // on recupere juste les javascripts et la fin des balises body et html
 $footer =  preg_replace('/^.+<script/Us', "\n".'<script', $this->Footer());

--- a/tools/templates/handlers/page/show__.php
+++ b/tools/templates/handlers/page/show__.php
@@ -26,8 +26,7 @@ if (isset($GLOBALS['template-error']) && $GLOBALS['template-error']['type'] == '
 
 if (!$this->HasAccess('read')) {
     if ($contenu = $this->LoadPage("PageLogin")) {
-        $output = $this->Header();
-        $output .= '<body class="login-body">'."\n"
+        $output = '<body class="login-body">'."\n"
             .'<div class="container">'."\n"
             .'<div class="yeswiki-page-widget page-widget page" '.$this->Format('{{doubleclic iframe="1"}}').'>'."\n";
         $output .= '<div class="alert alert-danger alert-error">'.
@@ -36,6 +35,7 @@ if (!$this->HasAccess('read')) {
         $output .= $this->Format($contenu["body"]);
         $output .= '</div><!-- end .page-widget -->' . "\n";
         $output .= '</div><!-- end .container -->' . "\n";
+        $output = $this->Header().$output;
         $output .= $this->Footer();
     } else {
         // sinon on affiche le formulaire d'identification minimal


### PR DESCRIPTION
Je fais la proposition de déplacer les liens css dans le header plutôt qu'en fin de body.
(c'est pour éviter d'avoir du rendu qui change après le chargement et exécution du javascript).

**Ce que ça fait**:
 - déplacer la création des liens css à la fin de linkstyle__
 - vérifier que tous les appels de `$this->header()` se font bien APRES avoir réalisé le rendu du contenu

J'ai besoin de testeurs d'où le côté draft. Et de retours sur le principe de cette PR.

Qu'en dis-tu @mrflos ?

J'ai ajouté le tag not_urgent
