### PR TITLE
Bazar dynamique get cache image

### DIFF
--- a/tools/attach/config.yaml
+++ b/tools/attach/config.yaml
@@ -135,3 +135,12 @@ parameters:
     - attach-video-config:
       - default_video_service
       - default_peertube_instance
+
+services:
+  _defaults:
+    autowire: true
+    public: true
+
+  # Allows to use controllers as services
+  YesWiki\Attach\Controller\:
+    resource: 'controllers/*'

--- a/tools/attach/controllers/ApiController.php
+++ b/tools/attach/controllers/ApiController.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace YesWiki\Attach\Controller;
+
+use Attach;
+use Exception;
+use Throwable;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManager;
+use Symfony\Component\Security\Csrf\Exception\TokenNotFoundException;
+use YesWiki\Core\ApiResponse;
+use YesWiki\Core\YesWikiController;
+
+class ApiController extends YesWikiController
+{
+    public const GET_CACHE_URLIMAGE_TOKEN_ID = "GET api/images/cache/{width}/{height}/{mode}";
+
+    /**
+     * @Route("/api/images/{filename}/cache/{width}/{height}/{mode}", methods={"GET"}, options={"acl":{"public"}})
+     */
+    public function getCacheUrlImage($filename, $width, $height, $mode)
+    {
+        try {
+            $this->checkParamsGetCacheUrlImage($filename, $width, $height, $mode);
+            $newToken = $this->checkTokenForGetCacheUrlImage($width, $height, $mode);
+            // check file
+            if (!file_exists("files/$filename")) {
+                return new ApiResponse([
+                        'error' => _t('ATTACH_GET_CACHE_URLIMAGE_NO_FILE'),
+                        'filename' => $filename,
+                        'width' => $width,
+                        'height' => $height,
+                        'mode' => $mode,
+                        'newToken' => $newToken,
+                    ], Response::HTTP_BAD_REQUEST);
+            }
+            // process new file
+            try {
+                $cachefilename = $this->getCacheFileName($filename, $width, $height, $mode);
+            } catch (Exception $e) {
+                return new ApiResponse([
+                    'error' => $e->getMessage(),
+                    'cachefilename' => "",
+                    'filename' => $filename,
+                    'width' => $width,
+                    'height' => $height,
+                    'mode' => $mode,
+                    'newToken' => $newToken,
+                ], Response::HTTP_INTERNAL_SERVER_ERROR);
+            }
+
+            return new ApiResponse([
+                'cachefilename' => $cachefilename,
+                'filename' => $filename,
+                'width' => $width,
+                'height' => $height,
+                'mode' => $mode,
+                'newToken' => $newToken,
+            ], Response::HTTP_OK);
+        } catch (TokenNotFoundException $th) {
+            $errorMessage = $th->getMessage();
+            return new ApiResponse([
+                'error' => $errorMessage
+            ], Response::HTTP_UNAUTHORIZED);
+        } catch (Exception $e) {
+            return new ApiResponse([
+                'error' => $e->getMessage()
+            ], Response::HTTP_BAD_REQUEST);
+        }
+    }
+
+    private function checkParamsGetCacheUrlImage(string $filename, string  &$width, string  &$height, string  $mode)
+    {
+        if (strval($width) != strval(intval($width))) {
+            throw new Exception("width should be an integer for ".self::GET_CACHE_URLIMAGE_TOKEN_ID);
+        }
+        $width = intval($width);
+        if (empty($width)) {
+            throw new Exception("width should not be 0 or null for ".self::GET_CACHE_URLIMAGE_TOKEN_ID);
+        }
+        if (strval($height) != strval(intval($height))) {
+            throw new Exception("height should be an integer for ".self::GET_CACHE_URLIMAGE_TOKEN_ID);
+        }
+        $height = intval($height);
+        if (empty($height)) {
+            throw new Exception("height should not be 0 or null for ".self::GET_CACHE_URLIMAGE_TOKEN_ID);
+        }
+        if (!in_array($mode, ['fit','crop'], true)) {
+            throw new Exception("mode should be in ['fit','mode'] for ".self::GET_CACHE_URLIMAGE_TOKEN_ID);
+        }
+        if (empty(trim($filename))) {
+            throw new Exception("filename should not be empty for ".self::GET_CACHE_URLIMAGE_TOKEN_ID);
+        }
+    }
+
+    /**
+     * use $_GET['csrftoken']
+     * @param int $width
+     * @param int $height
+     * @param string $mode
+     * @return string $newToken
+     */
+    private function checkTokenForGetCacheUrlImage(int $width, int $height, string $mode): string
+    {
+        $csrfTokenManager = $this->getService(CsrfTokenManager::class);
+        $inputToken = filter_input(INPUT_GET, 'csrftoken', FILTER_SANITIZE_STRING);
+        $tokenId = str_replace(
+            ["{width}","{height}","{mode}"],
+            [$width,$height,$mode],
+            self::GET_CACHE_URLIMAGE_TOKEN_ID
+        );
+    
+        if (is_null($inputToken) || $inputToken === false) {
+            throw new TokenNotFoundException(_t('NO_CSRF_TOKEN_ERROR'));
+        }
+        $token = new CsrfToken($tokenId, $inputToken);
+        $isValid = $csrfTokenManager->isTokenValid($token);
+        if (!$isValid) {
+            throw new TokenNotFoundException(_t('CSRF_TOKEN_FAIL_ERROR'));
+        }
+        $csrfTokenManager->removeToken($tokenId);
+        $newToken = $csrfTokenManager->getToken($tokenId)->getValue();
+        return $newToken;
+    }
+
+    private function getCacheFileName(string $filename, int $width, int $height, string $mode): string
+    {
+        if (!class_exists('attach')) {
+            include('tools/attach/libs/attach.lib.php');
+        }
+        $attach = new attach($this->wiki);
+        $newFileName = $attach->getResizedFilename("files/$filename", $width, $height, $mode);
+        if (file_exists($newFileName)) {
+            return $newFileName;
+        } else {
+            $returnedFileName = $attach->redimensionner_image("files/$filename", $newFileName, $width, $height, $mode);
+            if ($returnedFileName != $newFileName) {
+                // TODO see what to do with error
+            }
+            return $newFileName;
+        }
+    }
+
+    /**
+     * Display Bazar api documentation
+     *
+     * @return string
+     */
+    public function getDocumentation()
+    {
+        $output = '<h2>Attach</h2>' . "\n";
+
+        $output .= "<p><b>".
+        "<code>GET {$this->wiki->href('', 'api/images/{filename}/cache/{width}/{height}/{mode}', ['csrftoken' => 'xxxx'], false)}</code></b><br />".
+        nl2br(_t('ATTACH_GET_URLIMAGE_CACHE_API_HELP'))."</p>";
+
+        return $output;
+    }
+}

--- a/tools/attach/lang/attach_ca.inc.php
+++ b/tools/attach/lang/attach_ca.inc.php
@@ -2,6 +2,11 @@
 
 return [
 
+    // controllers/ApiController.php
+    // 'ATTACH_GET_URLIMAGE_CACHE_API_HELP' => "Fournit l'url du fichier de cache pour l'image voulue\n".
+    //     "Nécessite le passage du jeton anti-csrf !",
+    // 'ATTACH_GET_CACHE_URLIMAGE_NO_FILE' => 'Fichier image inexistant',
+
     // libs/attach.lib.php
     'ATTACH_ACTION_ATTACH' => 'Acció {{attach ...}}',
     'ATTACH_PARAM_DESC_REQUIRED' => 'El paràmetre "desc" és obligatori per una imatge',

--- a/tools/attach/lang/attach_en.inc.php
+++ b/tools/attach/lang/attach_en.inc.php
@@ -2,6 +2,11 @@
 
 return [
 
+    // controllers/ApiController.php
+    'ATTACH_GET_URLIMAGE_CACHE_API_HELP' => "Gives cache filename for wanted image\n".
+        "Need anti-csrf token!",
+        'ATTACH_GET_CACHE_URLIMAGE_NO_FILE' => 'Not existing image file',
+
     // libs/attach.lib.php
     'ATTACH_ACTION_ATTACH' => 'Action {{attach ...}}',
     'ATTACH_PARAM_DESC_REQUIRED' => '"desc" parameter required for an image',

--- a/tools/attach/lang/attach_es.inc.php
+++ b/tools/attach/lang/attach_es.inc.php
@@ -2,6 +2,11 @@
 
 return [
 
+    // controllers/ApiController.php
+    // 'ATTACH_GET_URLIMAGE_CACHE_API_HELP' => "Fournit l'url du fichier de cache pour l'image voulue\n".
+    //     "Nécessite le passage du jeton anti-csrf !",
+    // 'ATTACH_GET_CACHE_URLIMAGE_NO_FILE' => 'Fichier image inexistant',
+
     // libs/attach.lib.php
     'ATTACH_ACTION_ATTACH' => 'Acción {{attach ...}}',
     'ATTACH_PARAM_DESC_REQUIRED' => 'parámetro "desc" obligatorio para una imagen',

--- a/tools/attach/lang/attach_fr.inc.php
+++ b/tools/attach/lang/attach_fr.inc.php
@@ -2,6 +2,11 @@
 
 return [
 
+    // controllers/ApiController.php
+    'ATTACH_GET_URLIMAGE_CACHE_API_HELP' => "Fournit l'url du fichier de cache pour l'image voulue\n".
+        "Nécessite le passage du jeton anti-csrf !",
+    'ATTACH_GET_CACHE_URLIMAGE_NO_FILE' => 'Fichier image inexistant',
+
     // libs/attach.lib.php
     'ATTACH_ACTION_ATTACH' => 'Action {{attach ...}}',
     'ATTACH_PARAM_DESC_REQUIRED' => 'param&egrave;tre "desc" obligatoire pour une image',

--- a/tools/attach/lang/attach_nl.inc.php
+++ b/tools/attach/lang/attach_nl.inc.php
@@ -2,6 +2,11 @@
 
 return [
 
+    // controllers/ApiController.php
+    // 'ATTACH_GET_URLIMAGE_CACHE_API_HELP' => "Fournit l'url du fichier de cache pour l'image voulue\n".
+    //     "Nécessite le passage du jeton anti-csrf !",
+    // 'ATTACH_GET_CACHE_URLIMAGE_NO_FILE' => 'Fichier image inexistant',
+
     // libs/attach.lib.php
     'ATTACH_ACTION_ATTACH' => 'Actie {{Attach ...}}',
     'ATTACH_PARAM_DESC_REQUIRED' => 'parameter "desc" verplicht voor een afbeelding',

--- a/tools/attach/lang/attach_pt.inc.php
+++ b/tools/attach/lang/attach_pt.inc.php
@@ -2,6 +2,11 @@
 
 return [
 
+    // controllers/ApiController.php
+    // 'ATTACH_GET_URLIMAGE_CACHE_API_HELP' => "Fournit l'url du fichier de cache pour l'image voulue\n".
+    //     "Nécessite le passage du jeton anti-csrf !",
+    // 'ATTACH_GET_CACHE_URLIMAGE_NO_FILE' => 'Fichier image inexistant',
+
     // libs/attach.lib.php
     'ATTACH_ACTION_ATTACH' => 'Ação {{attach ...}}',
     'ATTACH_PARAM_DESC_REQUIRED' => 'parâmetro "desc" necessário para uma imagem',

--- a/tools/bazar/fields/ImageField.php
+++ b/tools/bazar/fields/ImageField.php
@@ -209,20 +209,6 @@ class ImageField extends FileField
                 'imageHeight' => $this->imageHeight,
                 'imageWidth' => $this->imageWidth,
                 'imageClass' => $this->imageClass,
-                'regExp' => [
-                    'thumbnailPath' => [
-                        "^({tag}_{$this->getPropertyName()}_.*)_(\d{14})_(\d{14})\.(.*)$" => "{$baseUrl}/{$this->getAttach()->GetCachePath()}/$1_vignette_{$this->thumbnailWidth}_{$this->thumbnailHeight}_$2_$3.$4"
-                    ],
-                    'imagePath' => [
-                        "^({tag}_{$this->getPropertyName()}_.*)_(\d{14})_(\d{14})\.(.*)$" => "{$baseUrl}/{$this->getAttach()->GetCachePath()}/$1_vignette_{$this->imageWidth}_{$this->imageHeight}_$2_$3.$4"
-                    ],
-                    'oldThumbnailPath' => [
-                        "^(.*)\.([^.]*)$" => "{$baseUrl}/{$this->getAttach()->GetCachePath()}/vignette_$1.$2"
-                    ],
-                    'oldImagePath' => [
-                        "^(.*)\.([^.]*)$" => "{$baseUrl}/{$this->getAttach()->GetCachePath()}/image_$1.$2"
-                    ],
-                ],
             ]
         );
     }

--- a/tools/bazar/presentation/javascripts/bazar-list-dynamic.js
+++ b/tools/bazar/presentation/javascripts/bazar-list-dynamic.js
@@ -243,24 +243,33 @@ document.addEventListener('DOMContentLoaded', function() {
         $(node).removeAttr('onerror');
         if (entry[fieldName]){
           let fileName = entry[fieldName];
-          if (this.tokenForImages === null){
-            this.tokenForImages = token;
+          if (!this.isExternalUrl(entry)){
+            // currently not supporting api for external images (anti-csrf token not generated)
+            if (this.tokenForImages === null){
+              this.tokenForImages = token;
+            }
+            this.imagesToProcess.push({
+              fileName: fileName,
+              width: width,
+              height: height,
+              mode: mode,
+              node: node
+            });
+            this.processNextImage();
+          } else {
+            let baseUrl = entry.url.slice(0,-entry.id_fiche.length).replace(/\?$/,"").replace(/\/$/,"");
+            $(node).prop('src',`${baseUrl}/files/${fileName}`);
           }
-          this.imagesToProcess.push({
-            fileName: fileName,
-            width: width,
-            height: height,
-            mode: mode,
-            node: node
-          });
-          this.processNextImage();
         }
       },
       urlImage(entry,fieldName,width,height,mode) {
         if (!entry[fieldName]){
           return null;
         }
-        let baseUrl = wiki.baseUrl.replace(/\?$/,"").replace(/\/$/,"");
+        let baseUrl = (this.isExternalUrl(entry))
+          ? entry.url.slice(0,-entry.id_fiche.length)
+          : wiki.baseUrl;
+        baseUrl = baseUrl.replace(/\?$/,"").replace(/\/$/,"");
         let fileName = entry[fieldName];
         let field = this.fieldInfo(fieldName);
         let regExp = new RegExp(`^(${entry.id_fiche}_${field.propertyname}_.*)_(\\d{14})_(\\d{14})\\.([^.]+)$`);

--- a/tools/bazar/presentation/javascripts/bazar-list-dynamic.js
+++ b/tools/bazar/presentation/javascripts/bazar-list-dynamic.js
@@ -238,12 +238,6 @@ document.addEventListener('DOMContentLoaded', function() {
         if (this.computedFilters[field]) values = values.filter(val => this.computedFilters[field].includes(val))
         return mapping[values[0]]
       },
-      urlImage(entry,fieldName,mode = "image") {
-        // kept for backward compatibility
-        let width = (mode == "image") ? 600 : 140;
-        let height = (mode == "image") ? 600 : 140;
-        return this.urlImageResized(entry,fieldName,width,height,"fit");
-      },
       urlImageResizedOnError(entry,fieldName,width,height,mode,token) {
         let node = event.target;
         $(node).removeAttr('onerror');
@@ -262,7 +256,7 @@ document.addEventListener('DOMContentLoaded', function() {
           this.processNextImage();
         }
       },
-      urlImageResized(entry,fieldName,width,height,mode) {
+      urlImage(entry,fieldName,width,height,mode) {
         if (!entry[fieldName]){
           return null;
         }

--- a/tools/bazar/presentation/styles/bazar-list-dynamic.css
+++ b/tools/bazar/presentation/styles/bazar-list-dynamic.css
@@ -106,6 +106,11 @@
   min-height: 100px;
   background-color: var(--neutral-soft-color);
 }
+.bazar-list.dynamic .panel-heading-container .visual-area img {
+  object-fit: cover;
+  width: 100%;
+  min-height: 100px;
+}
 .bazar-list.dynamic .panel-heading-container .title-area {
   grid-area: title;
 }

--- a/tools/bazar/presentation/styles/bazar-list-dynamic.css
+++ b/tools/bazar/presentation/styles/bazar-list-dynamic.css
@@ -110,6 +110,7 @@
   object-fit: cover;
   width: 100%;
   min-height: 100px;
+  max-height: 170px;
 }
 .bazar-list.dynamic .panel-heading-container .title-area {
   grid-area: title;

--- a/tools/bazar/presentation/styles/card.css
+++ b/tools/bazar/presentation/styles/card.css
@@ -133,6 +133,7 @@
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
   border-bottom: 1px solid #ebebeb;
+  object-fit: cover;
 } 
 .style-vertical .bazar-card .footer-area {
   margin: -1.5rem;
@@ -172,6 +173,7 @@
     width: 13.5rem;
     margin-right: 1.5rem;
     margin-bottom: 0;
+    object-fit: cover;
   }
   .style-horizontal .bazar-card .floating-area {
     left: 1rem;
@@ -213,7 +215,10 @@
 .bazar-cards-container.nbcol-4.style-square .bazar-card .visual-area {
   height: 250px;
 }
-.bazar-cards-container.nbcol-5.style-square .bazar-card .visual-area {
+.bazar-cards-container.nbcol-5.style-square .bazar-card .visual-area ,
+.bazar-cards-container.nbcol-6.style-square .bazar-card .visual-area ,
+.bazar-cards-container.nbcol-7.style-square .bazar-card .visual-area ,
+.bazar-cards-container.nbcol-8.style-square .bazar-card .visual-area {
   height: 200px;
 }
 .style-square .bazar-card .content {

--- a/tools/bazar/templates/entries/index-dynamic-templates/card.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/card.twig
@@ -14,7 +14,7 @@
     {{ include('@templates/alert-message.twig',{type:'info',message:_t('BAZ_CARD_NBCOL_TOO_HIGH')}) }}
   {% endif %}
   {% set imWidth = (nbcol == 4) ? 250 : (nbcol == 5 ? 200 : 300 ) %}
-  {% set imHeight = imWidth %}
+  {% set imHeight = params.style == "square" ? imWidth : (params.style == "horizontal" ? imWidth*23//27 : imWidth*3//2 ) %}
   {% set firstTokenCrop = csrfToken("GET api/images/cache/#{imWidth}/#{imHeight}/crop") %}
   <div class="bazar-cards-container" v-if="ready" 
        :class="[{ready: ready}, `style-${params.style || 'vertical'}`, `nbcol-{{nbcol}}`]" 
@@ -40,17 +40,9 @@
       
       {# VISUAL AREA #}
       <template v-if="Object.keys(entry).includes('visual')">
-        <template v-if="params.style == 'square'">
-          <img v-if="entry.visual" class="area visual-area" :src="urlImageResized(entry,'visual',{{ imWidth }},{{ imHeight }},'crop')"
-          @error="urlImageResizedOnError(entry,'visual',{{ imWidth }},{{ imHeight }},'crop',{{ firstTokenCrop|json_encode }})"></img>
-          <div v-else class="area area visual-area placeholder"></div>
-        </template>
-        <template v-else>
-          <div v-if="entry.visual" class="area visual-area" 
-            :style="{'background-image': `url(${urlImageResized(entry,'visual',{{ imWidth }},{{ imHeight }},'crop')})`}">
-          </div>
-          <div v-else class="area area visual-area placeholder"></div>
-        </template>
+        <img v-if="entry.visual" class="area visual-area" :src="urlImageResized(entry,'visual',{{ imWidth }},{{ imHeight }},'crop')"
+        @error="urlImageResizedOnError(entry,'visual',{{ imWidth }},{{ imHeight }},'crop',{{ firstTokenCrop|json_encode }})"></img>
+        <div v-else class="area area visual-area placeholder"></div>
       </template>
       
       <div class="content">

--- a/tools/bazar/templates/entries/index-dynamic-templates/card.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/card.twig
@@ -40,7 +40,7 @@
       
       {# VISUAL AREA #}
       <template v-if="Object.keys(entry).includes('visual')">
-        <img v-if="entry.visual" class="area visual-area" :src="urlImageResized(entry,'visual',{{ imWidth }},{{ imHeight }},'crop')"
+        <img v-if="entry.visual" class="area visual-area" :src="urlImage(entry,'visual',{{ imWidth }},{{ imHeight }},'crop')"
         @error="urlImageResizedOnError(entry,'visual',{{ imWidth }},{{ imHeight }},'crop',{{ firstTokenCrop|json_encode }})"></img>
         <div v-else class="area area visual-area placeholder"></div>
       </template>

--- a/tools/bazar/templates/entries/index-dynamic-templates/card.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/card.twig
@@ -13,6 +13,9 @@
     {% set nbcol =  2 %}
     {{ include('@templates/alert-message.twig',{type:'info',message:_t('BAZ_CARD_NBCOL_TOO_HIGH')}) }}
   {% endif %}
+  {% set imWidth = (nbcol == 4) ? 250 : (nbcol == 5 ? 200 : 300 ) %}
+  {% set imHeight = imWidth %}
+  {% set firstTokenCrop = csrfToken("GET api/images/cache/#{imWidth}/#{imHeight}/crop") %}
   <div class="bazar-cards-container" v-if="ready" 
        :class="[{ready: ready}, `style-${params.style || 'vertical'}`, `nbcol-{{nbcol}}`]" 
        :style="{'grid-template-columns': `repeat({{nbcol}}, 1fr)`}">
@@ -38,12 +41,13 @@
       {# VISUAL AREA #}
       <template v-if="Object.keys(entry).includes('visual')">
         <template v-if="params.style == 'square'">
-          <img v-if="entry.visual" class="area visual-area" :src="`${urlImage(entry,'visual')}`"></img>
+          <img v-if="entry.visual" class="area visual-area" :src="urlImageResized(entry,'visual',{{ imWidth }},{{ imHeight }},'crop')"
+          @error="urlImageResizedOnError(entry,'visual',{{ imWidth }},{{ imHeight }},'crop',{{ firstTokenCrop|json_encode }})"></img>
           <div v-else class="area area visual-area placeholder"></div>
         </template>
         <template v-else>
           <div v-if="entry.visual" class="area visual-area" 
-            :style="{'background-image': `url(${urlImage(entry,'visual')})`}">
+            :style="{'background-image': `url(${urlImageResized(entry,'visual',{{ imWidth }},{{ imHeight }},'crop')})`}">
           </div>
           <div v-else class="area area visual-area placeholder"></div>
         </template>

--- a/tools/bazar/templates/entries/index-dynamic-templates/list.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/list.twig
@@ -1,6 +1,9 @@
 {% extends "@bazar/entries/index-dynamic.twig" %}
 
 {% block display_entries %}
+  {% set imWidth = 170 %}
+  {% set imHeight = 170 %}
+  {% set firstTokenCrop = csrfToken("GET api/images/cache/#{imWidth}/#{imHeight}/crop") %}
   <div class="panel-group no-dblclick" style="opacity: 0;" :class="{ready: ready}" v-if="ready">
     <div v-if="entriesToDisplay.length == 0" class="alert alert-info">
       {{ _t('BAZ_NO_RESULT') }}
@@ -10,8 +13,11 @@
       <template #header>
         <div class="panel-heading-container" :class="{'with-image': entry.visual}">
           {# VISUAL AREA #}
-          <div class="visual-area" v-if="entry.visual" 
-              :style="{'background-image': `url(${urlImage(entry,'visual','thumbnail')})`}">
+          <div class="visual-area" v-if="entry.visual">
+            <img
+              :src="urlImageResized(entry,'visual',{{ imWidth }},{{ imHeight }},'crop')"
+              @error="urlImageResizedOnError(entry,'visual',{{ imWidth }},{{ imHeight }},'crop',{{ firstTokenCrop|json_encode }})">
+            </img>
           </div>
           {# TITLE AREA #}
           <h4 div class="title-area panel-title">

--- a/tools/bazar/templates/entries/index-dynamic-templates/list.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/list.twig
@@ -15,7 +15,7 @@
           {# VISUAL AREA #}
           <div class="visual-area" v-if="entry.visual">
             <img
-              :src="urlImageResized(entry,'visual',{{ imWidth }},{{ imHeight }},'crop')"
+              :src="urlImage(entry,'visual',{{ imWidth }},{{ imHeight }},'crop')"
               @error="urlImageResizedOnError(entry,'visual',{{ imWidth }},{{ imHeight }},'crop',{{ firstTokenCrop|json_encode }})">
             </img>
           </div>

--- a/tools/templates/libs/templates.functions.php
+++ b/tools/templates/libs/templates.functions.php
@@ -746,9 +746,11 @@ function getImageFromBody($page, $width, $height)
         $attach->CheckParams();
         $imagefile = $attach->GetFullFilename();
         $GLOBALS['wiki']->tag = $oldpage;
+        
+        $image_dest = $attach->getResizedFilename($imagefile, $width, $height, 'crop');
         $image = $GLOBALS['wiki']->getBaseUrl().'/'.$attach->redimensionner_image(
             $imagefile,
-            'cache/'.$width.'x'.$height.'-'.str_replace('files/', '', $imagefile),
+            $image_dest,
             $width,
             $height,
             'crop'
@@ -762,9 +764,10 @@ function getImageFromBody($page, $width, $height)
                 include 'tools/attach/libs/attach.lib.php';
             }
             $attach = new Attach($GLOBALS['wiki']);
+            $image_dest = $attach->getResizedFilename('files/'.$imagefile, $width, $height, 'crop');
             $image = $GLOBALS['wiki']->getBaseUrl().'/'.$attach->redimensionner_image(
                 'files/'.$imagefile,
-                'cache/'.$width.'x'.$height.'-'.$imagefile,
+                $image_dest,
                 $width,
                 $height,
                 'crop'


### PR DESCRIPTION
Branche pour permettre de gérer les url pour les images en cache pour les templates dynamic

**Pour tester**:
 - vider le dossier cache
 - afficher un template dynamic, les images devraient revenir

**Ce que ça fait**:
 - créer une route api sécurisée par un jeton anti-csrf pour permettre de générer un nouveau fichier en cache (**nouveauté**)
 - ajouter dans `bazar-list-dynamic` les méthodes nécessaires pour pré-calculer l'url du fichier et pour gérer les urls en erreurs
 - adaptation de `card.twig` pour appeler la bonne url
 - balayer tous les templates dynamic pour gérer les appels à url images
