### PR TITLE
fix(BazarFields): change canEdit signature and create formatValuesBeforeSaveIfEditable methods

### DIFF
--- a/tools/attach/handlers/UpdateHandler__.php
+++ b/tools/attach/handlers/UpdateHandler__.php
@@ -88,7 +88,7 @@ class UpdateHandler__ extends YesWikiHandler
         $updated = false;
         foreach ($form['prepared'] as $field) {
             if ($field instanceof TextareaField && !empty($entry[$field->getPropertyName()])) {
-                $newValue = $field->formatValuesBeforeSave($entry);
+                $newValue = $field->formatValuesBeforeSaveIfEditable($entry);
                 if (isset($newValue[$field->getPropertyName()])) {
                     $oldValue = json_encode($entry[$field->getPropertyName()]);
                     $newValue = json_encode($newValue[$field->getPropertyName()]);

--- a/tools/bazar/fields/BazarField.php
+++ b/tools/bazar/fields/BazarField.php
@@ -85,11 +85,18 @@ abstract class BazarField implements \JsonSerializable
     public function renderInputIfPermitted($entry)
     {
         // Safety checks, must be run before every renderInput
-        if (!$this->canEdit($entry)) {
+        if (!$this->canEdit($entry, !$entry)) {
             return '';
         }
 
         return $this->renderInput($entry);
+    }
+
+    public function formatValuesBeforeSaveIfEditable($entry, bool $isCreation = false)
+    {
+        // this method is defined to check $this->canEdit with $isCreation
+        // without changing signature of formatValuesBeforeSave()
+        return $this->formatValuesBeforeSave($entry);
     }
 
     // Format input values before save
@@ -145,10 +152,9 @@ abstract class BazarField implements \JsonSerializable
     }
 
     /* Return true if we are if editing is allowed for the field */
-    public function canEdit($entry)
+    public function canEdit($entry, bool $isCreation = false)
     {
         $writeAcl = empty($this->writeAccess) ? '' : $this->writeAccess;
-        $isCreation = !$entry;
         return empty($writeAcl) || $this->getService(AclService::class)->check($writeAcl, null, true, $isCreation ? '' : $entry['id_fiche'], $isCreation ? 'creation' : 'edit');
     }
 

--- a/tools/bazar/fields/CheckboxField.php
+++ b/tools/bazar/fields/CheckboxField.php
@@ -80,7 +80,12 @@ abstract class CheckboxField extends EnumField
     
     public function formatValuesBeforeSave($entry)
     {
-        if ($this->canEdit($entry)) {
+        return $this->formatValuesBeforeSaveIfEditable($entry, false);
+    }
+
+    public function formatValuesBeforeSaveIfEditable($entry, bool $isCreation = false)
+    {
+        if ($this->canEdit($entry, $isCreation)) {
             // get value
             $checkboxField = $entry[$this->propertyName] ?? null ;
             // detect if from Form to check if clean field

--- a/tools/bazar/fields/MapField.php
+++ b/tools/bazar/fields/MapField.php
@@ -271,10 +271,14 @@ class MapField extends BazarField
             'longitude' => is_array($value) && !empty($value[$this->getLongitudeField()]) ? $value[$this->getLongitudeField()] : null
         ]);
     }
-
     public function formatValuesBeforeSave($entry)
     {
-        if (!$this->canEdit($entry)) {
+        return $this->formatValuesBeforeSaveIfEditable($entry, false);
+    }
+
+    public function formatValuesBeforeSaveIfEditable($entry, bool $isCreation = false)
+    {
+        if (!$this->canEdit($entry, $isCreation)) {
             // retrieve value from value because redefined with right value
             $values = $this->getValue($entry);
             if (empty($values)) {

--- a/tools/bazar/fields/PasswordField.php
+++ b/tools/bazar/fields/PasswordField.php
@@ -22,8 +22,13 @@ class PasswordField extends BazarField
 
     public function formatValuesBeforeSave($entry)
     {
+        return $this->formatValuesBeforeSaveIfEditable($entry, false);
+    }
+
+    public function formatValuesBeforeSaveIfEditable($entry, bool $isCreation = false)
+    {
         $value = $this->getValue($entry);
-        if ($this->canEdit($entry)) {
+        if ($this->canEdit($entry, $isCreation)) {
             if (!empty($value)) {
                 // If a new password has been set, encode it
                 return [$this->propertyName => md5($value),

--- a/tools/bazar/fields/TitleField.php
+++ b/tools/bazar/fields/TitleField.php
@@ -49,7 +49,7 @@ class TitleField extends BazarField
                     $fieldValue = $field->getValue($entry);
                     if ($field instanceof CheckboxField) {
                         // get first value instead of keys
-                        $formattedValue = $field->formatValuesBeforeSave($entry)[$field->getPropertyName()];
+                        $formattedValue = $field->formatValuesBeforeSaveIfEditable($entry)[$field->getPropertyName()];
                         $fieldValues = $field->getValues([$field->getPropertyName() => $formattedValue]);
                         $replacement = $field->getOptions()[$fieldValues[0] ?? null] ?? '';
                     } elseif ($field instanceof TagsField) {

--- a/tools/bazar/handlers/UpdateHandler__.php
+++ b/tools/bazar/handlers/UpdateHandler__.php
@@ -97,7 +97,7 @@ class UpdateHandler__ extends YesWikiHandler
             if ($field instanceof MapField) {
                 // update location
                 $entry = array_merge($entry, $this->getMapFieldValue($field, $entry));
-                $tab = $field->formatValuesBeforeSave($entry);
+                $tab = $field->formatValuesBeforeSaveIfEditable($entry);
                 if (is_array($tab)) {
                     if (isset($tab['fields-to-remove']) and is_array($tab['fields-to-remove'])) {
                         foreach ($tab['fields-to-remove'] as $fieldName) {

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -499,7 +499,7 @@ class EntryManager
 
         $this->validate($data);
 
-        $data = $this->formatDataBeforeSave($data);
+        $data = $this->formatDataBeforeSave($data, true);
 
         // on change provisoirement d'utilisateur
         if (isset($GLOBALS['utilisateur_wikini'])) {
@@ -610,7 +610,7 @@ class EntryManager
 
         $this->validate($data);
 
-        $data = $this->formatDataBeforeSave($data);
+        $data = $this->formatDataBeforeSave($data, false);
 
         // get the sendmail and remove it before saving
         $sendmail = $this->removeSendmail($data);
@@ -648,7 +648,7 @@ class EntryManager
                 // be carefull : BazarField's objects, that do not save data (as ACL, Label, Hidden), do not have propertyName
                 // see BazarField->formatValuesBeforeSave() for details
                 // so do not save the previous data even if existing
-                if (!empty($propName) && !$field->canEdit($data)) {
+                if (!empty($propName) && !$field->canEdit($data, false)) {
                     $restrictedFields[] = $propName;
                 }
             }
@@ -761,10 +761,11 @@ class EntryManager
      * prepare la requete d'insertion ou de MAJ de la fiche en supprimant
      * de la valeur POST les valeurs inadequates et en formattant les champs.
      * @param $data
+     * @param bool $isCreation
      * @return array
      * @throws Exception
      */
-    public function formatDataBeforeSave($data)
+    public function formatDataBeforeSave($data, bool $isCreation = false)
     {
         // not possible to init the formManager in the constructor because of circular reference problem
         $form = $this->wiki->services->get(FormManager::class)->getOne($data['id_typeannonce']);
@@ -772,7 +773,7 @@ class EntryManager
         // If there is a title field, compute the entry's title
         foreach ($form['prepared'] as $field) {
             if ($field instanceof TitleField) {
-                $data = array_merge($data, $field->formatValuesBeforeSave($data));
+                $data = array_merge($data, $field->formatValuesBeforeSaveIfEditable($data, $isCreation));
             }
         }
 
@@ -803,7 +804,7 @@ class EntryManager
 
         foreach ($form['prepared'] as $bazarField) {
             if ($bazarField instanceof BazarField) {
-                $tab = $bazarField->formatValuesBeforeSave($data);
+                $tab = $bazarField->formatValuesBeforeSaveIfEditable($data, $isCreation);
             }
 
             if (is_array($tab)) {


### PR DESCRIPTION
BREAKING_CHANGE custom fields must change canEdit signature

je crée cette PR pour résoudre un souci d'accès aux données par les champs lors de la création et de l'usage du droit d'écriture `%`. En effet celui-ci n'est pas bien pris en compte car la page n'existant pas encore, il n'est pas possible de vérifier que la personne connectée en est propriétaire et il faut forcer le mode `creation` à  la main.
La détection en place jusque là fonctionne pour `renderIfpermitted` mais pas pour `formatBeforeSave`.

je propose cette PR pour permettre le passage du paramètre `isCreation` au bon endroit.

Il y a un BREAKNG_CHANGE concernant la signature de la méthode `BazarField::canEdit`.
J'attends donc que nous travaillions sur `doryphore 4.3` pour mettre en place la fusion.

en attendant, est-ce qu'un de vous @mrflos ou @acheype aurait un retour à me faire sur les points d'attention que je dois avoir avant de fusionner ? Merci d'avance.
