### PR TITLE
fix(command): define YesWiki::isCli and YesWiki::exit

### DIFF
--- a/actions/HeaderAction.php
+++ b/actions/HeaderAction.php
@@ -39,7 +39,7 @@ class HeaderAction extends YesWikiAction
                     'message' => _t('TEMPLATE_NO_DEFAULT_THEME') .'<br><b>' .  _t('THEME_MANAGER_LOGIN_AS_ADMIN') . '</b>',
                 ]);
                 $output .= $this->callAction('login');
-                exit($output);
+                $this->wiki->exit($output);
             }
         } else {
             return $themeManager->renderHeader() ;

--- a/handlers/UpdateHandler.php
+++ b/handlers/UpdateHandler.php
@@ -16,6 +16,7 @@ class UpdateHandler extends YesWikiHandler
         };
 
         $output = '';
+        $withoutHeaders = filter_input(INPUT_GET, 'withoutHeaders', FILTER_VALIDATE_BOOL);
 
         if ($this->wiki->UserIsAdmin()) {
             $output .= '<strong>YesWiki core</strong><br />';
@@ -79,7 +80,7 @@ class UpdateHandler extends YesWikiHandler
         // BE CAREFULL this comment is used for extensions to add content above, don't delete it!
         $output .= '<!-- end handler /update -->';
 
-        if (empty($this->wiki->config['is_cli']) || $this->wiki->config['is_cli'] !== true) {
+        if (!$withoutHeaders) {
             $output = $this->wiki->header().$output;
             // add button to return to previous page
             $output .= '<div>

--- a/handlers/UpdateHandler.php
+++ b/handlers/UpdateHandler.php
@@ -16,7 +16,6 @@ class UpdateHandler extends YesWikiHandler
         };
 
         $output = '';
-        $withoutHeaders = filter_input(INPUT_GET, 'withoutHeaders', FILTER_VALIDATE_BOOL);
 
         if ($this->wiki->UserIsAdmin()) {
             $output .= '<strong>YesWiki core</strong><br />';
@@ -80,7 +79,7 @@ class UpdateHandler extends YesWikiHandler
         // BE CAREFULL this comment is used for extensions to add content above, don't delete it!
         $output .= '<!-- end handler /update -->';
 
-        if (!$withoutHeaders) {
+        if (!$this->wiki->isCli()) {
             $output = $this->wiki->header().$output;
             // add button to return to previous page
             $output .= '<div>

--- a/handlers/page/edit.php
+++ b/handlers/page/edit.php
@@ -121,7 +121,7 @@ if ($this->HasAccess('write') && $this->HasAccess('read') && !$isWikiHibernated)
                 }
 
                 // sécurité
-                exit;
+                $this->exit();
             }
         // NB.: en cas d'erreur on arrive ici, donc default sera exécuté...
         // no break

--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -43,6 +43,7 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\RequestContext;
+use YesWiki\Core\Exception\ExitException;
 use YesWiki\Core\Service\AclService;
 use YesWiki\Core\Service\ApiService;
 use YesWiki\Core\Service\DbService;
@@ -57,8 +58,6 @@ use YesWiki\Core\Service\AssetsManager;
 use YesWiki\Core\YesWikiControllerResolver;
 use YesWiki\Security\Controller\SecurityController;
 use YesWiki\Tags\Service\TagsManager;
-
-class ExitException extends Exception {}
 
 class Wiki
 {
@@ -162,7 +161,7 @@ class Wiki
 
     public function isCli(): bool
     {
-        return in_array(php_sapi_name(),['cli', 'cli-server',' phpdbg'],true);
+        return in_array(php_sapi_name(), ['cli', 'cli-server',' phpdbg'], true);
     }
 
     // inclusions
@@ -406,7 +405,7 @@ class Wiki
 
     public function exit(string $message = "")
     {
-        if ($this->isCli()){
+        if ($this->isCli()) {
             throw new ExitException($message);
         } else {
             exit($message);
@@ -1175,7 +1174,7 @@ class Wiki
             try {
                 echo $this->Method($this->method);
             } catch (ExitException $th) {
-                if (!$this->isCli()){
+                if (!$this->isCli()) {
                     // action redirect: aucune redirection n'a eu lieu, effacer la liste des redirections precedentes
                     if (!empty($_SESSION['redirects'])) {
                         unset($_SESSION['redirects']);

--- a/includes/YesWikiLoader.php
+++ b/includes/YesWikiLoader.php
@@ -54,9 +54,7 @@ class YesWikiLoader
                 if ($test) {
                     $_SERVER['REQUEST_URI'] = $_SERVER['REQUEST_URI'] ?? '';
                     $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_HOST'] ?? 'localhost';
-                    $_SERVER['REMOTE_ADDR'] = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
                     $_SESSION = $_SESSION ?? [];
-                    $_REQUEST['wiki'] = 'TesT';
                 }
 
                 self::$wiki = new Wiki();

--- a/includes/exceptions/ExitException.php
+++ b/includes/exceptions/ExitException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace YesWiki\Core\Exception;
+
+class ExitException extends \Exception
+{
+}

--- a/includes/services/DbService.php
+++ b/includes/services/DbService.php
@@ -43,7 +43,7 @@ class DbService
                 }
             }
         } else {
-            exit(_t('DB_CONNECT_FAIL'));
+            $this->wiki->exit(_t('DB_CONNECT_FAIL'));
         }
     }
 

--- a/includes/services/Mailer.php
+++ b/includes/services/Mailer.php
@@ -93,7 +93,7 @@ class Mailer
         $text = $this->templateEngine->render(
             '@contact/notify-admins-list-deleted-email-text.twig',
             [
-                'ip' => $_SERVER['REMOTE_ADDR'],
+                'ip' => $this->wiki->isCli() ? '' : $_SERVER['REMOTE_ADDR'],
                 'userName' => $this->wiki->GetUserName(),
             ]
         );
@@ -101,7 +101,7 @@ class Mailer
             '@contact/notify-admins-list-deleted-email-html.twig',
             [
                 'style' => file_get_contents('tools/bazar/presentation/styles/bazar.css'),
-                'ip' => $_SERVER['REMOTE_ADDR'],
+                'ip' => $this->wiki->isCli() ? '' : $_SERVER['REMOTE_ADDR'],
                 'userName' => $this->wiki->GetUserName(),
                 'baseUrl' => $baseUrl,
             ]

--- a/includes/services/Performer.php
+++ b/includes/services/Performer.php
@@ -5,8 +5,8 @@ namespace YesWiki\Core\Service;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Throwable;
+use YesWiki\Core\Exception\ExitException;
 use YesWiki\Core\Exception\PerformerException;
-use YesWiki\ExitException;
 use YesWiki\Wiki;
 
 /**

--- a/includes/services/Performer.php
+++ b/includes/services/Performer.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Throwable;
 use YesWiki\Core\Exception\PerformerException;
+use YesWiki\ExitException;
 use YesWiki\Wiki;
 
 /**
@@ -197,6 +198,8 @@ class Performer
                     $output = &$vars['plugin_output_new'];
                     unset($vars['plugin_output_new']);
                 }
+            } catch (ExitException $t) {
+                throw $t;
             } catch (Throwable $t) {
                 // catch all errors and exceptions thrown by the execution of the performable
                 $message = _t('PERFORMABLE_ERROR');

--- a/includes/services/UserManager.php
+++ b/includes/services/UserManager.php
@@ -54,7 +54,7 @@ class UserManager
         if ($user = $this->getLoggedUser()) {
             $name = $user["name"];
         } else {
-            $name = $_SERVER["REMOTE_ADDR"];
+            $name = $this->wiki->isCli() ? '' : $_SERVER["REMOTE_ADDR"];
         }
         return $name;
     }

--- a/tools/autoupdate/commands/PostUpdaterCommand.php
+++ b/tools/autoupdate/commands/PostUpdaterCommand.php
@@ -39,8 +39,6 @@ class PostUpdaterCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         ob_start();
-        $_GET['wiki'] = $this->wiki->getPageTag().'/update';
-        $_GET['withoutHeaders'] = "1";
         $this->wiki->Run($this->wiki->getPageTag(), 'update');
         $bufferedOutput = ob_get_contents();
         ob_end_clean();

--- a/tools/autoupdate/commands/PostUpdaterCommand.php
+++ b/tools/autoupdate/commands/PostUpdaterCommand.php
@@ -39,15 +39,17 @@ class PostUpdaterCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         ob_start();
+        $_GET['wiki'] = $this->wiki->getPageTag().'/update';
+        $_GET['withoutHeaders'] = "1";
         $this->wiki->Run($this->wiki->getPageTag(), 'update');
         $bufferedOutput = ob_get_contents();
         ob_end_clean();
 
         $bufferedOutput = strip_tags($bufferedOutput, '<br><hr><em><strong>');
         $bufferedOutput = preg_replace(
-          ['#<[bh]r ?/?>#Ui', '/<(em|strong)>/Ui', '#</ ?(em|strong)>#Ui'],
-          ["\n", "\e[1m", "\e[0m"],
-          $bufferedOutput
+            ['#<[bh]r ?/?>#Ui', '/<(em|strong)>/Ui', '#</ ?(em|strong)>#Ui'],
+            ["\n", "\e[1m", "\e[0m"],
+            $bufferedOutput
         );
         $output->write($bufferedOutput);
 

--- a/tools/autoupdate/commands/console
+++ b/tools/autoupdate/commands/console
@@ -5,15 +5,16 @@
 namespace YesWiki\AutoUpdate\Commands;
 
 if (!file_exists('wakka.config.php')) {
-  exit("\e[31mThe command should be launched from your YesWiki root directory\e[0m");
+    exit("\e[31mThe command should be launched from your YesWiki root directory\e[0m");
 } else {
-  include_once('wakka.config.php');
-  // fake $_SERVER vars
-  $_SERVER['REQUEST_URI'] = $wakkaConfig['base_url'].$wakkaConfig['root_page'];
-  $_SERVER['HTTP_HOST'] = parse_url($wakkaConfig['base_url'], PHP_URL_HOST);
-  $_SERVER['REQUEST_METHOD'] = 'GET';
-  // fake wiki page
-  $_REQUEST['wiki'] = $wakkaConfig['root_page'];
+    include_once('wakka.config.php');
+    // fake $_SERVER vars
+    $_SERVER['REQUEST_URI'] = $wakkaConfig['base_url'].$wakkaConfig['root_page'];
+    $_SERVER['HTTP_HOST'] = parse_url($wakkaConfig['base_url'], PHP_URL_HOST);
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $_SERVER['REMOTE_ADDR'] = 'console script';
+    // fake wiki page
+    $_REQUEST['wiki'] = $wakkaConfig['root_page'];
 }
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
@@ -30,9 +31,6 @@ $application = new Application();
 require_once 'includes/YesWiki.php';
 $wiki = new \YesWiki\Wiki();
 
-// little hack to understand that we are lauching a cli command
-$wiki->config['is_cli'] = true;
-
 // second little hack (bad habit..): we use the first admin user to perform updates as an admin
 $admins = $wiki->GetGroupACL('admins');
 $firstAdmin = $wiki->LoadUser(preg_split("/\s+/", $admins)[0]);
@@ -40,9 +38,11 @@ $wiki->setUser($firstAdmin);
 
 // ... register commands
 use YesWiki\AutoUpdate\Commands\UpdaterCommand;
+
 $application->add(new UpdaterCommand($wiki));
 
 use YesWiki\AutoUpdate\Commands\PostUpdaterCommand;
+
 $application->add(new PostUpdaterCommand($wiki));
 
 $application->run();

--- a/tools/autoupdate/commands/console
+++ b/tools/autoupdate/commands/console
@@ -12,7 +12,6 @@ if (!file_exists('wakka.config.php')) {
     $_SERVER['REQUEST_URI'] = $wakkaConfig['base_url'].$wakkaConfig['root_page'];
     $_SERVER['HTTP_HOST'] = parse_url($wakkaConfig['base_url'], PHP_URL_HOST);
     $_SERVER['REQUEST_METHOD'] = 'GET';
-    $_SERVER['REMOTE_ADDR'] = 'console script';
     // fake wiki page
     $_REQUEST['wiki'] = $wakkaConfig['root_page'];
 }

--- a/tools/bazar/actions/BazarListeAction.php
+++ b/tools/bazar/actions/BazarListeAction.php
@@ -35,7 +35,7 @@ class BazarListeAction extends YesWikiAction
                         $icon = trim(array_values($tabparam)[0]);
                     }
                 } else {
-                    exit('<div class="alert alert-danger">action bazarliste : le paramètre icon est mal rempli.<br />Il doit être de la forme icon="nomIcone1=valeur1, nomIcone2=valeur2"</div>');
+                    throw new Exception('action bazarliste : le paramètre icon est mal rempli.<br />Il doit être de la forme icon="nomIcone1=valeur1, nomIcone2=valeur2"');
                 }
             } else {
                 $icon = $this->params->get('baz_marker_icon');
@@ -62,7 +62,7 @@ class BazarListeAction extends YesWikiAction
                         $color = trim(array_values($tabparam)[0]);
                     }
                 } else {
-                    exit('<div class="alert alert-danger">action bazarliste : le paramètre color est mal rempli.<br />Il doit être de la forme color="couleur1=valeur1, couleur2=valeur2"</div>');
+                    throw new Exception('action bazarliste : le paramètre color est mal rempli.<br />Il doit être de la forme color="couleur1=valeur1, couleur2=valeur2"');
                 }
             } else {
                 $color = $this->params->get('baz_marker_color');

--- a/tools/bazar/actions/bazarlistecategorie.php
+++ b/tools/bazar/actions/bazarlistecategorie.php
@@ -15,6 +15,7 @@
 // +------------------------------------------------------------------------------------------------------+
 
 use YesWiki\Bazar\Service\EntryManager;
+use YesWiki\Core\Service\TemplateEngine;
 
 if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
@@ -47,7 +48,7 @@ if (empty($GLOBALS['ordre'])) {
 }
 
 $template = $this->GetParameter("template");
-$template = $this->getService(TemplateEngine::class)->hasTemplate("@bazar/$template") ? $template : '';
+$template = $this->services->get(TemplateEngine::class)->hasTemplate("@bazar/$template") ? $template : '';
 if (empty($template)) {
     $template = $GLOBALS['wiki']->config['default_bazar_template'];
 }

--- a/tools/bazar/actions/bazarlistecategorie.php
+++ b/tools/bazar/actions/bazarlistecategorie.php
@@ -55,7 +55,7 @@ if (empty($template)) {
 // identifiant de la base de donnée pour la liste
 $id = $this->GetParameter("id");
 if (empty($id)) {
-    exit('<div class="alert alert-danger">Error action bazarlistecategorie: parameter "id" missing.</div>');
+    throw new Exception('Error action bazarlistecategorie: parameter "id" missing.');
 } else {
     $GLOBALS['champ'] = $id;
 }

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -227,7 +227,7 @@ class EntryController extends YesWikiController
                     );
                 }
                 header('Location: ' . $redirectUrl);
-                exit;
+                $this->wiki->exit();
             }
         } catch (UserFieldException $e) {
             $error .= $this->render('@templates/alert-message.twig', [
@@ -272,7 +272,7 @@ class EntryController extends YesWikiController
                     ], false);
                 }
                 header('Location: ' . $redirectUrl);
-                exit;
+                $this->wiki->exit();
             }
         } catch (UserFieldException $e) {
             $error .= $this->render('@templates/alert-message.twig', [

--- a/tools/bazar/handlers/__EditHandler.php
+++ b/tools/bazar/handlers/__EditHandler.php
@@ -27,7 +27,7 @@ class __EditHandler extends YesWikiHandler
             $this->output .= $this->wiki->Footer();
 
             // we use die so that the script stop there and the default handler of wiki isn't called
-            die($this->output);
+            $this->wiki->exit($this->output);
         }
     }
 }

--- a/tools/bazar/handlers/__WidgetHandler.php
+++ b/tools/bazar/handlers/__WidgetHandler.php
@@ -66,6 +66,6 @@ class __WidgetHandler extends YesWikiHandler
         $output = ob_get_contents();
         ob_end_clean();
         echo $this->wiki->Header().$output.$this->wiki->Footer();
-        exit();
+        $this->wiki->exit();
     }
 };

--- a/tools/bazar/handlers/page/__show.php
+++ b/tools/bazar/handlers/page/__show.php
@@ -43,7 +43,7 @@ if ($entryManager->isEntry($this->GetPageTag()) && $this->HasAccess("read")) {
         header("Access-Control-Allow-Origin: *");
 
         $fiche = $entryManager->getOne($this->GetPageTag(), $semantic);
-        exit(json_encode($fiche));
+        $this->exit(json_encode($fiche));
     } else {
         $this->AddJavascriptFile('tools/bazar/libs/bazar.js');
     }

--- a/tools/bazar/services/SemanticTransformer.php
+++ b/tools/bazar/services/SemanticTransformer.php
@@ -76,7 +76,7 @@ class SemanticTransformer
         ];
 
         if (($data['@type'] && $data['@type'] !== $form['bn_sem_type']) || $data['type'] && $data['type'] !== $form['bn_sem_type']) {
-            exit('The @type of the sent data must be ' . $form['bn_sem_type']);
+            throw new \Exception('The @type of the sent data must be ' . $form['bn_sem_type']);
         }
 
         foreach ($form['prepared'] as $field) {

--- a/tools/login/actions/login.php
+++ b/tools/login/actions/login.php
@@ -114,7 +114,7 @@ if ($_REQUEST["action"] == "logout") {
     $this->LogoutUser();
     $this->SetMessage(_t('LOGIN_YOU_ARE_NOW_DISCONNECTED'));
     $this->Redirect(preg_replace('/(&|\\\?)$/m', '', preg_replace('/(&|\\\?)action=logout(&)?/', '$1', $incomingurl)));
-    exit;
+    $this->exit();
 }
 
 // cas de l'identification

--- a/tools/login/handlers/page/auth.php
+++ b/tools/login/handlers/page/auth.php
@@ -39,7 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
         header('Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE, PUT');
         header('Access-Control-Max-Age: 86400');
     }
-    exit;
+    $this->exit();
 }
 if ($_SERVER['REQUEST_METHOD'] == 'POST' && empty($_POST)) {
     $_POST = json_decode(file_get_contents('php://input'), true) ?? [];

--- a/tools/rss/actions/recentchangesrssplus.php
+++ b/tools/rss/actions/recentchangesrssplus.php
@@ -67,5 +67,5 @@ if ($pages = $this->LoadAll("select tag, time, user, owner, LEFT(body,500) as bo
     // Définition du type de document et de son encodage.
     header("Content-Type: text/xml; charset=ISO-8859-1");
     echo $output;
-    exit;
+    $this->exit();
 }

--- a/tools/security/handlers/page/__addcomment.php
+++ b/tools/security/handlers/page/__addcomment.php
@@ -15,25 +15,25 @@ if (isset($_POST["action"]) && $_POST["action"] == 'addcomment') {
 
     if ($this->config['use_nospam']) {
         if (!isset($_SESSION['nospam'])) {
-            die("Vous avez été trop long.");
+            $this->exit("Vous avez été trop long.");
         }
 
         $nospam = $_SESSION['nospam'];
 
         if (!array_key_exists($nospam['nospam1'], $_POST)) {
-            die("NoSpam : Commentaire refusé");
+            $this->exit("NoSpam : Commentaire refusé");
         } elseif ($_POST[$nospam['nospam1']] != "") {
-            die("NoSpam : Commentaire refusé");
+            $this->exit("NoSpam : Commentaire refusé");
         } elseif (!array_key_exists($nospam['nospam2'], $_POST)) {
-            die("NoSpam : Commentaire refusé");
+            $this->exit("NoSpam : Commentaire refusé");
         } elseif ($_POST[$nospam['nospam2']] != $nospam['nospam2-val']) {
-            die("NoSpam : Commentaire refusé");
+            $this->exit("NoSpam : Commentaire refusé");
         } elseif (!array_key_exists('nxts', $_POST) || !array_key_exists('nxts_signed', $_POST)) {
-            die("NoSpam : Commentaire refusé");
+            $this->exit("NoSpam : Commentaire refusé");
         } elseif (sha1($_POST['nxts'] . $nospam['salt']) != $_POST['nxts_signed']) {
-            die("NoSpam : Commentaire refusé");
+            $this->exit("NoSpam : Commentaire refusé");
         } elseif (time() < $_POST['nxts'] + 15) {
-            die("NoSpam : trop rapide");
+            $this->exit("NoSpam : trop rapide");
         }
     }
 }

--- a/tools/security/handlers/page/__edit.php
+++ b/tools/security/handlers/page/__edit.php
@@ -14,7 +14,7 @@ if ($this->HasAccess('write') && $this->HasAccess('read')) {
         echo $this->Header().
             $message.
             $this->Footer();
-        exit;
+        $this->exit();
     }
   
     if ($this->config['use_hashcash']) {

--- a/tools/tags/handlers/page/ajaxedit.php
+++ b/tools/tags/handlers/page/ajaxedit.php
@@ -101,7 +101,7 @@ if (isset($_GET['jsonp_callback'])) {
                     }
                     
                     // sécurité
-                    exit;
+                    $this->exit();
                 }
                 // NB.: en cas d'erreur on arrive ici, donc default sera exécuté...
                 // no break

--- a/tools/templates/handlers/page/edit__.php
+++ b/tools/templates/handlers/page/edit__.php
@@ -125,5 +125,5 @@ if (!$this->HasAccess('write')) {
     .'</div><!-- end .page -->'."\n";
     // on recupere juste les javascripts et la fin des balises body et html
     $output .= preg_replace('/^.+<script/Us', '<script', $this->Footer());
-    exit($output);
+    $this->exit($output);
 }

--- a/tools/templates/handlers/page/show__.php
+++ b/tools/templates/handlers/page/show__.php
@@ -49,7 +49,7 @@ if (!$this->HasAccess('read')) {
             $plugin_output_new
         );
     }
-    exit($output);
+    $this->exit($output);
 }
 
 // TODO : make it work with big buffers


### PR DESCRIPTION
@mrflos je propose une petite amélioration de `command` qui est utilisé par la ferme.

**Ce que ça fait**:
 - retirer le hack `is_cli`
 - définir deux méthodes
   - `YesWiki->isCli()` qui teste si on est en mode cli
   - `YesWiki->exit()` qui remplace l'appel de `exit` par la levée d'une `ExitException` qu'il est ainsi possible d'attraper pendant les tests en cli uniquement.

C'est encore en phase d'idée pour le moment
