### PR TITLE
Action builder checkboxes

### DIFF
--- a/docs/actions/README.md
+++ b/docs/actions/README.md
@@ -101,7 +101,6 @@ Paramètres optionels : `checkedvalue` `uncheckedvalue`. Par défault la valeur 
 modal:
   label: Affichage d'une fenêtre modale lors du clic
   type: checkbox
-  default: 0
   checkedvalue: 1
   uncheckedvalue: 0
 ```
@@ -168,3 +167,25 @@ mydivider:
   label: Un titre
   type: divider
 ```
+
+### default vs value
+Ils vont tous les deux servir à initialiser une valeur.
+La différence étant que si on utilise `default`, alors si la valeur est égale à `default` le paramètre
+sera masqué dans le wiki code généré
+Généralement on utilisera donc `default` afin d'éviter les code wiki à rallonge
+
+```
+modal:
+  label: Affichage d'une fenêtre modale lors du clic
+  type: checkbox
+  default: true
+```
+-> checkbox cochée par default, et le code généré ne contiendra pas le param modal si il est égal à true, mais contiendra `modal="false"` si on décoche
+
+```
+modal:
+  label: Affichage d'une fenêtre modale lors du clic
+  type: checkbox
+  value: true
+```
+-> checkbox cochée par default, et le code généré contiendra quoiqu'il arrive soit `modal="true"` soit `modal="false"`

--- a/tools/aceditor/presentation/javascripts/actions-builder.js
+++ b/tools/aceditor/presentation/javascripts/actions-builder.js
@@ -216,7 +216,7 @@ window.myapp = new Vue({
       for(let key in this.values) {
         let config = this.selectedActionAllConfigs[key]
         let value = this.values[key]
-        if (result.hasOwnProperty(key) || value === undefined 
+        if (result.hasOwnProperty(key) || value === undefined || config && config.default && value === config.default
             || typeof value == "object" || config && !this.checkConfigDisplay(config) ) 
           continue
         result[key] = value

--- a/tools/aceditor/presentation/javascripts/actions-builder.js
+++ b/tools/aceditor/presentation/javascripts/actions-builder.js
@@ -216,7 +216,7 @@ window.myapp = new Vue({
       for(let key in this.values) {
         let config = this.selectedActionAllConfigs[key]
         let value = this.values[key]
-        if (result.hasOwnProperty(key) || value === undefined || config && config.default && value === config.default
+        if (result.hasOwnProperty(key) || value === undefined || config && config.default && `${value}` == `${config.default}`
             || typeof value == "object" || config && !this.checkConfigDisplay(config) ) 
           continue
         result[key] = value

--- a/tools/aceditor/presentation/javascripts/components/InputCheckbox.js
+++ b/tools/aceditor/presentation/javascripts/components/InputCheckbox.js
@@ -1,28 +1,35 @@
 export default {
   props: [ 'value', 'config' ],
-  computed: {
-    customValue: {
-      get() {
-        let result = this.value
-        if (this.config.checkedvalue) {
-          result = this.value == this.config.checkedvalue
-        }
-        if (result == "false") result = false
-        return result
-      },
-      set(newValue) {
-        if (this.config.checkedvalue) {
-          newValue = newValue ? this.config.checkedvalue : this.config.uncheckedvalue
-        }
-        this.$emit('input', newValue)
-      }
+  data() {
+    return {
+      // boolean internal value cause the real value could be a string when using checkedvalue and uncheckedvalue
+      checked: undefined
+    }
+  },
+  mounted() {
+    if (this.value === undefined) {
+      // if no value, we initialize to false, the the param will be correctly set 
+      // i.e. myparam="false" or myparam="0" if uncheckvalue is defined
+      this.checked = false
+    }
+    else {
+      if (this.config.checkedvalue) this.checked = this.value == this.config.checkedvalue
+      else this.checked = this.value
+    }
+  },
+  watch: {
+    checked() {
+      let result
+      if (this.config.checkedvalue) result = this.checked ? this.config.checkedvalue : this.config.uncheckedvalue
+      else result = this.checked
+      this.$emit('input', result)
     }
   },
   template: `
     <div class="form-group input-group checkbox" :title="config.hint" >
       <addon-icon :config="config" v-if="config.icon"></addon-icon>
       <label>
-        <input type="checkbox" v-model="customValue" />
+        <input type="checkbox" v-model="checked" />
         <span>{{ config.label }}</span>
       </label>
       <input-hint :config="config"></input-hint>

--- a/tools/aceditor/presentation/javascripts/components/InputCheckbox.js
+++ b/tools/aceditor/presentation/javascripts/components/InputCheckbox.js
@@ -13,8 +13,10 @@ export default {
       this.checked = false
     }
     else {
-      if (this.config.checkedvalue) this.checked = this.value == this.config.checkedvalue
-      else this.checked = this.value
+      // Cast values to string before compare, because in yaml we might use boolean or number, but
+      // wikicode will always use strings
+      let checkedvalue = this.config.checkedvalue || "true"
+      this.checked = `${this.value}` == `${checkedvalue}`
     }
   },
   watch: {


### PR DESCRIPTION
Voilà un fix pour pouvoir mettre par default les checkboxes

Et aussi un fix pour cacher les param lorsque la valeur est égale à la valeur par default
donc en gros `default` et `value` permettent d'initialiser la valeur de base, mais si `default` est utilisé, alors le params est caché lorsqu'il est égal à la valeur par default

Voilà quelques exemples pour illustrer le comportement

```yaml
filter:
  label: Activer filtre
  type: checkbox
```
- [ ] Activer filtre
`filter="false"`
**-> je coche**
- [x] Activer filtre
`filter="true"`

### Avec default: false

```yaml
filter:
  label: Activer filtre
  type: checkbox
  default: false
```
- [ ] Activer filtre
` ` <- le param est caché dans le code généré
**-> je coche**
- [x] Activer filtre
`filter="true"`

### Avec default: true

```yaml
filter:
  label: Activer filtre
  type: checkbox
  default: true
```
- [x] Activer filtre
` ` <- le param est caché
**-> je décoche**
- [ ] Activer filtre
`filter="false"`

### Avec value: true
la checkbox est initialisée cochée, mais le params est toujours affiché
```yaml
filter:
  label: Activer filtre
  type: checkbox
  value: true
```
- [x] Activer filtre
`filter="true"`
**-> je décoche**
- [ ] Activer filtre
`filter="false"`

---

Voilà et tout ça fonctionne avec `ceckedvalue` et `uncheckvalue`

J'espère que ça répond au besoin @mrflos @acheype @J9rem ?







