### PR TITLE
Fix xss for text fields

### DIFF
--- a/actions/EditConfigAction.php
+++ b/actions/EditConfigAction.php
@@ -18,6 +18,7 @@ class EditConfigAction extends YesWikiAction
         'allowed_methods_in_iframe' => 'core',
         'revisionscount' => 'core',
         'default_comment_avatar' => 'core',
+        'htmlPurifierActivated' => 'core',
 
         'default_read_acl' => 'access',
         'default_write_acl' => 'access',

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "doctrine/annotations": "^1.11",
         "doctrine/cache": "^1.10",
         "enshrined/svg-sanitize": "^0.15.0",
+        "ezyang/htmlpurifier": "^4.14",
         "oomphinc/composer-installers-extender": "^2.0",
         "phpmailer/phpmailer": "^6.2",
         "symfony/config": "^5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f098d95761ca9b9519b1eac6f069d39e",
+    "content-hash": "55e2262a8295fa485cfe0588ea4fdd1b",
     "packages": [
         {
             "name": "caxy/php-htmldiff",
@@ -1162,16 +1162,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.0",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
+                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
-                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
                 "shasum": ""
             },
             "require": {
@@ -1209,7 +1209,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.1"
             },
             "funding": [
                 {
@@ -1225,7 +1225,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-12T14:48:14+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -1385,16 +1385,16 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.5.0",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "66bea3b09be61613cd3b4043a65a8ec48cfa6d2a"
+                "reference": "f98b54df6ad059855739db6fcbc2d36995283fe1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/66bea3b09be61613cd3b4043a65a8ec48cfa6d2a",
-                "reference": "66bea3b09be61613cd3b4043a65a8ec48cfa6d2a",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/f98b54df6ad059855739db6fcbc2d36995283fe1",
+                "reference": "f98b54df6ad059855739db6fcbc2d36995283fe1",
                 "shasum": ""
             },
             "require": {
@@ -1444,7 +1444,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.5.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.5.1"
             },
             "funding": [
                 {
@@ -1460,7 +1460,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-12T14:48:14+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -2612,22 +2612,22 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.5.0",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc"
+                "reference": "24d9dc654b83e91aa59f9d167b131bc3b5bea24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
-                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/24d9dc654b83e91aa59f9d167b131bc3b5bea24c",
+                "reference": "24d9dc654b83e91aa59f9d167b131bc3b5bea24c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "psr/container": "^1.1",
-                "symfony/deprecation-contracts": "^2.1"
+                "symfony/deprecation-contracts": "^2.1|^3"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -2675,7 +2675,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.1"
             },
             "funding": [
                 {
@@ -2691,7 +2691,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-04T16:48:04+00:00"
+            "time": "2022-03-13T20:07:29+00:00"
         },
         {
             "name": "symfony/string",
@@ -3008,16 +3008,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.3.9",
+            "version": "v3.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "6ff9b0e440fa66f97f207e181c41340ddfa5683d"
+                "reference": "8442df056c51b706793adf80a9fd363406dd3674"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/6ff9b0e440fa66f97f207e181c41340ddfa5683d",
-                "reference": "6ff9b0e440fa66f97f207e181c41340ddfa5683d",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/8442df056c51b706793adf80a9fd363406dd3674",
+                "reference": "8442df056c51b706793adf80a9fd363406dd3674",
                 "shasum": ""
             },
             "require": {
@@ -3068,7 +3068,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.3.9"
+                "source": "https://github.com/twigphp/Twig/tree/v3.3.10"
             },
             "funding": [
                 {
@@ -3080,7 +3080,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-25T09:37:52+00:00"
+            "time": "2022-04-06T06:47:41+00:00"
         },
         {
             "name": "yeswiki/theme-margot",

--- a/includes/YesWikiInit.php
+++ b/includes/YesWikiInit.php
@@ -241,6 +241,7 @@ class Init
             'timezone' => 'GMT', // Only used if not set in wakka.config.php nor in php.ini
             'root_page' => 'PagePrincipale', // backup root_page if deleted from wakka.config.php
             'wakka_name' => '', // backup wakka_name if deleted from wakka.config.php
+            'htmlPurifierActivated' => false, // TODO ectoplasme set to true
         );
         unset($_rewrite_mode);
 

--- a/includes/services/HtmlPurifierService.php
+++ b/includes/services/HtmlPurifierService.php
@@ -10,8 +10,6 @@ use YesWiki\Wiki;
 
 class HtmlPurifierService
 {
-    public const HTMLPURIFIER_PATH = "vendor/ezyang/htmlpurifier/";
-
     protected $wiki;
     private $purifier;
 

--- a/includes/services/HtmlPurifierService.php
+++ b/includes/services/HtmlPurifierService.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace YesWiki\Core\Service;
+
+use HTMLPurifier;
+use HTMLPurifier_Config;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use YesWiki\Security\Controller\SecurityController;
+use YesWiki\Wiki;
+
+class HtmlPurifierService
+{
+    public const HTMLPURIFIER_PATH = "vendor/ezyang/htmlpurifier/";
+
+    protected $wiki;
+    private $purifier;
+
+    public function __construct(Wiki $wiki)
+    {
+        $this->wiki = $wiki;
+        $this->purifier = null;
+    }
+
+    /**
+     * load a HTMLpurifier if needed
+     * configure it
+     *  then use it to clean HTML
+     */
+    public function cleanHTML(string $dirty_html): string
+    {
+        if (is_null($this->purifier)) {
+            $this->load();
+        }
+
+        return $this->purifier->purify($dirty_html);
+    }
+
+    private function load()
+    {
+        $config = HTMLPurifier_Config::createDefault();
+        $this->purifier = new HTMLPurifier($config);
+    }
+}

--- a/includes/services/HtmlPurifierService.php
+++ b/includes/services/HtmlPurifierService.php
@@ -10,11 +10,13 @@ use YesWiki\Wiki;
 
 class HtmlPurifierService
 {
+    protected $params;
     protected $wiki;
     private $purifier;
 
-    public function __construct(Wiki $wiki)
+    public function __construct(Wiki $wiki, ParameterBagInterface $params)
     {
+        $this->params = $params;
         $this->wiki = $wiki;
         $this->purifier = null;
     }
@@ -26,6 +28,9 @@ class HtmlPurifierService
      */
     public function cleanHTML(string $dirty_html): string
     {
+        if (!$this->params->get('htmlPurifierActivated')) {
+            return $dirty_html;
+        }
         if (is_null($this->purifier)) {
             $this->load();
         }

--- a/lang/yeswiki_ca.php
+++ b/lang/yeswiki_ca.php
@@ -518,6 +518,7 @@ return [
     // 'EDIT_CONFIG_HINT_TIMEZONE' => 'Fuseau horaire du site (ex. UCT, Europe/Paris, Europe/London, GMT = utiliser celui du serveur,)',
     // 'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,all = autoriser tout)',
     // 'EDIT_CONFIG_HINT_REVISIONSCOUNT' => 'Nombre maximum de versions d\'une page affichées par le handler `/revisions`.',
+    // 'EDIT_CONFIG_HINT_HTMLPURIFIERACTIVATED' => 'Activer le nettoyage HTML avant sauvegarde. Attention, modifie le contenu à la sauvegarde ! (true ou false)',
     // 'EDIT_CONFIG_GROUP_CORE' => 'Paramètres Principaux',
     // 'EDIT_CONFIG_GROUP_ACCESS' => 'Droit d\'accès',
     // 'EDIT_CONFIG_GROUP_EMAIL' => 'Emails',

--- a/lang/yeswiki_en.php
+++ b/lang/yeswiki_en.php
@@ -482,6 +482,7 @@ return [
     // 'EDIT_CONFIG_HINT_TIMEZONE' => 'Fuseau horaire du site (ex. UCT, Europe/Paris, Europe/London, GMT = utiliser celui du serveur,)',
     // 'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,all = autoriser tout)',
     'EDIT_CONFIG_HINT_REVISIONSCOUNT' => 'Maximum number of page\'s revisions displayed by the handler `/revisions`.',
+    // 'EDIT_CONFIG_HINT_HTMLPURIFIERACTIVATED' => 'Activer le nettoyage HTML avant sauvegarde. Attention, modifie le contenu à la sauvegarde ! (true ou false)',
     'EDIT_CONFIG_GROUP_CORE' => 'Main parameters',
     'EDIT_CONFIG_GROUP_ACCESS' => "Access rights",
     'EDIT_CONFIG_GROUP_EMAIL' => 'Emails',

--- a/lang/yeswiki_es.php
+++ b/lang/yeswiki_es.php
@@ -520,6 +520,7 @@ return [
     // 'EDIT_CONFIG_HINT_TIMEZONE' => 'Fuseau horaire du site (ex. UCT, Europe/Paris, Europe/London, GMT = utiliser celui du serveur,)',
     // 'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,all = autoriser tout)',
     // 'EDIT_CONFIG_HINT_REVISIONSCOUNT' => 'Nombre maximum de versions d\'une page affichées par le handler `/revisions`.',
+    // 'EDIT_CONFIG_HINT_HTMLPURIFIERACTIVATED' => 'Activer le nettoyage HTML avant sauvegarde. Attention, modifie le contenu à la sauvegarde ! (true ou false)',
     // 'EDIT_CONFIG_GROUP_CORE' => 'Paramètres Principaux',
     // 'EDIT_CONFIG_GROUP_ACCESS' => 'Droit d\'accès',
     // 'EDIT_CONFIG_GROUP_EMAIL' => 'Emails',

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -530,6 +530,7 @@ return [
     'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,all = autoriser tout)',
     'EDIT_CONFIG_HINT_REVISIONSCOUNT' => 'Nombre maximum de versions d\'une page affichées par le handler `/revisions`.',
     'EDIT_CONFIG_HINT_DEFAULT_COMMENT_AVATAR' => 'Image d\'avatar par défaut pour les commentaires (URL vers une image)',
+    'EDIT_CONFIG_HINT_HTMLPURIFIERACTIVATED' => 'Activer le nettoyage HTML avant sauvegarde. Attention, modifie le contenu à la sauvegarde ! (true ou false)',
     'EDIT_CONFIG_GROUP_CORE' => 'Paramètres Principaux',
     'EDIT_CONFIG_GROUP_ACCESS' => 'Droit d\'accès',
     'EDIT_CONFIG_GROUP_EMAIL' => 'Emails',

--- a/lang/yeswiki_nl.php
+++ b/lang/yeswiki_nl.php
@@ -517,6 +517,7 @@ return [
     // 'EDIT_CONFIG_HINT_TIMEZONE' => 'Fuseau horaire du site (ex. UCT, Europe/Paris, Europe/London, GMT = utiliser celui du serveur,)',
     // 'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,all = autoriser tout)',
     // 'EDIT_CONFIG_HINT_REVISIONSCOUNT' => 'Nombre maximum de versions d\'une page affichées par le handler `/revisions`.',
+    // 'EDIT_CONFIG_HINT_HTMLPURIFIERACTIVATED' => 'Activer le nettoyage HTML avant sauvegarde. Attention, modifie le contenu à la sauvegarde ! (true ou false)',
     // 'EDIT_CONFIG_GROUP_CORE' => 'Paramètres Principaux',
     // 'EDIT_CONFIG_GROUP_ACCESS' => 'Droit d\'accès',
     // 'EDIT_CONFIG_GROUP_EMAIL' => 'Emails',

--- a/lang/yeswiki_pt.php
+++ b/lang/yeswiki_pt.php
@@ -517,6 +517,7 @@ return [
     // 'EDIT_CONFIG_HINT_TIMEZONE' => 'Fuseau horaire du site (ex. UCT, Europe/Paris, Europe/London, GMT = utiliser celui du serveur,)',
     // 'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,all = autoriser tout)',
     // 'EDIT_CONFIG_HINT_REVISIONSCOUNT' => 'Nombre maximum de versions d\'une page affichées par le handler `/revisions`.',
+    // 'EDIT_CONFIG_HINT_HTMLPURIFIERACTIVATED' => 'Activer le nettoyage HTML avant sauvegarde. Attention, modifie le contenu à la sauvegarde ! (true ou false)',
     // 'EDIT_CONFIG_GROUP_CORE' => 'Paramètres Principaux',
     // 'EDIT_CONFIG_GROUP_ACCESS' => 'Droit d\'accès',
     // 'EDIT_CONFIG_GROUP_EMAIL' => 'Emails',

--- a/setup/install.php
+++ b/setup/install.php
@@ -51,6 +51,8 @@ $config['wikini_version'] = WIKINI_VERSION;
 $config['wakka_version'] = WAKKA_VERSION;
 $config['yeswiki_version'] = YESWIKI_VERSION;
 $config['yeswiki_release'] = YESWIKI_RELEASE;
+// default var
+$config['htmlPurifierActivated'] = true; // TODO ectoplasme remove this line
 // list of tableNames
 $tablesNames = ['pages','links','referrers','nature','triples','users','acls'];
 

--- a/styles/yeswiki-base.css
+++ b/styles/yeswiki-base.css
@@ -749,3 +749,16 @@ section.full-width:not(.with-bg-pattern) {
 .comment-reponses .yw-comment {
   margin: 1em 0;
 }
+
+/* === trick to manage lists'translation === */
+
+html[lang="ca"] [lang]:not([lang="ca"]),
+html[lang="en"] [lang]:not([lang="en"]),
+html[lang="es"] [lang]:not([lang="es"]),
+html[lang="fr"] [lang]:not([lang="fr"]),
+html[lang="nl"] [lang]:not([lang="nl"]),
+html[lang="pt"] [lang]:not([lang="pt"]){
+  display:none;
+}
+
+/* === === */

--- a/tools/bazar/fields/TextField.php
+++ b/tools/bazar/fields/TextField.php
@@ -3,6 +3,7 @@
 namespace YesWiki\Bazar\Field;
 
 use Psr\Container\ContainerInterface;
+use YesWiki\Core\Service\HtmlPurifierService;
 
 /**
  * @Field({"texte"})
@@ -62,6 +63,17 @@ class TextField extends BazarField
                 'value' => $value
             ]);
         }
+    }
+
+    public function formatValuesBeforeSave($entry)
+    {
+        if (empty($this->propertyName)) {
+            return [];
+        }
+        $dirtyHtml = $this->getValue($entry);
+        $cleanHTML = $this->getService(HtmlPurifierService::class)->cleanHTML($dirtyHtml);
+
+        return [$this->propertyName => $cleanHTML];
     }
 
     public function getPattern()

--- a/tools/bazar/fields/TitleField.php
+++ b/tools/bazar/fields/TitleField.php
@@ -34,7 +34,8 @@ class TitleField extends BazarField
 
     public function formatValuesBeforeSave($entry)
     {
-        $value = $this->getValue($entry);
+        $dirtyHtml = $this->getValue($entry);
+        $value = $this->getService(HtmlPurifierService::class)->cleanHTML($dirtyHtml);
         $formManager = $this->getService(FormManager::class);
 
         // TODO improve import detection

--- a/tools/bazar/templates/fields/radio.twig
+++ b/tools/bazar/templates/fields/radio.twig
@@ -1,1 +1,3 @@
 {% extends "@bazar/layouts/field.twig" %}
+
+{% block value %}{{ value|raw }}{% endblock %}

--- a/tools/bazar/templates/fields/select.twig
+++ b/tools/bazar/templates/fields/select.twig
@@ -1,1 +1,3 @@
 {% extends "@bazar/layouts/field.twig" %}
+
+{% block value %}{{ value|raw }}{% endblock %}

--- a/tools/bazar/templates/fields/text.twig
+++ b/tools/bazar/templates/fields/text.twig
@@ -1,1 +1,3 @@
 {% extends "@bazar/layouts/field.twig" %}
+
+{% block value %}{{ value|raw }}{% endblock %}

--- a/tools/bazar/templates/layouts/field.twig
+++ b/tools/bazar/templates/layouts/field.twig
@@ -7,7 +7,7 @@
     {% endblock %}
     {% block value_container %}
         <span class="BAZ_texte">
-            {% block value %}{{ value|raw|e }}{% endblock %}
+            {% block value %}{{ value }}{% endblock %}
         </span>
     {% endblock %}
 </div>

--- a/tools/bazar/templates/layouts/field.twig
+++ b/tools/bazar/templates/layouts/field.twig
@@ -7,7 +7,7 @@
     {% endblock %}
     {% block value_container %}
         <span class="BAZ_texte">
-            {% block value %}{{ value|raw }}{% endblock %}
+            {% block value %}{{ value|raw|e }}{% endblock %}
         </span>
     {% endblock %}
 </div>


### PR DESCRIPTION
Je crée cette PR pour proposer un nettoyage automatique du HTML qui peut être ajouté dans le champ `textelong` par exemple.
et dans les champs `texte`

Ceci permet de réduire les attaques XSS;
L'option est activée par défaut pour les nouveaux wiki mais doit être activée manuellement pour les wikis existants afin de ne pas changer le comportement.

En effet, lors de l'enregistrement des champs concernées, la valeur sauvegardée peut être différente de la valeur saisie par l'utilisateur afin de retirer les bouts de codes problématiques.

**ce que ça fait**:
 - utiliser la librairie htmlpurifier déjà présente dans YesWiki pour nettoyer les champs lors de l'enregistrement
 - passer l'affichage par défaut des champs sans le `|raw` pour les champs bazar (côté twig)

**A vérifier**:
 - que tous les champs bazar soient toujours bien affichés par la suppression du `|raw`