### PR TITLE
Csrftokenmanager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "symfony/yaml": "^5.1",
         "tamtamchik/simple-flash": "^2.0",
         "twig/twig": "^3.0",
-        "yeswiki/theme-margot": "dev-master"
+        "yeswiki/theme-margot": "dev-master",
+        "symfony/security-csrf": "^5.0"
     },
     "conflict": {
         "psr/cache": ">=2.0",
@@ -45,6 +46,8 @@
         "symfony/error-handler": ">=6.0",
         "symfony/event-dispatcher": ">=6.0",
         "symfony/filesystem": ">=6.0",
+        "symfony/password-hasher": ">=6.0",
+        "symfony/security-core": ">=6.0",
         "symfony/string": ">=6.0"
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "215040317134baa2df64f1754c381c80",
+    "content-hash": "5fe1db9baef4f17aaa55a1aa32d1d0ad",
     "packages": [
         {
             "name": "caxy/php-htmldiff",
@@ -1713,6 +1713,79 @@
             "time": "2022-01-29T18:08:07+00:00"
         },
         {
+            "name": "symfony/password-hasher",
+            "version": "v5.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/password-hasher.git",
+                "reference": "b5ed59c4536d8386cd37bb86df2b7bd5fbbd46d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/password-hasher/zipball/b5ed59c4536d8386cd37bb86df2b7bd5fbbd46d4",
+                "reference": "b5ed59c4536d8386cd37bb86df2b7bd5fbbd46d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "conflict": {
+                "symfony/security-core": "<5.3"
+            },
+            "require-dev": {
+                "symfony/console": "^5",
+                "symfony/security-core": "^5.3|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PasswordHasher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robin Chalas",
+                    "email": "robin.chalas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides password hashing utilities",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "hashing",
+                "password"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/password-hasher/tree/v5.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-02T09:53:40+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.24.0",
             "source": {
@@ -1825,12 +1898,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1906,12 +1979,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -2070,12 +2143,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -2149,12 +2222,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -2232,12 +2305,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -2356,6 +2429,171 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/routing/tree/v5.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-02T09:53:40+00:00"
+        },
+        {
+            "name": "symfony/security-core",
+            "version": "v5.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-core.git",
+                "reference": "b26a44457a4d1a60c79f1c23273e812c4077ce85"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/b26a44457a4d1a60c79f1c23273e812c4077ce85",
+                "reference": "b26a44457a4d1a60c79f1c23273e812c4077ce85",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/event-dispatcher-contracts": "^1.1|^2|^3",
+                "symfony/password-hasher": "^5.3|^6.0",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1.6|^2|^3"
+            },
+            "conflict": {
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/http-foundation": "<5.3",
+                "symfony/ldap": "<4.4",
+                "symfony/security-guard": "<4.4",
+                "symfony/validator": "<5.2"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "psr/container": "^1.0|^2.0",
+                "psr/log": "^1|^2|^3",
+                "symfony/cache": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/expression-language": "^4.4|^5.0|^6.0",
+                "symfony/http-foundation": "^5.3|^6.0",
+                "symfony/ldap": "^4.4|^5.0|^6.0",
+                "symfony/translation": "^4.4|^5.0|^6.0",
+                "symfony/validator": "^5.2|^6.0"
+            },
+            "suggest": {
+                "psr/container-implementation": "To instantiate the Security class",
+                "symfony/event-dispatcher": "",
+                "symfony/expression-language": "For using the expression voter",
+                "symfony/http-foundation": "",
+                "symfony/ldap": "For using LDAP integration",
+                "symfony/validator": "For using the user password constraint"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Core\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - Core Library",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-core/tree/v5.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-02T09:53:40+00:00"
+        },
+        {
+            "name": "symfony/security-csrf",
+            "version": "v5.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-csrf.git",
+                "reference": "57c1c252ca756289c2b61327e08fb10be3936956"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/57c1c252ca756289c2b61327e08fb10be3936956",
+                "reference": "57c1c252ca756289c2b61327e08fb10be3936956",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/security-core": "^4.4|^5.0|^6.0"
+            },
+            "conflict": {
+                "symfony/http-foundation": "<5.3"
+            },
+            "require-dev": {
+                "symfony/http-foundation": "^5.3|^6.0"
+            },
+            "suggest": {
+                "symfony/http-foundation": "For using the class SessionTokenStorage."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Csrf\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - CSRF Library",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-csrf/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -2851,12 +3089,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/YesWiki/yeswiki-theme-margot.git",
-                "reference": "0c9fc2d4155dad994656637db0ee3df7bc12f23c"
+                "reference": "06b61539b7ec0d3f3d19bfb527c22e4e41689672"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/YesWiki/yeswiki-theme-margot/zipball/0c9fc2d4155dad994656637db0ee3df7bc12f23c",
-                "reference": "0c9fc2d4155dad994656637db0ee3df7bc12f23c",
+                "url": "https://api.github.com/repos/YesWiki/yeswiki-theme-margot/zipball/06b61539b7ec0d3f3d19bfb527c22e4e41689672",
+                "reference": "06b61539b7ec0d3f3d19bfb527c22e4e41689672",
                 "shasum": ""
             },
             "require": {
@@ -2873,9 +3111,9 @@
             ],
             "support": {
                 "issues": "https://github.com/YesWiki/yeswiki-theme-margot/issues",
-                "source": "https://github.com/YesWiki/yeswiki-theme-margot/tree/master"
+                "source": "https://github.com/YesWiki/yeswiki-theme-margot/tree/margot-fun"
             },
-            "time": "2022-01-27T18:06:16+00:00"
+            "time": "2022-02-08T11:31:22+00:00"
         }
     ],
     "packages-dev": [
@@ -3121,16 +3359,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+                "reference": "15a90844ad40f127afd244c0cad228de2a80052a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/15a90844ad40f127afd244c0cad228de2a80052a",
+                "reference": "15a90844ad40f127afd244c0cad228de2a80052a",
                 "shasum": ""
             },
             "require": {
@@ -3166,9 +3404,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.1.0"
+                "source": "https://github.com/phar-io/version/tree/3.1.1"
             },
-            "time": "2021-02-23T14:00:09+00:00"
+            "time": "2022-02-07T21:56:48+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3777,11 +4015,11 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
                     "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4324,16 +4562,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.3",
+            "version": "5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
+                "reference": "19c519631c5a511b7ed0ad64a6713fdb3fd25fe4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/19c519631c5a511b7ed0ad64a6713fdb3fd25fe4",
+                "reference": "19c519631c5a511b7ed0ad64a6713fdb3fd25fe4",
                 "shasum": ""
             },
             "require": {
@@ -4376,7 +4614,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.4"
             },
             "funding": [
                 {
@@ -4384,7 +4622,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-11T13:31:12+00:00"
+            "time": "2022-02-10T07:01:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",

--- a/docs/csrf.md
+++ b/docs/csrf.md
@@ -22,11 +22,25 @@ CRSF (Cross-site request forgery) is a method of web attack in one click describ
    use Symfony\Component\Security\Csrf\CsrfTokenManager;
    ...
    $csrfTokenManager = $this->wiki->services->get(CsrfTokenManager::class);
-   $token = new CsrfToken('tokenId', filter_input(INPUT_POST,'token', FILTER_SANITIZE_STRING));
+   $token = new CsrfToken('tokenId', filter_input(INPUT_POST,'tokenNameInForm', FILTER_SANITIZE_STRING));
    // replace 'token' by the used name in form's input
    if ($csrfTokenManager->isTokenValid($token)) {
        ...
        $csrfTokenManager->removeToken('tokenId'); // remove it if you want only one usage
+   }
+   ```
+
+   or with a controller throwing `TokenNotFoundException` :
+   ```
+   use Symfony\Component\Security\Csrf\Exception\TokenNotFoundException;
+   use YesWiki\Core\Controller\CsrfTokenController;
+   $csrfTokenController = $this->wiki->services->get(CsrfTokenController::class);
+   try {
+      $csrfTokenController->checkTockenThenRemove('tokenId', 'POST', 'tokenNameInForm');
+      ... code if OK
+   } catch (TokenNotFoundException $th) {
+      $errorMessage = $th->getMessage();
+      ... // code if not OK
    }
    ```
 

--- a/docs/csrf.md
+++ b/docs/csrf.md
@@ -8,14 +8,17 @@ CRSF (Cross-site request forgery) is a method of web attack in one click describ
 
 `symfony/security-csrf` is used to manage tokens needed to prevent csrf. It is installed bt default with composer and `YesWiki::loadExtensions()`.
 
- 1. Get a token and use it into the concerned form or link for dangerous actions reserved to admins or owners (like `deletepage`, delete a user, change password)
+ 1. Get a token and use it into the concerned form or link for any action that may alter data (create/update/delete) and that needs acl validation (like `deletepage`, delete a user, change password)
     - in php code, get a token with this code for example :
     ```
     use Symfony\Component\Security\Csrf\CsrfTokenManager;
     ...
     $token = $this->wiki->services->get(CsrfTokenManager::class)->getToken('tokenId');
     ```
-    - in `twig` template, use `{{ crsfToken('tokenId') }}`
+    - in `twig` template, use `{{ crsfToken('tokenId') }}`. Example for a form (twig):
+    ```
+    <input type="hiden" name="tokenNameInForm" value="{{ crsfToken('tokenId')|e('html_attr') }}">
+    ```
  2. when processing a request with the token, check if it is right inspiring of this example :
    ```
    use Symfony\Component\Security\Csrf\CsrfToken;
@@ -36,7 +39,7 @@ CRSF (Cross-site request forgery) is a method of web attack in one click describ
    use YesWiki\Core\Controller\CsrfTokenController;
    $csrfTokenController = $this->wiki->services->get(CsrfTokenController::class);
    try {
-      $csrfTokenController->checkTockenThenRemove('tokenId', 'POST', 'tokenNameInForm');
+      $csrfTokenController->checkTocken('tokenId', 'POST', 'tokenNameInForm');
       ... code if OK
    } catch (TokenNotFoundException $th) {
       $errorMessage = $th->getMessage();

--- a/docs/csrf.md
+++ b/docs/csrf.md
@@ -33,9 +33,13 @@ CRSF (Cross-site request forgery) is a method of web attack in one click describ
 ## Refreshing a token
 
 You can refresh a token to delete its previous value and replace it by a new one.
+ - in PHP
 ```
 $token = $this->wiki->services->get(CsrfTokenManager::class)->refreshToken('tokenId');
 ```
+ -  in `twig` template, use `{{ crsfToken({id:'tokenId',refresh:true}) }}`;
+```
+
 Previous token will be considered as invalid after calling `refreshToken`.
 
 ## Rules to name 'tokenId'

--- a/handlers/page/deletepage.php
+++ b/handlers/page/deletepage.php
@@ -70,7 +70,7 @@ if ($this->UserIsOwner() || $this->UserIsAdmin()) {
             $msg .= "</form></span>\n";
         } else {
             try {
-                $csrfTokenController->checkTockenThenRemove("handler\deletepage\\$tag", 'POST', 'crsf-token');
+                $csrfTokenController->checkTocken("handler\deletepage\\$tag", 'POST', 'crsf-token');
 
                 $this->DeleteOrphanedPage($tag);
                 $this->LogAdministrativeAction($this->GetUserName(), "Suppression de la page ->\"\"" . $tag . "\"\"");
@@ -93,7 +93,7 @@ if ($this->UserIsOwner() || $this->UserIsAdmin()) {
             && ($_GET['confirme'] === 'oui')) {
             // a trouble occured, invald token ?
             try {
-                $csrfTokenController->checkTockenThenRemove("handler\deletepage\\{$this->tag}", 'POST', 'crsf-token');
+                $csrfTokenController->checkTocken("handler\deletepage\\{$this->tag}", 'POST', 'crsf-token');
             } catch (TokenNotFoundException $th) {
                 $msg .= $this->render("@templates/alert-message.twig", [
                     'type' => 'danger',

--- a/includes/YesWikiInit.php
+++ b/includes/YesWikiInit.php
@@ -44,6 +44,7 @@ use Symfony\Component\Routing\Loader\AnnotationClassLoader;
 use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Security\Csrf\CsrfTokenManager;
 
 // TODO put elsewhere
 // https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/src/Routing/AnnotatedRouteControllerLoader.php
@@ -310,6 +311,7 @@ class Init
 
         $containerBuilder->set(Wiki::class, $wiki);
         $containerBuilder->set(ParameterBagInterface::class, $containerBuilder->getParameterBag());
+        $containerBuilder->set(CsrfTokenManager::class, new CsrfTokenManager());
 
         $loader = new YamlFileLoader($containerBuilder, new FileLocator(__DIR__));
         $loader->load('services.yaml');

--- a/includes/controllers/CsrfTokenController.php
+++ b/includes/controllers/CsrfTokenController.php
@@ -20,14 +20,16 @@ class CsrfTokenController extends YesWikiController
 
     /**
      * check if token is present and valid in input
-     * throw TokenNotFoundException or Exception
      *
      * @param string $name
      * @param string $inputType "GET" or "POST"
      * @param string $inputKey key in the input to use
      * @return bool
+     *
+     * @throws TokenNotFoundException
+     * @throws Exception
      */
-    public function checkTockenThenRemove(string $name, string $inputType, string $inputKey): bool
+    public function checkTocken(string $name, string $inputType, string $inputKey): bool
     {
         if (empty($name)) {
             throw new Exception("parameter `\$name` should not be empty !");

--- a/includes/controllers/CsrfTokenController.php
+++ b/includes/controllers/CsrfTokenController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace YesWiki\Core\Controller;
+
+use Exception;
+use Symfony\Component\Security\Csrf\Exception\TokenNotFoundException;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManager;
+use YesWiki\Core\YesWikiController;
+
+class CsrfTokenController extends YesWikiController
+{
+    protected $csrfTokenManager;
+
+    public function __construct(
+        CsrfTokenManager $csrfTokenManager
+    ) {
+        $this->csrfTokenManager = $csrfTokenManager;
+    }
+
+    /**
+     * check if token is present and valid in input
+     * throw TokenNotFoundException or Exception
+     *
+     * @param string $name
+     * @param string $inputType "GET" or "POST"
+     * @param string $inputKey key in the input to use
+     * @return bool
+     */
+    public function checkTockenThenRemove(string $name, string $inputType, string $inputKey): bool
+    {
+        if (empty($name)) {
+            throw new Exception("parameter `\$name` should not be empty !");
+        }
+        switch ($inputType) {
+            case 'GET':
+                $inputToken = filter_input(INPUT_GET, $inputKey, FILTER_SANITIZE_STRING);
+                break;
+
+            case 'POST':
+                $inputToken = filter_input(INPUT_POST, $inputKey, FILTER_SANITIZE_STRING);
+                break;
+            
+            default:
+                throw new Exception("Unknown type for parameter `\$inputType` !");
+                return false;
+        }
+        if (is_null($inputToken) || $inputToken === false) {
+            throw new TokenNotFoundException(_t('NO_CSRF_TOKEN_ERROR'));
+        }
+        $token = new CsrfToken($name, $inputToken);
+        $isValid = $this->csrfTokenManager->isTokenValid($token);
+        $this->csrfTokenManager->removeToken($name);
+        if (!$isValid) {
+            throw new TokenNotFoundException(_t('CSRF_TOKEN_FAIL_ERROR'));
+        }
+        return true;
+    }
+}

--- a/includes/services.yaml
+++ b/includes/services.yaml
@@ -19,3 +19,6 @@ services:
 
   YesWiki\Core\Service\:
     resource: 'services/*'
+
+  YesWiki\Core\Controller\:
+    resource: 'controllers/*'

--- a/includes/services.yaml
+++ b/includes/services.yaml
@@ -9,6 +9,10 @@ services:
     synthetic: true
 
   # Manually set inside the initCoreService method
+  Symfony\Component\Security\Csrf\CsrfTokenManager:
+    synthetic: true
+
+  # Manually set inside the initCoreService method
   # TODO remove this object when refactoring will be finished
   YesWiki\Wiki:
     synthetic: true

--- a/includes/services/TemplateEngine.php
+++ b/includes/services/TemplateEngine.php
@@ -3,6 +3,7 @@
 namespace YesWiki\Core\Service;
 
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use YesWiki\Wiki;
 
 class TemplateNotFound extends \Exception
@@ -15,11 +16,17 @@ class TemplateEngine
     protected $twigLoader;
     protected $twig;
     protected $assetsManager;
+    protected $csrfTokenManager;
 
-    public function __construct(Wiki $wiki, ParameterBagInterface $config, AssetsManager $assetsManager)
-    {
+    public function __construct(
+        Wiki $wiki,
+        ParameterBagInterface $config,
+        AssetsManager $assetsManager,
+        CsrfTokenManager $csrfTokenManager
+    ) {
         $this->wiki = $wiki;
         $this->assetsManager = $assetsManager;
+        $this->csrfTokenManager = $csrfTokenManager;
         // Default path (main namespace) is the root of the project. There are no templates
         // there, but it's needed to call relative path like render('tools/bazar/templates/...')
         $this->twigLoader = new \Twig\Loader\FilesystemLoader('./');
@@ -97,6 +104,9 @@ class TemplateEngine
         });
         $this->addTwigHelper('include_css', function ($file) {
             $this->assetsManager->AddCSSFile($file);
+        });
+        $this->addTwigHelper('crsfToken', function ($tokenId) {
+            $this->csrfTokenManager->getToken($tokenId);
         });
     }
 

--- a/includes/services/TemplateEngine.php
+++ b/includes/services/TemplateEngine.php
@@ -2,6 +2,7 @@
 
 namespace YesWiki\Core\Service;
 
+use Exception;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use YesWiki\Wiki;
@@ -106,7 +107,21 @@ class TemplateEngine
             $this->assetsManager->AddCSSFile($file);
         });
         $this->addTwigHelper('crsfToken', function ($tokenId) {
-            $this->csrfTokenManager->getToken($tokenId);
+            if (is_string($tokenId)) {
+                return $this->csrfTokenManager->getToken($tokenId);
+            } elseif (is_array($tokenId)) {
+                if (!isset($tokenId['id'])) {
+                    throw new Exception("When array, `\$tokenId` should contain `id` key !");
+                } else {
+                    if (isset($tokenId['refresh']) && $tokenId['refresh'] === true) {
+                        return $this->csrfTokenManager->grefreshToken($tokenId['id']);
+                    } else {
+                        return $this->csrfTokenManager->getToken($tokenId['id']);
+                    }
+                }
+            } else {
+                throw new Exception("`\$tokenId` should be a string or an array !");
+            }
         });
     }
 

--- a/lang/yeswiki_ca.php
+++ b/lang/yeswiki_ca.php
@@ -530,6 +530,7 @@ return [
     // 'DELETEPAGE_NOT_ORPHEANED' => 'Cette page n\'est pas orpheline.',
     // 'DELETEPAGE_NOT_OWNER' => 'Vous n\'&ecirc;tes pas le propri&eacute;taire de cette page.',
     // 'DELETEPAGE_PAGES_WITH_LINKS_TO' => 'Pages ayant un lien vers {tag} :',
+    'DELETEPAGE_NOT_DELETED' => 'La pàgina no s\'ha suprimit.',
 
     // handlers/edit
     // 'EDIT_ALERT_ALREADY_SAVED_BY_ANOTHER_USER' => 'ALERTE : '.

--- a/lang/yeswiki_ca.php
+++ b/lang/yeswiki_ca.php
@@ -269,6 +269,12 @@ return [
     // actions/wantedpages.php
     'NO_PAGE_TO_CREATE' => 'No hi ha cap pàgina per crear',
 
+    // includes/controllers/CrsfController.php
+    'NO_CSRF_TOKEN_ERROR' => 'Error de disseny del lloc: el formulari d\'enviament no contenia el testimoni '.
+        'd\'identificació únic necessari per als mecanismes de seguretat interns.',
+    'CSRF_TOKEN_FAIL_ERROR' => 'Pot ser que aquesta pàgina s\'hagi obert per segona vegada. '.
+        'Si us plau, renoveu la sol·licitud des d\'aquesta finestra (el testimoni de seguretat intern no era bo).',
+
     // setup/header.php
     'OK' => 'D\'acord',
     'FAIL' => 'Error',

--- a/lang/yeswiki_en.php
+++ b/lang/yeswiki_en.php
@@ -491,6 +491,7 @@ return [
     'DELETEPAGE_NOT_ORPHEANED' => 'This page is not orpheaned.',
     'DELETEPAGE_NOT_OWNER' => 'You are not owner of this page.',
     'DELETEPAGE_PAGES_WITH_LINKS_TO' => 'Pages with a link to {tag} :',
+    'DELETEPAGE_NOT_DELETED' => 'Not deleted page.',
 
     // handlers/edit
     'EDIT_ALERT_ALREADY_SAVED_BY_ANOTHER_USER' => 'ALERT : '.

--- a/lang/yeswiki_en.php
+++ b/lang/yeswiki_en.php
@@ -266,6 +266,12 @@ return [
     
     // actions/wantedpages.php
     'NO_PAGE_TO_CREATE' => 'No page to create',
+
+    // includes/controllers/CrsfController.php
+    'NO_CSRF_TOKEN_ERROR' => 'Site design error: The submission form did not contain the unique '.
+        'identification token needed for internal security mechanisms.',
+    'CSRF_TOKEN_FAIL_ERROR' => 'This page may have been opened a second time. '.
+        'Please renew the request from this window (the internal security token was not good).',
     
     // setup/header.php
     'OK' => 'OK',

--- a/lang/yeswiki_es.php
+++ b/lang/yeswiki_es.php
@@ -271,6 +271,12 @@ return [
     // actions/wantedpages.php
     'NO_PAGE_TO_CREATE' => 'Ninguna página para crear',
 
+    // includes/controllers/CrsfController.php
+    'NO_CSRF_TOKEN_ERROR' => 'Error de diseño del sitio: el formulario de envío no contenía el token '.
+        'de identificación único necesario para los mecanismos de seguridad internos.',
+    'CSRF_TOKEN_FAIL_ERROR' => 'Es posible que esta página se haya abierto por segunda vez. '.
+        'Renueve la solicitud desde esta ventana (el token de seguridad interno no era bueno).',
+
     // setup/header.php
     'OK' => 'OK',
     'FAIL' => 'FRACASO',

--- a/lang/yeswiki_es.php
+++ b/lang/yeswiki_es.php
@@ -533,6 +533,7 @@ return [
     // 'DELETEPAGE_NOT_ORPHEANED' => 'Cette page n\'est pas orpheline.',
     // 'DELETEPAGE_NOT_OWNER' => 'Vous n\'&ecirc;tes pas le propri&eacute;taire de cette page.',
     // 'DELETEPAGE_PAGES_WITH_LINKS_TO' => 'Pages ayant un lien vers {tag} :',
+    'DELETEPAGE_NOT_DELETED' => 'Página no eliminada.',
 
     // handlers/edit
     // 'EDIT_ALERT_ALREADY_SAVED_BY_ANOTHER_USER' => 'ALERTE : '.

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -267,6 +267,12 @@ return [
     // actions/wantedpages.php
     'NO_PAGE_TO_CREATE' => 'Aucune page &agrave; cr&eacute;er',
 
+    // includes/controllers/CrsfController.php
+    'NO_CSRF_TOKEN_ERROR' => 'Erreur de conception du site : Le formulaire de soumission ne contenait pas '.
+        'le jeton d\'identification unique nécessaire aux mécanismes internes de sécurité.',
+    'CSRF_TOKEN_FAIL_ERROR' => 'Cette page a peut-être été ouverte une seconde fois. '.
+        'Veuillez renouveler la demande depuis cette fenêtre (le jeton interne de sécurité n\'était pas bon).',
+
     // setup/header.php
     'OK' => 'OK',
     'FAIL' => 'ECHEC',

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -528,6 +528,7 @@ return [
     'DELETEPAGE_NOT_ORPHEANED' => 'Cette page n\'est pas orpheline.',
     'DELETEPAGE_NOT_OWNER' => 'Vous n\'&ecirc;tes pas le propri&eacute;taire de cette page.',
     'DELETEPAGE_PAGES_WITH_LINKS_TO' => 'Pages ayant un lien vers {tag} :',
+    'DELETEPAGE_NOT_DELETED' => 'Page non supprimée.',
 
     // handlers/edit
     'EDIT_ALERT_ALREADY_SAVED_BY_ANOTHER_USER' => 'ALERTE : '.

--- a/lang/yeswiki_nl.php
+++ b/lang/yeswiki_nl.php
@@ -529,6 +529,7 @@ return [
     // 'DELETEPAGE_NOT_ORPHEANED' => 'Cette page n\'est pas orpheline.',
     // 'DELETEPAGE_NOT_OWNER' => 'Vous n\'&ecirc;tes pas le propri&eacute;taire de cette page.',
     // 'DELETEPAGE_PAGES_WITH_LINKS_TO' => 'Pages ayant un lien vers {tag} :',
+    'DELETEPAGE_NOT_DELETED' => 'Pagina niet verwijderd.',
 
     // handlers/edit
     // 'EDIT_ALERT_ALREADY_SAVED_BY_ANOTHER_USER' => 'ALERTE : '.

--- a/lang/yeswiki_nl.php
+++ b/lang/yeswiki_nl.php
@@ -268,6 +268,12 @@ return [
     // actions/wantedpages.php
     'NO_PAGE_TO_CREATE' => 'Geen enkele pagina aan te maken',
 
+    // includes/controllers/CrsfController.php
+    'NO_CSRF_TOKEN_ERROR' => 'Fout bij het ontwerpen van de site: het indieningsformulier bevatte niet het unieke identificatietoken '.
+        'dat nodig is voor interne beveiligingsmechanismen.',
+    'CSRF_TOKEN_FAIL_ERROR' => 'Deze pagina is mogelijk een tweede keer geopend. '.
+        'Verleng het verzoek vanuit dit venster (het interne beveiligingstoken was niet goed).',
+
     // setup/header.php
     'OK' => 'OK',
     'FAIL' => 'MISLUKT',

--- a/lang/yeswiki_pt.php
+++ b/lang/yeswiki_pt.php
@@ -530,6 +530,7 @@ return [
     // 'DELETEPAGE_NOT_ORPHEANED' => 'Cette page n\'est pas orpheline.',
     // 'DELETEPAGE_NOT_OWNER' => 'Vous n\'&ecirc;tes pas le propri&eacute;taire de cette page.',
     // 'DELETEPAGE_PAGES_WITH_LINKS_TO' => 'Pages ayant un lien vers {tag} :',
+    'DELETEPAGE_NOT_DELETED' => 'Página não apagada.',
 
     // handlers/edit
     // 'EDIT_ALERT_ALREADY_SAVED_BY_ANOTHER_USER' => 'ALERTE : '.

--- a/lang/yeswiki_pt.php
+++ b/lang/yeswiki_pt.php
@@ -267,6 +267,12 @@ return [
     // actions/wantedpages.php
     'NO_PAGE_TO_CREATE' => 'Nenhuma página para criar',
 
+    // includes/controllers/CrsfController.php
+    'NO_CSRF_TOKEN_ERROR' => 'Erro de conceção do local: O formulário de submissão não continha o símbolo de identificação '.
+    'único necessário para os mecanismos de segurança interna.',
+    'CSRF_TOKEN_FAIL_ERROR' => 'Esta página pode ter sido aberta uma segunda vez. '.
+        'Por favor, renove o pedido desta janela (o sinal de segurança interna não foi bom).',
+
     // setup/header.php
     'OK' => 'OK',
     'FAIL' => 'FALHA',

--- a/tools/login/actions/usersettings.php
+++ b/tools/login/actions/usersettings.php
@@ -54,7 +54,7 @@ if ($action == 'logout') { // User wants to log out
 } elseif ($adminIsActing || $userLoggedIn) { // Admin or user wants to manage the user
     if (substr($action, 0, 6) == 'update') { // Whoever it is tries to update the user
         try {
-            $csrfTokenController->checkTockenThenRemove('login\action\usersettings\updateuser', 'POST', 'crsf-token');
+            $csrfTokenController->checkTocken('login\action\usersettings\updateuser', 'POST', 'crsf-token');
 
             $OK = $this->user->setByAssociativeArray(array(
                 'email'	 			=> isset($_POST['email']) ? $_POST['email'] : '',
@@ -88,7 +88,7 @@ if ($action == 'logout') { // User wants to log out
 
         if ($action == 'deleteByAdmin') { // Admin trying to delete user
             try {
-                $csrfTokenController->checkTockenThenRemove('login\action\usersettings\deleteByAdmin', 'POST', 'crsf-token');
+                $csrfTokenController->checkTocken('login\action\usersettings\deleteByAdmin', 'POST', 'crsf-token');
 
                 $this->user->delete();
                 // forward
@@ -106,7 +106,7 @@ if ($action == 'logout') { // User wants to log out
             } else { // user properly typed his old password in
                 // check token
                 try {
-                    $csrfTokenController->checkTockenThenRemove('login\action\usersettings\changepass', 'POST', 'crsf-token');
+                    $csrfTokenController->checkTocken('login\action\usersettings\changepass', 'POST', 'crsf-token');
 
                     $password = $_POST['password'];
                     if ($this->user->updatePassword($password)) {

--- a/tools/login/lang/login_ca.inc.php
+++ b/tools/login/lang/login_ca.inc.php
@@ -71,4 +71,11 @@ return [
 
     // actions/login.php
     // 'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',
+
+    // actions/usersettins.php
+    'USERSTTINGS_CHANGE_PASS_NO_TOKEN_ERROR' => 'Error de disseny del lloc: el nou formulari d\'enviament de contrasenyes '.
+        'no contenia el testimoni d\'identificació únic necessari per als mecanismes de seguretat interns. '.
+        'La contrasenya no ha canviat.',
+    'USERSTTINGS_CHANGE_PASS_TOKEN_FAIL_ERROR' => 'La contrasenya no s\'ha canviat perquè és possible que aquesta pàgina s\'hagi obert per segona vegada. '.
+        'Si us plau, renoveu la sol·licitud de canvi des d\'aquesta finestra (el testimoni de seguretat intern no era bo). ',
 ];

--- a/tools/login/lang/login_ca.inc.php
+++ b/tools/login/lang/login_ca.inc.php
@@ -72,10 +72,8 @@ return [
     // actions/login.php
     // 'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',
 
-    // actions/usersettins.php
-    'USERSTTINGS_CHANGE_PASS_NO_TOKEN_ERROR' => 'Error de disseny del lloc: el nou formulari d\'enviament de contrasenyes '.
-        'no contenia el testimoni d\'identificació únic necessari per als mecanismes de seguretat interns. '.
-        'La contrasenya no ha canviat.',
-    'USERSTTINGS_CHANGE_PASS_TOKEN_FAIL_ERROR' => 'La contrasenya no s\'ha canviat perquè és possible que aquesta pàgina s\'hagi obert per segona vegada. '.
-        'Si us plau, renoveu la sol·licitud de canvi des d\'aquesta finestra (el testimoni de seguretat intern no era bo). ',
+    // actions/usersettings.php
+    'USERSETTINGS_EMAIL_NOT_CHANGED' => 'El correu electrònic no s\'ha modificat.',
+    'USERSETTINGS_PASSWORD_NOT_CHANGED' => 'La contrasenya no ha canviat.',
+    'USERSETTINGS_USER_NOT_DELETED' => 'Utilizador não eliminado.',
 ];

--- a/tools/login/lang/login_en.inc.php
+++ b/tools/login/lang/login_en.inc.php
@@ -72,9 +72,8 @@ return [
     // actions/login.php
     // 'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',
 
-    // actions/usersettins.php
-    'USERSTTINGS_CHANGE_PASS_NO_TOKEN_ERROR' => 'Site design error: The new password submission form did not contain the unique identification token '.
-        'needed for internal security mechanisms. Password not changed.',
-    'USERSTTINGS_CHANGE_PASS_TOKEN_FAIL_ERROR' => 'Password not changed because this page may have been opened a second time. '.
-        'Please renew the change request from this window (the internal security token was not good). ',
+    // actions/usersettings.php
+    'USERSETTINGS_EMAIL_NOT_CHANGED' => 'Email not modified.',
+    'USERSETTINGS_PASSWORD_NOT_CHANGED' => 'Password not changed.',
+    'USERSETTINGS_USER_NOT_DELETED' => 'User not deleted.',
 ];

--- a/tools/login/lang/login_en.inc.php
+++ b/tools/login/lang/login_en.inc.php
@@ -71,4 +71,10 @@ return [
 
     // actions/login.php
     // 'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',
+
+    // actions/usersettins.php
+    'USERSTTINGS_CHANGE_PASS_NO_TOKEN_ERROR' => 'Site design error: The new password submission form did not contain the unique identification token '.
+        'needed for internal security mechanisms. Password not changed.',
+    'USERSTTINGS_CHANGE_PASS_TOKEN_FAIL_ERROR' => 'Password not changed because this page may have been opened a second time. '.
+        'Please renew the change request from this window (the internal security token was not good). ',
 ];

--- a/tools/login/lang/login_es.inc.php
+++ b/tools/login/lang/login_es.inc.php
@@ -71,4 +71,10 @@ return [
 
     // actions/login.php
     // 'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',
+
+    // actions/usersettins.php
+    'USERSTTINGS_CHANGE_PASS_NO_TOKEN_ERROR' => 'Error de diseño del sitio: el nuevo formulario de envío de contraseña no contenía el token de identificación único '.
+        'necesario para los mecanismos de seguridad internos. Contraseña no cambiada.',
+    'USERSTTINGS_CHANGE_PASS_TOKEN_FAIL_ERROR' => 'La contraseña no se ha cambiado porque es posible que esta página se haya abierto por segunda vez. '.
+        'Renueve la solicitud de cambio desde esta ventana (el token de seguridad interno no era bueno).',
 ];

--- a/tools/login/lang/login_es.inc.php
+++ b/tools/login/lang/login_es.inc.php
@@ -72,9 +72,8 @@ return [
     // actions/login.php
     // 'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',
 
-    // actions/usersettins.php
-    'USERSTTINGS_CHANGE_PASS_NO_TOKEN_ERROR' => 'Error de diseño del sitio: el nuevo formulario de envío de contraseña no contenía el token de identificación único '.
-        'necesario para los mecanismos de seguridad internos. Contraseña no cambiada.',
-    'USERSTTINGS_CHANGE_PASS_TOKEN_FAIL_ERROR' => 'La contraseña no se ha cambiado porque es posible que esta página se haya abierto por segunda vez. '.
-        'Renueve la solicitud de cambio desde esta ventana (el token de seguridad interno no era bueno).',
+    // actions/usersettings.php
+    'USERSETTINGS_EMAIL_NOT_CHANGED' => 'Correo electrónico no cambiado.',
+    'USERSETTINGS_PASSWORD_NOT_CHANGED' => 'Contraseña no cambiada.',
+    'USERSETTINGS_USER_NOT_DELETED' => 'Usuario no eliminado.',
 ];

--- a/tools/login/lang/login_fr.inc.php
+++ b/tools/login/lang/login_fr.inc.php
@@ -71,4 +71,10 @@ return [
 
     // actions/login.php
     'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',
+
+    // actions/usersettins.php
+    'USERSTTINGS_CHANGE_PASS_NO_TOKEN_ERROR' => 'Erreur de conception du site : Le formulaire de soumission du nouveau mot de passe ne contenait pas '.
+        'le jeton d\'identification unique nécessaire aux mécanismes internes de sécurité. Mot de passe non modifié.',
+    'USERSTTINGS_CHANGE_PASS_TOKEN_FAIL_ERROR' => 'Mot de passe non modifié car cette page a peut-être été ouverte une seconde fois. '.
+        'Veuillez renouveler la demande de changement depuis cette fenêtre (le jeton interne de sécurité n\'était pas bon).',
 ];

--- a/tools/login/lang/login_fr.inc.php
+++ b/tools/login/lang/login_fr.inc.php
@@ -72,9 +72,8 @@ return [
     // actions/login.php
     'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',
 
-    // actions/usersettins.php
-    'USERSTTINGS_CHANGE_PASS_NO_TOKEN_ERROR' => 'Erreur de conception du site : Le formulaire de soumission du nouveau mot de passe ne contenait pas '.
-        'le jeton d\'identification unique nécessaire aux mécanismes internes de sécurité. Mot de passe non modifié.',
-    'USERSTTINGS_CHANGE_PASS_TOKEN_FAIL_ERROR' => 'Mot de passe non modifié car cette page a peut-être été ouverte une seconde fois. '.
-        'Veuillez renouveler la demande de changement depuis cette fenêtre (le jeton interne de sécurité n\'était pas bon).',
+    // actions/usersettings.php
+    'USERSETTINGS_EMAIL_NOT_CHANGED' => 'E-mail non modifié.',
+    'USERSETTINGS_PASSWORD_NOT_CHANGED' => 'Mot de passe non modifié.',
+    'USERSETTINGS_USER_NOT_DELETED' => 'Utilisateur non supprimé.',
 ];

--- a/tools/login/lang/login_nl.inc.php
+++ b/tools/login/lang/login_nl.inc.php
@@ -72,9 +72,8 @@ return [
     // actions/login.php
     // 'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',
 
-    // actions/usersettins.php
-    'USERSTTINGS_CHANGE_PASS_NO_TOKEN_ERROR' => 'Fout bij siteontwerp: het nieuwe formulier voor het indienen van wachtwoorden bevatte niet het '.
-        'unieke identificatietoken dat nodig is voor interne beveiligingsmechanismen. Wachtwoord niet gewijzigd.',
-    'USERSTTINGS_CHANGE_PASS_TOKEN_FAIL_ERROR' => 'Wachtwoord niet gewijzigd omdat deze pagina mogelijk een tweede keer is geopend. '.
-        'Verleng het wijzigingsverzoek vanuit dit venster (het interne beveiligingstoken was niet goed).',
+    // actions/usersettings.php
+    'USERSETTINGS_EMAIL_NOT_CHANGED' => 'E-mail niet gewijzigd.',
+    'USERSETTINGS_PASSWORD_NOT_CHANGED' => 'Wachtwoord niet gewijzigd.',
+    'USERSETTINGS_USER_NOT_DELETED' => 'Gebruiker niet verwijderd.',
 ];

--- a/tools/login/lang/login_nl.inc.php
+++ b/tools/login/lang/login_nl.inc.php
@@ -71,4 +71,10 @@ return [
 
     // actions/login.php
     // 'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',
+
+    // actions/usersettins.php
+    'USERSTTINGS_CHANGE_PASS_NO_TOKEN_ERROR' => 'Fout bij siteontwerp: het nieuwe formulier voor het indienen van wachtwoorden bevatte niet het '.
+        'unieke identificatietoken dat nodig is voor interne beveiligingsmechanismen. Wachtwoord niet gewijzigd.',
+    'USERSTTINGS_CHANGE_PASS_TOKEN_FAIL_ERROR' => 'Wachtwoord niet gewijzigd omdat deze pagina mogelijk een tweede keer is geopend. '.
+        'Verleng het wijzigingsverzoek vanuit dit venster (het interne beveiligingstoken was niet goed).',
 ];

--- a/tools/login/lang/login_pt.inc.php
+++ b/tools/login/lang/login_pt.inc.php
@@ -71,4 +71,10 @@ return [
 
     // actions/login.php
     // 'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',
+
+    // actions/usersettins.php
+    'USERSTTINGS_CHANGE_PASS_NO_TOKEN_ERROR' => 'Erro de conceção do site: O novo formulário de submissão da palavra-passe não continha o símbolo de '.
+        'identificação único necessário para os mecanismos de segurança interna. A palavra-passe não foi alterada.',
+    'USERSTTINGS_CHANGE_PASS_TOKEN_FAIL_ERROR' => 'A palavra-passe não foi alterada porque esta página pode ter sido aberta uma segunda vez. '.
+        'Por favor, renove o pedido de alteração desta janela (o sinal de segurança interna não foi bom).',
 ];

--- a/tools/login/lang/login_pt.inc.php
+++ b/tools/login/lang/login_pt.inc.php
@@ -72,9 +72,8 @@ return [
     // actions/login.php
     // 'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',
 
-    // actions/usersettins.php
-    'USERSTTINGS_CHANGE_PASS_NO_TOKEN_ERROR' => 'Erro de conceção do site: O novo formulário de submissão da palavra-passe não continha o símbolo de '.
-        'identificação único necessário para os mecanismos de segurança interna. A palavra-passe não foi alterada.',
-    'USERSTTINGS_CHANGE_PASS_TOKEN_FAIL_ERROR' => 'A palavra-passe não foi alterada porque esta página pode ter sido aberta uma segunda vez. '.
-        'Por favor, renove o pedido de alteração desta janela (o sinal de segurança interna não foi bom).',
+    // actions/usersettings.php
+    'USERSETTINGS_PASSWORD_NOT_CHANGED' => 'Palavra-passe não alterada.',
+    'USERSETTINGS_EMAIL_NOT_CHANGED' => 'E-mail não modificado.',
+    'USERSETTINGS_USER_NOT_DELETED' => 'Utilizador não eliminado.',
 ];


### PR DESCRIPTION
Je propose cette PR pour introduire le mécanisme de gestion de jetons anti-csrf en utilisant la bibliothèque `symfony` dédiée.

**Ce que ça fait**:
 - ajouter `Symfony\Component\Security\Csrf\CsrfTokenManager` dans les services de `YesWiki` pour pouvoir facilement l'utiliser
 - création d'une doc pour expliquer son usage facile
 - ajout d'un helper dans twig 
 - ajout de `Yeswiki\Core\Controller\CsrfTokenController` qui permet de mutualiser la vérification du jeton entre les différents contrôleurs primaires (actions, handlers, etc)
 - mise en place dans `usersettings.php` ce qui permettra de prévenir une attaque possible (_sans refactor, je me charge de faire le rafectr de `usersettings` ensuite car c'est lié à d'autres choses dans `UserManager`, j'ai préféré séparer_)
 - mise en place avec `deletepage.php` (je me charge de le synchroniser avec `webhooks` ou tout autre extension qui utilise `__deletepage.php`)

**Point à valider** (je mets des cases à cocher @mrflos il te suffira de les cocher pour m'indiquer que c'est OK):
 - [x] usage de `Symfony\Component\Security\Csrf\CsrfTokenManager`
 - [x] la doc `csrf.md`
 - [x] la proposition de nommage des identifiants de jetons (cf. `csrf.md`) s'il y a des remarques, je propose de faire des commentaires sur les lignes de ce fichier, plus facile à suivre
 - [x] usage de `Yeswiki\Core\Controller\CsrfTokenController`
 - [x] nom de la méthode `Yeswiki\Core\Controller\CsrfTokenController::checkTockenThenRemove`
 - [x] usage du helper `twig` `crsfToken` avec les deux syntaxes possibles afin de permettre une syntaxe courte et une syntaxe longue avec paramètres nommés
 - [x] validation de la syntaxe 1 pour le helper `twig` `{{ crsfToken('tokenId') }}`
 - [x] validation de la syntaxe 2 pour le helper `twig` `{{ crsfToken({id:'tokenId',refresh:true}) }}`
 - [x] usage dans `usersettings.php`
 - [x] usage dans `deletepage.php` et __`deletepage.php`

Merci pour la relecture @mrflos 
