### PR TITLE
More secure fields

### DIFF
--- a/tools/bazar/fields/PasswordField.php
+++ b/tools/bazar/fields/PasswordField.php
@@ -15,6 +15,7 @@ class PasswordField extends BazarField
 
         $this->type = 'password';
         $this->maxChars = $this->maxChars ?? 255;
+        $this->readAccess = empty($this->readAccess) ? '%' : str_replace(['!*','*'], ['%','%'], $this->readAccess); // not public
     }
 
     public function formatValuesBeforeSave($entry)

--- a/tools/bazar/fields/PasswordField.php
+++ b/tools/bazar/fields/PasswordField.php
@@ -15,7 +15,9 @@ class PasswordField extends BazarField
 
         $this->type = 'password';
         $this->maxChars = $this->maxChars ?? 255;
-        $this->readAccess = empty($this->readAccess) ? '%' : str_replace(['!*','*'], ['%','%'], $this->readAccess); // not public
+        // Here, we force not to use public read acces for password (not empty, not presence of *)
+        // because, the field is not rendered and it is not waited to see it in api, or bazar templates like tablea.twig
+        $this->readAccess = empty($this->readAccess) ? '%' : str_replace(['!*','*'], ['%','%'], $this->readAccess);
     }
 
     public function formatValuesBeforeSave($entry)

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -865,11 +865,8 @@ class EntryManager
             if ($tabcorrespondances['fail'] != 1) {
                 foreach ($tabcorrespondances as $key => $data) {
                     if (isset($key)) {
-                        if (isset($data) && isset($fiche[$data])) {
-                            $fiche[$key] = $fiche[$data];
-                        } else {
-                            $fiche[$key] = '';
-                        }
+                        // not possible to init the Guard in the constructor because of circular reference problem
+                        $fiche[$key] = $this->wiki->services->get(Guard::class)->isFieldDataAuthorizedForCorrespondance($page, $fiche, $data);
                     } else {
                         echo '<div class="alert alert-danger">'._t('BAZ_CORRESPONDANCE_ERROR').'</div>';
                     }

--- a/tools/bazar/services/Guard.php
+++ b/tools/bazar/services/Guard.php
@@ -138,4 +138,29 @@ class Guard
         }
         return false;
     }
+
+    /**
+     * sanitize data for correspondance
+     * @param null|array $page
+     * @param null|array $entry
+     * @param string $fieldName
+     * @return $value value or empty string
+     */
+    public function isFieldDataAuthorizedForCorrespondance(?array $page, ?array $entry, $fieldName)
+    {
+        if (!$this->wiki->UserIsAdmin()
+                && !$this->isPageOwner($page)
+                && !empty($fieldName)
+                && isset($entry[$fieldName])
+                && !empty($entry['id_typeannonce'])) {
+            $formId = $entry['id_typeannonce'];
+            if (strval($formId) == strval(intval($formId))) {
+                $field = $this->formManager->findFieldFromNameOrPropertyName($fieldName, $formId);
+                if (!empty($field) && $field instanceof EmailField && $field->getShowContactForm()) {
+                    return '';
+                }
+            }
+        }
+        return (empty($fieldName) || !isset($entry[$fieldName])) ? "" : $entry[$fieldName];
+    }
 }

--- a/tools/bazar/services/Guard.php
+++ b/tools/bazar/services/Guard.php
@@ -154,11 +154,9 @@ class Guard
                 && isset($entry[$fieldName])
                 && !empty($entry['id_typeannonce'])) {
             $formId = $entry['id_typeannonce'];
-            if (strval($formId) == strval(intval($formId))) {
-                $field = $this->formManager->findFieldFromNameOrPropertyName($fieldName, $formId);
-                if (!empty($field) && $field instanceof EmailField && $field->getShowContactForm()) {
-                    return '';
-                }
+            $field = $this->formManager->findFieldFromNameOrPropertyName($fieldName, $formId);
+            if (!empty($field) && $field instanceof EmailField && $field->getShowContactForm()) {
+                return '';
             }
         }
         return (empty($fieldName) || !isset($entry[$fieldName])) ? "" : $entry[$fieldName];


### PR DESCRIPTION
**PR en DRAFT** pour discussion préliminaire

@acheype j'ai remarqué des fuites de données éventuelles pour la partie "correspondance" et pour le champ Mot de passe
Je propose un peu de code pour montrer l'idée d'un correctif mais nous pouvons partir vers une autre solution.

**Contexte et proposition**:
 - le champ mot de passe n'affiche jamais le mot de passe mais si l'admin du wiki a mis les droits de lecture de ce champ en public ou vide, les `templates` bazar ont accès à la valeur (en md5) et peuvent l'afficher sans vérification (sauf s'ils passent pas `$field->renderStaticIfPermitted`) du coup, je propose que par défaut, il ne soit pas possible pour ce champ d'avoir la valeur `*` dans les acls (ainsi l'api ne dévoile pas ce champ s'il est en public, api en mode public, si propriétaire de la donnée, ou admin, c'est bon)
  - le paramètre `correspondance` de `EntryManager` permet d'envoyer les données d'un champ accessible en lecture vers un autre champ. Ceci ne pose pas de souci SAUF pour le champ e-mail qui, dans le cas de l'affichage par bouton, est accessible en lecture mais l'idée est de ne pas dévoiler l'e-mail. en utilisant `correspondance` il est possible de contourner cette restriction. Je propose de créer une nouvelle méthode dans le `Guard` pour prévenir ce souci.
  
 @acheype as-tu besoin d'autres informations pour comprendre mon intention et le problème rencontré ? 
 Que penses-tu de la solution proposée ? (n'hésite pas à faire des propositions d'amélioration des performances)
 si tu n'as pas le temps pour cette PR sous une semaine, je verrai si Florian peut prendre le relais à ta place.
 
 merci en tout cas pour ton aide.