### PR TITLE
Feat/only one entry by form

### DIFF
--- a/handlers/UpdateHandler.php
+++ b/handlers/UpdateHandler.php
@@ -19,54 +19,55 @@ class UpdateHandler extends YesWikiHandler
 
         if ($this->wiki->UserIsAdmin()) {
             $output .= '<strong>YesWiki core</strong><br />';
-            $dblink = $this->getService(DbService::class)->getLink();
+            $dbService = $this->getService(DbService::class);
+            $dblink = $dbService->getLink();
 
             // drop old nature table fields
-            $result = $this->wiki->Query("SHOW COLUMNS FROM ".$this->wiki->config['table_prefix']."nature WHERE FIELD IN ('bn_ce_id_menu' ,'bn_commentaire' , 'bn_appropriation' , 'bn_image_titre' , 'bn_image_logo' , 'bn_couleur_calendrier' , 'bn_picto_calendrier' , 'bn_type_fiche' , 'bn_label_class')");
+            $result = $this->wiki->Query("SHOW COLUMNS FROM {$dbService->prefixTable("nature")} WHERE FIELD IN ('bn_ce_id_menu' ,'bn_commentaire' , 'bn_appropriation' , 'bn_image_titre' , 'bn_image_logo' , 'bn_couleur_calendrier' , 'bn_picto_calendrier' , 'bn_type_fiche' , 'bn_label_class')");
             if (@mysqli_num_rows($result) > 0) {
-                $output .= 'ℹ️ Removing old fields from ' . $this->wiki->config['table_prefix'].'nature table.<br />';
+                $output .= "ℹ️ Removing old fields from {$dbService->prefixTable("nature")}table.<br />";
 
                 // don't show output because it can be an error if column doesn't exists
-                @$this->wiki->Query("ALTER TABLE ".$this->wiki->config['table_prefix']."nature DROP `bn_ce_id_menu`;");
-                @$this->wiki->Query("ALTER TABLE ".$this->wiki->config['table_prefix']."nature DROP `bn_commentaire`;");
-                @$this->wiki->Query("ALTER TABLE ".$this->wiki->config['table_prefix']."nature DROP `bn_appropriation`;");
-                @$this->wiki->Query("ALTER TABLE ".$this->wiki->config['table_prefix']."nature DROP `bn_image_titre`;");
-                @$this->wiki->Query("ALTER TABLE ".$this->wiki->config['table_prefix']."nature DROP `bn_image_logo`;");
-                @$this->wiki->Query("ALTER TABLE ".$this->wiki->config['table_prefix']."nature DROP `bn_couleur_calendrier`;");
-                @$this->wiki->Query("ALTER TABLE ".$this->wiki->config['table_prefix']."nature DROP `bn_picto_calendrier`;");
-                @$this->wiki->Query("ALTER TABLE ".$this->wiki->config['table_prefix']."nature DROP `bn_type_fiche`;");
-                @$this->wiki->Query("ALTER TABLE ".$this->wiki->config['table_prefix']."nature DROP `bn_label_class`;");
-                @$this->wiki->Query("ALTER TABLE ".$this->wiki->config['table_prefix']."nature MODIFY COLUMN bn_ce_i18n VARCHAR(5) NOT NULL DEFAULT ''");
+                @$this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} DROP `bn_ce_id_menu`;");
+                @$this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} DROP `bn_commentaire`;");
+                @$this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} DROP `bn_appropriation`;");
+                @$this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} DROP `bn_image_titre`;");
+                @$this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} DROP `bn_image_logo`;");
+                @$this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} DROP `bn_couleur_calendrier`;");
+                @$this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} DROP `bn_picto_calendrier`;");
+                @$this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} DROP `bn_type_fiche`;");
+                @$this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} DROP `bn_label_class`;");
+                @$this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} MODIFY COLUMN bn_ce_i18n VARCHAR(5) NOT NULL DEFAULT ''");
                 $output .= '✅ Done !<br />';
             } else {
-                $output .= '✅ The table '.$this->wiki->config['table_prefix'].'nature is already cleaned up from old tables !<br />';
+                $output .= "✅ The table {$dbService->prefixTable("nature")}is already cleaned up from old tables !<br />";
             }
 
             // remove createur field
             $entryManager = $this->getService(EntryManager::class);
             if (method_exists(EntryManager::class, 'removeAttributes')) {
                 if ($entryManager->removeAttributes([], ['createur'], true)) {
-                    $output .= 'ℹ️ Removing createur field from bazar entries in ' . $this->wiki->config['table_prefix'].'pages table.<br />';
+                    $output .= "ℹ️ Removing createur field from bazar entries in {$dbService->prefixTable("pages")}table.<br />";
                     $output .= '✅ Done !<br />';
                 } else {
-                    $output .= '✅ The table '.$this->wiki->config['table_prefix'].'pages is already free of createur fields in bazar entries !<br />';
+                    $output .= "✅ The table {$dbService->prefixTable("pages")}is already free of createur fields in bazar entries !<br />";
                 }
             } else {
-                $output .= '! Not possible to remove createur field from bazar entries in ' . $this->wiki->config['table_prefix'].'pages table.<br />';
+                $output .= "! Not possible to remove createur field from bazar entries in {$dbService->prefixTable("pages")}table.<br />";
             }
 
             // add semantic bazar fields
-            $result = $this->wiki->Query("SHOW COLUMNS FROM ".$this->wiki->config['table_prefix']."nature LIKE 'bn_sem_context'");
+            $result = $this->wiki->Query("SHOW COLUMNS FROM {$dbService->prefixTable("nature")} LIKE 'bn_sem_context'");
             if (@mysqli_num_rows($result) === 0) {
-                $output .= 'ℹ️ Adding fields bn_sem_context, bn_sem_type and bn_sem_use_template to ' . $this->wiki->config['table_prefix'].'nature table.<br />';
+                $output .= "ℹ️ Adding fields bn_sem_context, bn_sem_type and bn_sem_use_template to {$dbService->prefixTable("nature")}table.<br />";
 
-                $this->wiki->Query("ALTER TABLE ".$this->wiki->config['table_prefix']."nature ADD COLUMN bn_sem_context text COLLATE utf8mb4_unicode_ci AFTER bn_condition");
-                $this->wiki->Query("ALTER TABLE ".$this->wiki->config['table_prefix']."nature ADD COLUMN bn_sem_type varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL AFTER bn_sem_context");
-                $this->wiki->Query("ALTER TABLE ".$this->wiki->config['table_prefix']."nature ADD COLUMN bn_sem_use_template tinyint(1) NOT NULL DEFAULT 1 AFTER bn_sem_type");
+                $this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} ADD COLUMN bn_sem_context text COLLATE utf8mb4_unicode_ci AFTER bn_condition");
+                $this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} ADD COLUMN bn_sem_type varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL AFTER bn_sem_context");
+                $this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} ADD COLUMN bn_sem_use_template tinyint(1) NOT NULL DEFAULT 1 AFTER bn_sem_type");
 
                 $output .= '✅ Done !<br />';
             } else {
-                $output .= '✅ The table '.$this->wiki->config['table_prefix'].'nature is already up-to-date with semantic fields!<br />';
+                $output .= "✅ The table {$dbService->prefixTable("nature")}is already up-to-date with semantic fields!<br />";
             }
 
             // propose to update content of admin's pages

--- a/handlers/UpdateHandler.php
+++ b/handlers/UpdateHandler.php
@@ -1,6 +1,7 @@
 <?php
 
 use YesWiki\Bazar\Service\EntryManager;
+use YesWiki\Bazar\Service\FormManager;
 use YesWiki\Core\Service\DbService;
 use YesWiki\Core\Service\LinkTracker;
 use YesWiki\Core\Service\PageManager;
@@ -70,9 +71,9 @@ class UpdateHandler extends YesWikiHandler
                 $output .= "✅ The table {$dbService->prefixTable("nature")}is already up-to-date with semantic fields!<br />";
             }
 
-            // add only_one_entry bazar fields
-            $result = $this->wiki->Query("SHOW COLUMNS FROM {$dbService->prefixTable("nature")} LIKE 'bn_only_one_entry'");
-            if (@mysqli_num_rows($result) === 0) {
+            // add bn_only_one_entry bazar fields
+            $formManager = $this->getService(FormManager::class);
+            if (!$formManager->isAvailableOnlyOneEntryOption()) {
                 $output .= "ℹ️ Adding 'bn_only_one_entry' to {$dbService->prefixTable("nature")}table.<br />";
 
                 $this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} ADD COLUMN `bn_only_one_entry` enum('Y','N') NOT NULL DEFAULT 'N' COLLATE utf8mb4_unicode_ci;");

--- a/handlers/UpdateHandler.php
+++ b/handlers/UpdateHandler.php
@@ -83,6 +83,17 @@ class UpdateHandler extends YesWikiHandler
                 $output .= "✅ The table {$dbService->prefixTable("nature")}is already up-to-date with 'bn_only_one_entry' field!<br />";
             }
 
+            // add isAvailableOnlyOneEntryMessage bazar fields
+            if (!$formManager->isAvailableOnlyOneEntryMessage()) {
+                $output .= "ℹ️ Adding 'bn_only_one_entry_message' to {$dbService->prefixTable("nature")}table.<br />";
+
+                $this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} ADD COLUMN `bn_only_one_entry_message` text DEFAULT NULL COLLATE utf8mb4_unicode_ci;");
+
+                $output .= '✅ Done !<br />';
+            } else {
+                $output .= "✅ The table {$dbService->prefixTable("nature")}is already up-to-date with 'bn_only_one_entry_message' field!<br />";
+            }
+
             // propose to update content of admin's pages
             $output .= $this->frontUpdateAdminPages();
         } else {

--- a/handlers/UpdateHandler.php
+++ b/handlers/UpdateHandler.php
@@ -70,6 +70,18 @@ class UpdateHandler extends YesWikiHandler
                 $output .= "✅ The table {$dbService->prefixTable("nature")}is already up-to-date with semantic fields!<br />";
             }
 
+            // add only_one_entry bazar fields
+            $result = $this->wiki->Query("SHOW COLUMNS FROM {$dbService->prefixTable("nature")} LIKE 'bn_only_one_entry'");
+            if (@mysqli_num_rows($result) === 0) {
+                $output .= "ℹ️ Adding 'bn_only_one_entry' to {$dbService->prefixTable("nature")}table.<br />";
+
+                $this->wiki->Query("ALTER TABLE {$dbService->prefixTable("nature")} ADD COLUMN `bn_only_one_entry` enum('Y','N') NOT NULL DEFAULT 'N' COLLATE utf8mb4_unicode_ci;");
+
+                $output .= '✅ Done !<br />';
+            } else {
+                $output .= "✅ The table {$dbService->prefixTable("nature")}is already up-to-date with 'bn_only_one_entry' field!<br />";
+            }
+
             // propose to update content of admin's pages
             $output .= $this->frontUpdateAdminPages();
         } else {

--- a/setup/sql/create-tables.sql
+++ b/setup/sql/create-tables.sql
@@ -23,6 +23,8 @@ CREATE TABLE IF NOT EXISTS `{{prefix}}nature` (
   `bn_sem_use_template` tinyint(1) NOT NULL DEFAULT 1,
   `bn_template` text NOT NULL,
   `bn_ce_i18n` varchar(5) NOT NULL,
+  `bn_only_one_entry` enum('Y','N') NOT NULL DEFAULT 'N',
+  `bn_only_one_entry_message` text DEFAULT NULL,
   PRIMARY KEY (`bn_id_nature`)
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci ENGINE=InnoDB;
 

--- a/setup/sql/default-content.sql
+++ b/setup/sql/default-content.sql
@@ -754,7 +754,7 @@ Texte colonne 3
 # end YesWiki pages
 
 # Bazar forms
-INSERT INTO `{{prefix}}nature` (`bn_id_nature`, `bn_label_nature`, `bn_description`, `bn_condition`, `bn_sem_context`, `bn_sem_type`, `bn_sem_use_template`, `bn_template`, `bn_ce_i18n`) VALUES
+INSERT INTO `{{prefix}}nature` (`bn_id_nature`, `bn_label_nature`, `bn_description`, `bn_condition`, `bn_sem_context`, `bn_sem_type`, `bn_sem_use_template`, `bn_template`, `bn_ce_i18n`, `bn_only_one_entry`, `bn_only_one_entry_message`) VALUES
 ('4', 'Ressources', 'Un formulaire pour créer un espace de ressources partagées. ', '', '', '', '1', 'texte***bf_titre***Nom de la ressource***60***255*** *** ***text***1*** *** *** * *** * *** *** *** ***
 lien_internet***bf_url***Site web***40***255*** *** ***url***0*** *** *** * *** * *** *** *** ***
 checkbox***ListeType***Type de ressource*** *** *** *** *** ***1*** *** *** * *** * *** *** *** ***
@@ -763,12 +763,12 @@ texte***bf_auteur***Auteur***60***255*** *** ***text***0*** *** *** * *** * *** 
 image***bf_image***Image de présentation (facultatif)***140***140***600***600***right***0*** *** *** * *** * *** *** *** ***
 fichier***fichier***Documents***20000000*** *** *** ***file***0*** *** *** * *** * *** *** *** ***
 labelhtml***<h3>Il ne vous reste plus qu\'à valider ! </h3>*** *** ***
-', 'fr-FR'),
+', 'fr-FR','N',''),
 ('3', 'Blog-actu', '', '', '', '', '1', 'image***bf_image***Image***400***300***1200***900***right***1*** *** *** * *** * *** *** *** ***
 texte***bf_titre***Titre***80***255*** *** ***text***1*** *** *** * *** * *** *** *** ***
 textelong***bf_chapeau***Résumé***40***3*** *** ***wiki***1*** *** *** * *** * *** *** *** ***
 textelong***bf_description***Billet***40***9*** *** ***wiki***1*** *** *** * *** * *** *** *** ***
-', 'fr-FR'),
+', 'fr-FR','N',''),
 ('1', 'Annuaire', '', '', '', '', '1', 'titre***{{bf_nom}} {{bf_prenom}}***Titre Automatique***
 texte***bf_nom***Nom***60***255*** *** ***text***1*** *** *** * *** * *** *** *** ***
 texte***bf_prenom***Prénom***60***255*** *** ***text***1*** *** *** * *** * *** *** *** ***
@@ -783,7 +783,7 @@ texte***bf_code_postal***Code postal***8***8*** *** ***text***0*** *** *** * ***
 texte***bf_ville***Ville***50***80*** *** ***text***0*** *** *** * *** * *** *** *** ***
 map***bf_latitude***bf_longitude*** *** ***
 labelhtml***<h3>Il ne vous reste plus qu\'à valider ! </h3>*** *** ***
-', 'fr-FR'),
+', 'fr-FR','N',''),
 ('2', 'Agenda', '', '', '1', '1', '1', 'texte***bf_titre***Nom de l\'événement***60***255*** *** ***text***1*** *** *** * *** * *** *** *** ***
 textelong***bf_description***Description***40***5*** *** ***wiki***0*** *** *** * *** * *** *** *** ***
 listedatedeb***bf_date_debut_evenement***Début de l\'événement*** *** ***today*** *** ***1*** *** *** * *** * *** *** *** ***
@@ -796,7 +796,7 @@ texte***bf_code_postal***Code postal***8***8*** *** ***text***0*** *** *** * ***
 texte***bf_ville***Ville***50***80*** *** ***text***0*** *** *** * *** * *** *** *** ***
 map***bf_latitude***bf_longitude*** *** ***
 labelhtml***<h3>Il ne vous reste plus qu\'à valider ! </h3>*** *** ***
-', 'fr-FR');
+', 'fr-FR','N','');
 # end Bazar forms
 
 # Bazar lists

--- a/tools/bazar/controllers/FormController.php
+++ b/tools/bazar/controllers/FormController.php
@@ -97,7 +97,7 @@ class FormController extends YesWikiController
                 'form' => $this->formManager->getOne($id),
                 'formAndListIds' => baz_forms_and_lists_ids(),
                 'groupsList' => $this->getGroupsListIfEnabled(),
-                'onlyOneEntryOptionAvailable' => $this->formManager->isAvailableOnlyOneEntryOption()
+                'onlyOneEntryOptionAvailable' => $this->formManager->isAvailableOnlyOneEntryOption() && $this->formManager->isAvailableOnlyOneEntryMessage()
             ]);
         } else {
             return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_NEED_ADMIN_RIGHTS'], false));

--- a/tools/bazar/controllers/FormController.php
+++ b/tools/bazar/controllers/FormController.php
@@ -76,7 +76,8 @@ class FormController extends YesWikiController
 
             return $this->render("@bazar/forms/forms_form.twig", [
                 'formAndListIds' => baz_forms_and_lists_ids(),
-                'groupsList' => $this->getGroupsListIfEnabled()
+                'groupsList' => $this->getGroupsListIfEnabled(),
+                'onlyOneEntryOptionAvailable' => $this->formManager->isAvailableOnlyOneEntryOption()
             ]);
         } else {
             return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_AUTH_NEEDED'], false));
@@ -95,7 +96,8 @@ class FormController extends YesWikiController
             return $this->render("@bazar/forms/forms_form.twig", [
                 'form' => $this->formManager->getOne($id),
                 'formAndListIds' => baz_forms_and_lists_ids(),
-                'groupsList' => $this->getGroupsListIfEnabled()
+                'groupsList' => $this->getGroupsListIfEnabled(),
+                'onlyOneEntryOptionAvailable' => $this->formManager->isAvailableOnlyOneEntryOption()
             ]);
         } else {
             return $this->wiki->redirect($this->wiki->href('', '', ['vue' => 'formulaire', 'msg' => 'BAZ_NEED_ADMIN_RIGHTS'], false));

--- a/tools/bazar/lang/bazar_ca.inc.php
+++ b/tools/bazar/lang/bazar_ca.inc.php
@@ -298,6 +298,8 @@ return [
 
     // controllers/FormController.php
     'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restringeix el nombre de targetes a una per usuari (el formulari ha de contenir el \'bf_mail\')',
+    'BAZ_MESSAGE_IF_OTHER_ENTRY_EXIST' => 'Missatge a mostrar quan ja existeixi una targeta. Deixeu-ho en blanc per mantenir el missatge per defecte.',
+    'BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM' => 'Ja heu introduït una targeta per al formulari "{formName}". Es mostra a continuació.',
 
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/lang/bazar_ca.inc.php
+++ b/tools/bazar/lang/bazar_ca.inc.php
@@ -284,7 +284,7 @@ return [
     'BAZ_SEPTEMBRE' => 'Setembre',
     'BAZ_OCTOBRE' => 'Octubre',
     'BAZ_NOVEMBRE' => 'Novembre',
-    'BAZ_DECEMBRE' => 'Desembre'
+    'BAZ_DECEMBRE' => 'Desembre',
 
     // 'BAZ_TODAY' => 'Aujourd\'hui',
     // 'BAZ_MONTH' => 'Mois',
@@ -295,6 +295,9 @@ return [
     // 'BAZ_ENTER_HOUR' => 'Entrer l\'heure',
 
     // 'BAZ_RESET_FILTERS' => 'Réinitialiser les filtres',
+
+    // controllers/FormController.php
+    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restringeix el nombre de targetes a una per usuari (el formulari ha de contenir el \'bf_mail\')',
 
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/lang/bazar_ca.inc.php
+++ b/tools/bazar/lang/bazar_ca.inc.php
@@ -297,9 +297,10 @@ return [
     // 'BAZ_RESET_FILTERS' => 'Réinitialiser les filtres',
 
     // controllers/FormController.php
-    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restringeix el nombre de targetes a una per usuari (el formulari ha de contenir el \'bf_mail\')',
+    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restringeix el nombre de targetes a una per usuari',
     'BAZ_MESSAGE_IF_OTHER_ENTRY_EXIST' => 'Missatge a mostrar quan ja existeixi una targeta. Deixeu-ho en blanc per mantenir el missatge per defecte.',
     'BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM' => 'Ja heu introduït una targeta per al formulari "{formName}". Es mostra a continuació.',
+    'BAZ_USER_SHOULD_BE_CONNECTED_TO_ACCES_THIS_FORM' => 'Cal iniciar sessió per poder emplenar aquest formulari.',
 
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/lang/bazar_en.inc.php
+++ b/tools/bazar/lang/bazar_en.inc.php
@@ -296,6 +296,9 @@ return [
 
     // 'BAZ_RESET_FILTERS' => 'Réinitialiser les filtres',
 
+    // controllers/FormController.php
+    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restrict the number of cards to one per user (the form must contain the \'bf_mail\')',
+
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',
 

--- a/tools/bazar/lang/bazar_en.inc.php
+++ b/tools/bazar/lang/bazar_en.inc.php
@@ -298,6 +298,8 @@ return [
 
     // controllers/FormController.php
     'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restrict the number of cards to one per user (the form must contain the \'bf_mail\')',
+    'BAZ_MESSAGE_IF_OTHER_ENTRY_EXIST' => 'Message to display when an entry already exists. Leave blank to keep the default message.',
+    'BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM' => 'You have already entered an entry for the "{formName}" form. It is displayed below.',
 
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/lang/bazar_en.inc.php
+++ b/tools/bazar/lang/bazar_en.inc.php
@@ -297,9 +297,10 @@ return [
     // 'BAZ_RESET_FILTERS' => 'Réinitialiser les filtres',
 
     // controllers/FormController.php
-    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restrict the number of cards to one per user (the form must contain the \'bf_mail\')',
+    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restrict the number of cards to one per user',
     'BAZ_MESSAGE_IF_OTHER_ENTRY_EXIST' => 'Message to display when an entry already exists. Leave blank to keep the default message.',
     'BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM' => 'You have already entered an entry for the "{formName}" form. It is displayed below.',
+    'BAZ_USER_SHOULD_BE_CONNECTED_TO_ACCES_THIS_FORM' => 'It is necessary to be logged in to be able to complete this form.',
 
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/lang/bazar_es.inc.php
+++ b/tools/bazar/lang/bazar_es.inc.php
@@ -298,6 +298,8 @@ return [
 
     // controllers/FormController.php
     'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restrinja el número de tarjetas a una por usuario (el formulario debe contener el \'bf_mail\')',
+    'BAZ_MESSAGE_IF_OTHER_ENTRY_EXIST' => 'Mensaje para mostrar cuando ya existe una tarjeta. Deje en blanco para mantener el mensaje predeterminado.',
+    'BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM' => 'Ya ha introducido una tarjeta para el formulario "{formName}". Se muestra a continuación.',
 
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/lang/bazar_es.inc.php
+++ b/tools/bazar/lang/bazar_es.inc.php
@@ -296,6 +296,9 @@ return [
 
     // 'BAZ_RESET_FILTERS' => 'Réinitialiser les filtres',
 
+    // controllers/FormController.php
+    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restrinja el número de tarjetas a una por usuario (el formulario debe contener el \'bf_mail\')',
+
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',
 

--- a/tools/bazar/lang/bazar_es.inc.php
+++ b/tools/bazar/lang/bazar_es.inc.php
@@ -297,9 +297,10 @@ return [
     // 'BAZ_RESET_FILTERS' => 'Réinitialiser les filtres',
 
     // controllers/FormController.php
-    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restrinja el número de tarjetas a una por usuario (el formulario debe contener el \'bf_mail\')',
+    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restrinja el número de tarjetas a una por usuario',
     'BAZ_MESSAGE_IF_OTHER_ENTRY_EXIST' => 'Mensaje para mostrar cuando ya existe una tarjeta. Deje en blanco para mantener el mensaje predeterminado.',
     'BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM' => 'Ya ha introducido una tarjeta para el formulario "{formName}". Se muestra a continuación.',
+    'BAZ_USER_SHOULD_BE_CONNECTED_TO_ACCES_THIS_FORM' => 'Es necesario estar conectado para poder completar este formulario.',
 
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/lang/bazar_fr.inc.php
+++ b/tools/bazar/lang/bazar_fr.inc.php
@@ -298,6 +298,8 @@ return [
 
     // controllers/FormController.php
     'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restreindre le nombre de fiche à une seule par utilisateur (le formulaire doit contenir le champ \'bf_mail\')',
+    'BAZ_MESSAGE_IF_OTHER_ENTRY_EXIST' => 'Message à afficher quand une fiche existe déjà. Laisser vide pour garder le message par défaut.',
+    'BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM' => 'Vous avez déjà saisie une fiche pour le formulaire "{formName}". Elle est affichée ci-dessous.',
 
     // fields/BookmarkletField.php
     'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/lang/bazar_fr.inc.php
+++ b/tools/bazar/lang/bazar_fr.inc.php
@@ -297,9 +297,10 @@ return [
     'BAZ_RESET_FILTERS' => 'Réinitialiser les filtres',
 
     // controllers/FormController.php
-    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restreindre le nombre de fiche à une seule par utilisateur (le formulaire doit contenir le champ \'bf_mail\')',
+    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restreindre le nombre de fiche à une seule par utilisateur',
     'BAZ_MESSAGE_IF_OTHER_ENTRY_EXIST' => 'Message à afficher quand une fiche existe déjà. Laisser vide pour garder le message par défaut.',
-    'BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM' => 'Vous avez déjà saisie une fiche pour le formulaire "{formName}". Elle est affichée ci-dessous.',
+    'BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM' => 'Vous avez déjà saisi une fiche pour le formulaire "{formName}". Elle est affichée ci-dessous.',
+    'BAZ_USER_SHOULD_BE_CONNECTED_TO_ACCES_THIS_FORM' => 'Il est nécessaire d\'être connecté pour pouvoir compléter ce formulaire.',
 
     // fields/BookmarkletField.php
     'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/lang/bazar_fr.inc.php
+++ b/tools/bazar/lang/bazar_fr.inc.php
@@ -296,6 +296,9 @@ return [
 
     'BAZ_RESET_FILTERS' => 'Réinitialiser les filtres',
 
+    // controllers/FormController.php
+    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restreindre le nombre de fiche à une seule par utilisateur (le formulaire doit contenir le champ \'bf_mail\')',
+
     // fields/BookmarkletField.php
     'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',
 

--- a/tools/bazar/lang/bazar_nl.inc.php
+++ b/tools/bazar/lang/bazar_nl.inc.php
@@ -297,9 +297,10 @@ return [
     // 'BAZ_RESET_FILTERS' => 'Réinitialiser les filtres',
 
     // controllers/FormController.php
-    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Beperk het aantal kaarten tot één per gebruiker (het formulier moet de \'bf_mail\') bevatten.',
+    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Beperk het aantal kaarten tot één per gebruiker bevatten.',
     'BAZ_MESSAGE_IF_OTHER_ENTRY_EXIST' => 'Mensagem para exibir quando um cartão já existe. Laat leeg om het standaardbericht te behouden.',
     'BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM' => 'U hebt al een kaart ingevoerd voor het formulier "{formName}". Het wordt hieronder weergegeven.',
+    'BAZ_USER_SHOULD_BE_CONNECTED_TO_ACCES_THIS_FORM' => 'Het is noodzakelijk om ingelogd te zijn om dit formulier te kunnen invullen.',
 
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/lang/bazar_nl.inc.php
+++ b/tools/bazar/lang/bazar_nl.inc.php
@@ -289,12 +289,15 @@ return [
     'BAZ_TODAY' => 'Vandaag',
     'BAZ_MONTH' => 'Maand',
     'BAZ_WEEK' => 'Week',
-    'BAZ_DAY' => 'Dag'
+    'BAZ_DAY' => 'Dag',
 
     // 'BAZ_ALL_DAY' => 'Toute la journ&eacute;e',
     // 'BAZ_ENTER_HOUR' => 'Entrer l\'heure',
 
     // 'BAZ_RESET_FILTERS' => 'Réinitialiser les filtres',
+
+    // controllers/FormController.php
+    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Beperk het aantal kaarten tot één per gebruiker (het formulier moet de \'bf_mail\') bevatten.',
 
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/lang/bazar_nl.inc.php
+++ b/tools/bazar/lang/bazar_nl.inc.php
@@ -298,6 +298,8 @@ return [
 
     // controllers/FormController.php
     'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Beperk het aantal kaarten tot één per gebruiker (het formulier moet de \'bf_mail\') bevatten.',
+    'BAZ_MESSAGE_IF_OTHER_ENTRY_EXIST' => 'Mensagem para exibir quando um cartão já existe. Laat leeg om het standaardbericht te behouden.',
+    'BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM' => 'U hebt al een kaart ingevoerd voor het formulier "{formName}". Het wordt hieronder weergegeven.',
 
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/lang/bazar_pt.inc.php
+++ b/tools/bazar/lang/bazar_pt.inc.php
@@ -294,6 +294,9 @@ return [
 
     // 'BAZ_RESET_FILTERS' => 'Réinitialiser les filtres',
 
+    // controllers/FormController.php
+    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restringir o número de cartões a um por utilizador (o formulário deve conter o \'bf_mail\')',
+
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',
 

--- a/tools/bazar/lang/bazar_pt.inc.php
+++ b/tools/bazar/lang/bazar_pt.inc.php
@@ -295,9 +295,10 @@ return [
     // 'BAZ_RESET_FILTERS' => 'Réinitialiser les filtres',
 
     // controllers/FormController.php
-    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restringir o número de cartões a um por utilizador (o formulário deve conter o \'bf_mail\')',
+    'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restringir o número de cartões a um por utilizador',
     'BAZ_MESSAGE_IF_OTHER_ENTRY_EXIST' => 'Mensagem para exibir quando um cartão já existe. Laat leeg om het standaardbericht te behouden.',
     'BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM' => 'Já inseriu um cartão para o formulário "{formName}". É exibido abaixo.',
+    'BAZ_USER_SHOULD_BE_CONNECTED_TO_ACCES_THIS_FORM' => 'É necessário fazer login para poder completar este formulário.',
 
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/lang/bazar_pt.inc.php
+++ b/tools/bazar/lang/bazar_pt.inc.php
@@ -296,6 +296,8 @@ return [
 
     // controllers/FormController.php
     'BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM' => 'Restringir o número de cartões a um por utilizador (o formulário deve conter o \'bf_mail\')',
+    'BAZ_MESSAGE_IF_OTHER_ENTRY_EXIST' => 'Mensagem para exibir quando um cartão já existe. Laat leeg om het standaardbericht te behouden.',
+    'BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM' => 'Já inseriu um cartão para o formulário "{formName}". É exibido abaixo.',
 
     // fields/BookmarkletField.php
     // 'BAZ_CLOSE_THIS_WINDOW' => 'Fermer cette fen&ecirc;tre',

--- a/tools/bazar/services/FormManager.php
+++ b/tools/bazar/services/FormManager.php
@@ -22,6 +22,7 @@ class FormManager
 
     protected $cachedForms;
     protected $isAvailableOnlyOneEntryOption;
+    protected $isAvailableOnlyOneEntryMessage;
 
     public function __construct(
         Wiki $wiki,
@@ -40,6 +41,7 @@ class FormManager
         $this->cachedForms = [];
         $this->securityController = $securityController;
         $this->isAvailableOnlyOneEntryOption = null;
+        $this->isAvailableOnlyOneEntryMessage = null;
     }
 
     public function getOne($formId): ?array
@@ -107,6 +109,7 @@ class FormManager
         return $this->dbService->query('INSERT INTO ' . $this->dbService->prefixTable('nature')
             . '(`bn_id_nature` ,`bn_ce_i18n` ,`bn_label_nature` ,`bn_template` ,`bn_description` ,`bn_sem_context` ,`bn_sem_type` ,`bn_sem_use_template`'
             . ($this->isAvailableOnlyOneEntryOption() ? ',`bn_only_one_entry`' : '')
+            . ($this->isAvailableOnlyOneEntryMessage() ? ',`bn_only_one_entry_message`' : '')
             .',`bn_condition`)'
             . ' VALUES (' . $data['bn_id_nature'] . ', "fr-FR", "'
             . $this->dbService->escape(_convert($data['bn_label_nature'], YW_CHARSET, true)) . '","'
@@ -116,6 +119,7 @@ class FormManager
             . $this->dbService->escape(_convert($data['bn_sem_type'], YW_CHARSET, true)) . '", '
             . (isset($data['bn_sem_use_template']) ? '1' : '0') . ', "'
             . ($this->isAvailableOnlyOneEntryOption() ? ((isset($data['bn_only_one_entry']) && $data['bn_only_one_entry'] === "Y") ? "Y" : "N") . '", "' : '')
+            . ($this->isAvailableOnlyOneEntryMessage() ? (empty($data['bn_only_one_entry_message']) ? "" : $this->dbService->escape(_convert($data['bn_only_one_entry_message'], YW_CHARSET, true))) . '", "' : '')
             . $this->dbService->escape(_convert($data['bn_condition'], YW_CHARSET, true)) . '")');
     }
 
@@ -132,6 +136,7 @@ class FormManager
             . '`bn_sem_type`="' . $this->dbService->escape(_convert($data['bn_sem_type'], YW_CHARSET, true)) . '" ,'
             . '`bn_sem_use_template`=' . (isset($data['bn_sem_use_template']) ? '1' : '0') . ' ,'
             . ($this->isAvailableOnlyOneEntryOption() ? '`bn_only_one_entry`="' . ((isset($data['bn_only_one_entry']) && $data['bn_only_one_entry'] === "Y") ? "Y" : "N") . '",' : '')
+            . ($this->isAvailableOnlyOneEntryMessage() ? '`bn_only_one_entry_message`="' . (empty($data['bn_only_one_entry_message']) ? "" : $this->dbService->escape(_convert($data['bn_only_one_entry_message'], YW_CHARSET, true))) . '",' : '')
             . '`bn_condition`="' . $this->dbService->escape(_convert($data['bn_condition'], YW_CHARSET, true)) . '"'
             . ' WHERE `bn_id_nature`=' . $this->dbService->escape($data['bn_id_nature']));
     }
@@ -415,5 +420,18 @@ class FormManager
             $this->isAvailableOnlyOneEntryOption = (@mysqli_num_rows($result) !== 0);
         }
         return $this->isAvailableOnlyOneEntryOption;
+    }
+
+    /**
+     * check if the bn_only_one_entry_message is available
+     * @return bool
+     */
+    public function isAvailableOnlyOneEntryMessage(): bool
+    {
+        if (is_null($this->isAvailableOnlyOneEntryMessage)) {
+            $result = $this->dbService->query("SHOW COLUMNS FROM {$this->dbService->prefixTable("nature")} LIKE 'bn_only_one_entry_message';");
+            $this->isAvailableOnlyOneEntryMessage = (@mysqli_num_rows($result) !== 0);
+        }
+        return $this->isAvailableOnlyOneEntryMessage;
     }
 }

--- a/tools/bazar/templates/forms/forms_form.twig
+++ b/tools/bazar/templates/forms/forms_form.twig
@@ -83,10 +83,30 @@
     <div class="controls checkbox">
       <label for="bn_only_one_entry">
 			    {% apply spaceless %}
-            <input id="bn_only_one_entry" type="checkbox" value="Y" name="bn_only_one_entry"{{ form.bn_only_one_entry == "Y" ? ' checked' : ''}}/>
+            <input 
+              id="bn_only_one_entry" 
+              type="checkbox" 
+              value="Y" 
+              name="bn_only_one_entry"{{ form.bn_only_one_entry == "Y" ? ' checked' : ''}}
+              onchange="javascript:if($(this).prop('checked')){$('#bn_only_one_entry_message-group').show();}else{$('#bn_only_one_entry_message-group').hide();};"
+              />
             <span>{{ _t('BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM') }}</span>
 			    {% endapply %}
         </label>
+    </div>
+    <div id="bn_only_one_entry_message-group" class="control-group form-group"{{ form.bn_only_one_entry == "Y" ? '': ' style="display:none;"' }}>
+      <label class="control-label col-sm-3">
+        {{ _t('BAZ_MESSAGE_IF_OTHER_ENTRY_EXIST') }}
+      </label>
+      <div class="controls col-sm-9">
+        <input
+          class="form-control input-xxlarge"
+          name="bn_only_one_entry_message"
+          type="text"
+          value="{{ form.bn_only_one_entry_message }}"
+          placeholder="{{ _t('BAZ_FORM_DEFAULT_MESSAGE_FOR_OTHER_ENTRY_IN_FORM') }}"
+        />
+      </div>
     </div>
   {% endif %}
 

--- a/tools/bazar/templates/forms/forms_form.twig
+++ b/tools/bazar/templates/forms/forms_form.twig
@@ -79,6 +79,17 @@
     </div>
   </div>
 
+  {% if onlyOneEntryOptionAvailable %}
+    <div class="controls checkbox">
+      <label for="bn_only_one_entry">
+			    {% apply spaceless %}
+            <input id="bn_only_one_entry" type="checkbox" value="Y" name="bn_only_one_entry"{{ form.bn_only_one_entry == "Y" ? ' checked' : ''}}/>
+            <span>{{ _t('BAZ_ONLY_ONE_ENTRY_FOR_THIS_FORM') }}</span>
+			    {% endapply %}
+        </label>
+    </div>
+  {% endif %}
+
   <div class="control-group form-group">
     <div class="controls col-sm-9 col-sm-offset-3">
       <div class="accordion-heading">


### PR DESCRIPTION
**PR draft pour le moment** le temps de discuter

Cette PR fait suite à nos discussions pour avoir une seule fiche par utilisateur pour certains formulaires.

**Ce que ça fait**:
 - modifier la base de données pour stocker l'option 'une seule fiche' vie `UpdateHandler`
 - ajouter une case à cocher en bas de formulaire pour activer le mode 'une seule fiche'
 - vérifie si une fiche existe déjà sur ce formulaire pour l'utilisateur connecté (critère owner ou bf_mail si existant)
   - si oui : l'affiche
   - si non : formulaire standard
 - pour un utilisateur non connecté, vérifie que le contenu de `bf_mail`  envoyé lors de l'enregistrement n'est pas déjà existant pour une autre fiche
   - si oui : message d'erreur à la création
   - si non : enregistre
   - cas de la mise à jour d'une fiche : pas de test (l'idéal serait que les fiches aient par défaut des droits de modification différents de '*' pour ce formulaire)

**A discuter**:
 - nom de la colonne dans la base de données
 - le contenu des fichiers de traduction
 - la structure retenu
 - les personnalisation à ajouter
 - stabiliser le système de mise à jour des fiches : droits de modification ? '*' interdit pour le formulaire ?, ...
 
 @acheype @mrflos merci pour vos retours et si vous voulez proposer du code pour améliorer 3 options:
  - soit dans un commentaire
  - soit via une PR vers cette branche
  - soit avec un commit direct MAIS en me prévenant avant pour que je puisse être attentif lors de mes `rebase` de ne pas écraser ce commit