### PR TITLE
refactor(Bazar/Update__): add parameters to core function to simplify…

### DIFF
--- a/tools/bazar/fields/UserField.php
+++ b/tools/bazar/fields/UserField.php
@@ -155,6 +155,9 @@ class UserField extends BazarField
                 && $entry['mot_de_passe_wikini'] !== $entry['mot_de_passe_repete_wikini']) {
                 throw new UserFieldException(_t('USER_PASSWORDS_NOT_IDENTICAL'));
             }
+            if (empty($entry['mot_de_passe_wikini'])) {
+                throw new UserFieldException(_t('BAZ_USER_FIELD_EMPTY_PASSWORD'));
+            }
 
             // check existence of user with same
             $userManager->create($wikiName, $entry[$this->emailField], $entry['mot_de_passe_wikini']);

--- a/tools/bazar/handlers/UpdateHandler__.php
+++ b/tools/bazar/handlers/UpdateHandler__.php
@@ -3,6 +3,7 @@
 namespace YesWiki\Bazar;
 
 use DateInterval;
+use DateTime;
 use Throwable;
 use YesWiki\Bazar\Field\MapField;
 use YesWiki\Bazar\Service\EntryManager;
@@ -52,13 +53,20 @@ class UpdateHandler__ extends YesWikiHandler
         $updatedEntries = [];
         $entriesWithErrors = [];
         if (!empty($entries)) {
+            $startTime = new DateTime();
+            $startTimePlus20s = $startTime->add(new DateInterval("PT20S"));
             foreach ($entries as $entry) {
-                try {
-                    if ($this->extractOldCarto($entry)) {
-                        $updatedEntries[] = $entry['id_fiche'];
+                if ($startTimePlus20s->diff(new DateTime())->invert > 0){
+                    // current DateTime below startTimePlus30s
+                    try {
+                        if ($this->extractOldCarto($entry)) {
+                            $updatedEntries[] = $entry['id_fiche'];
+                        }
+                    } catch (Throwable $th) {
+                        $entriesWithErrors[$entry['id_fiche']] = $th->getMessage();
                     }
-                } catch (Throwable $th) {
-                    $entriesWithErrors[$entry['id_fiche']] = $th->getMessage();
+                } else {
+                    $entriesWithErrors[$entry['id_fiche']] = "Not enough time, reload /update to finish !";
                 }
             }
         }

--- a/tools/bazar/lang/bazar_ca.inc.php
+++ b/tools/bazar/lang/bazar_ca.inc.php
@@ -365,6 +365,7 @@ return [
     // 'BAZ_USER_FIELD_ALREADY_CONNECTED_AUTOUPDATE' => 'Pour changer l\'adresse e-mail associée à ce compte, tapez-en une différente de "{email}".',
     // 'BAZ_USER_FIELD_FORCE_SAVE_ENTRY' => 'En tant qu\'admin, forcer la création de la fiche pour l\'e-mail donné (et ne créer un compte que s\'il n\'existe pas déjà)',
     // 'BAZ_USER_FIELD_LABEL' => 'Utilisateur',
+    // 'BAZ_USER_FIELD_EMPTY_PASSWORD' => 'Mot de passe vide !',
 
     // presentation/templates/annuaire_alphabetique.tpl.html
     // 'BAZ_MEMBERS' => 'membres',

--- a/tools/bazar/lang/bazar_en.inc.php
+++ b/tools/bazar/lang/bazar_en.inc.php
@@ -365,6 +365,7 @@ return [
     // 'BAZ_USER_FIELD_ALREADY_CONNECTED_AUTOUPDATE' => 'Pour changer l\'adresse e-mail associée à ce compte, tapez-en une différente de "{email}".',
     // 'BAZ_USER_FIELD_FORCE_SAVE_ENTRY' => 'En tant qu\'admin, forcer la création de la fiche pour l\'e-mail donné (et ne créer un compte que s\'il n\'existe pas déjà)',
     'BAZ_USER_FIELD_LABEL' => 'User',
+    // 'BAZ_USER_FIELD_EMPTY_PASSWORD' => 'Mot de passe vide !',
 
     // presentation/templates/annuaire_alphabetique.tpl.html
     // 'BAZ_MEMBERS' => 'membres',

--- a/tools/bazar/lang/bazar_es.inc.php
+++ b/tools/bazar/lang/bazar_es.inc.php
@@ -365,6 +365,7 @@ return [
     // 'BAZ_USER_FIELD_ALREADY_CONNECTED_AUTOUPDATE' => 'Pour changer l\'adresse e-mail associée à ce compte, tapez-en une différente de "{email}".',
     // 'BAZ_USER_FIELD_FORCE_SAVE_ENTRY' => 'En tant qu\'admin, forcer la création de la fiche pour l\'e-mail donné (et ne créer un compte que s\'il n\'existe pas déjà)',
     // 'BAZ_USER_FIELD_LABEL' => 'Utilisateur',
+    // 'BAZ_USER_FIELD_EMPTY_PASSWORD' => 'Mot de passe vide !',
 
     // presentation/templates/annuaire_alphabetique.tpl.html
     // 'BAZ_MEMBERS' => 'membres',

--- a/tools/bazar/lang/bazar_fr.inc.php
+++ b/tools/bazar/lang/bazar_fr.inc.php
@@ -365,6 +365,7 @@ return [
     'BAZ_USER_FIELD_ALREADY_CONNECTED_AUTOUPDATE' => 'Pour changer l\'adresse e-mail associée à ce compte, tapez-en une différente de "{email}".',
     'BAZ_USER_FIELD_FORCE_SAVE_ENTRY' => 'En tant qu\'admin, forcer la création de la fiche pour l\'e-mail donné (et ne créer un compte que s\'il n\'existe pas déjà)',
     'BAZ_USER_FIELD_LABEL' => 'Utilisateur',
+    'BAZ_USER_FIELD_EMPTY_PASSWORD' => 'Mot de passe vide !',
 
     // presentation/templates/annuaire_alphabetique.tpl.html
     'BAZ_MEMBERS' => 'membres',

--- a/tools/bazar/lang/bazar_nl.inc.php
+++ b/tools/bazar/lang/bazar_nl.inc.php
@@ -365,6 +365,7 @@ return [
     // 'BAZ_USER_FIELD_ALREADY_CONNECTED_AUTOUPDATE' => 'Pour changer l\'adresse e-mail associée à ce compte, tapez-en une différente de "{email}".',
     // 'BAZ_USER_FIELD_FORCE_SAVE_ENTRY' => 'En tant qu\'admin, forcer la création de la fiche pour l\'e-mail donné (et ne créer un compte que s\'il n\'existe pas déjà)',
     // 'BAZ_USER_FIELD_LABEL' => 'Utilisateur',
+    // 'BAZ_USER_FIELD_EMPTY_PASSWORD' => 'Mot de passe vide !',
 
     // presentation/templates/annuaire_alphabetique.tpl.html
     // 'BAZ_MEMBERS' => 'membres',

--- a/tools/bazar/lang/bazar_pt.inc.php
+++ b/tools/bazar/lang/bazar_pt.inc.php
@@ -363,6 +363,7 @@ return [
     // 'BAZ_USER_FIELD_ALREADY_CONNECTED_AUTOUPDATE' => 'Pour changer l\'adresse e-mail associée à ce compte, tapez-en une différente de "{email}".',
     // 'BAZ_USER_FIELD_FORCE_SAVE_ENTRY' => 'En tant qu\'admin, forcer la création de la fiche pour l\'e-mail donné (et ne créer un compte que s\'il n\'existe pas déjà)',
     // 'BAZ_USER_FIELD_LABEL' => 'Utilisateur',
+    // 'BAZ_USER_FIELD_EMPTY_PASSWORD' => 'Mot de passe vide !',
 
     // presentation/templates/annuaire_alphabetique.tpl.html
     // 'BAZ_MEMBERS' => 'membres',

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -614,6 +614,16 @@ class EntryManager
 
         $this->validate($data);
 
+           
+        if (!$sendmail){
+            // prevent UserField to send emails
+            // @todo find a better way to have this behaviour (see in UserField)
+            if (!isset($GLOBALS['_BAZAR_'])) {
+                $GLOBALS['_BAZAR_'] = [];
+            }
+            $GLOBALS['_BAZAR_']['provenance'] = 'import';
+        }
+
         $data = $this->formatDataBeforeSave($data,$dateIntervalToAdd);
 
         // get the sendmail and remove it before saving

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -615,7 +615,7 @@ class EntryManager
         $this->validate($data);
 
            
-        if (!$sendmail){
+        if (!$sendmail) {
             // prevent UserField to send emails
             // @todo find a better way to have this behaviour (see in UserField)
             if (!isset($GLOBALS['_BAZAR_'])) {
@@ -624,20 +624,21 @@ class EntryManager
             $GLOBALS['_BAZAR_']['provenance'] = 'import';
         }
 
-        $data = $this->formatDataBeforeSave($data,$dateIntervalToAdd);
+        $data = $this->formatDataBeforeSave($data, $dateIntervalToAdd);
 
         // get the sendmail and remove it before saving
         $sendmail = $this->removeSendmail($data);
         // on sauve les valeurs d'une fiche dans une PageWiki, pour garder l'historique
         $this->pageManager->save(
-            $data['id_fiche'], 
-            json_encode($data), 
+            $data['id_fiche'],
+            json_encode($data),
             '',
             false,
-            (empty($dateIntervalToAdd) || empty($data['date_maj_fiche'])) ? null : new DateTime($data['date_maj_fiche']));
+            (empty($dateIntervalToAdd) || empty($data['date_maj_fiche'])) ? null : new DateTime($data['date_maj_fiche'])
+        );
 
         // if sendmail has referenced email fields, send an email to their adresses
-        if ($sendmail){
+        if ($sendmail) {
             $this->sendMailToNotifiedEmails($sendmail, $data);
 
             if ($this->params->get('BAZ_ENVOI_MAIL_ADMIN')) {
@@ -782,7 +783,7 @@ class EntryManager
      * prepare la requete d'insertion ou de MAJ de la fiche en supprimant
      * de la valeur POST les valeurs inadequates et en formattant les champs.
      * @param $data
-     * @param ?DateInterval $dateIntervalToAdd 
+     * @param ?DateInterval $dateIntervalToAdd
      * @return array
      * @throws Exception
      */
@@ -845,7 +846,7 @@ class EntryManager
             throw new Exception('$data[\'id_fiche\'] is empty !');
         }
 
-        if (!empty($data['date_maj_fiche']) && !empty($dateIntervalToAdd) && $dateIntervalToAdd->invert == 0){
+        if (!empty($data['date_maj_fiche']) && !empty($dateIntervalToAdd) && $dateIntervalToAdd->invert == 0) {
             // only positives values
             $data['date_maj_fiche'] = (new DateTime($data['date_maj_fiche']))->add($dateIntervalToAdd)->format('Y-m-d H:i:s');
         } else {

--- a/tools/bazar/templates/handlers/extract-old-geoloc-at-update.twig
+++ b/tools/bazar/templates/handlers/extract-old-geoloc-at-update.twig
@@ -4,18 +4,20 @@
 ✅ The table {{ tablePrefix }}page is already already updated with no old geolocation data!<br />
 {% else %}
   {% if entriesWithErrors is not empty %}
-    There is somes errors for :<br />
+    There is some errors for :<br />
     <ul>
       {% for entry,message in entriesWithErrors %}
         <li style="color:red;"><a href="{{ url({tag:entry}) }}" class="modalbox" data-size="modal-lg">{{ entry }}</a> => {{ message }}</li>
       {% endfor %}
     </ul>
   {% endif %}
-  ✅ Done ! for :<br />
-  <ul>
-    {% for entry in updatedEntries %}
-      <li><a href="{{ url({tag:entry}) }}" class="modalbox" data-size="modal-lg">{{ entry }}</a></li>
-    {% endfor %}
-  </ul>
+  {% if updatedEntries is not empty %}
+    ✅ Done ! for :<br />
+    <ul>
+      {% for entry in updatedEntries %}
+        <li><a href="{{ url({tag:entry}) }}" class="modalbox" data-size="modal-lg">{{ entry }}</a></li>
+      {% endfor %}
+    </ul>
+  {% endif %}
 {% endif %}
 <hr>


### PR DESCRIPTION
Faisons plus propre, utilisons les fonctions du coeur en leur ajoutant juste ce qu'il faut comme paramètres pour sauvegarder une mise à jour de fiche via `EntryManager` sans envoyer les e-mails et en pouvant choisir le date de sauvegarde.

@mrflos est-ce que les nouveaux paramètres des méthodes concernées te semblent bien choisis (nom, type, position )?