### PR TITLE
fix(card): remove underline on hover

### DIFF
--- a/tools/bazar/presentation/styles/card.css
+++ b/tools/bazar/presentation/styles/card.css
@@ -14,6 +14,9 @@
   position: relative;
   cursor: pointer;
 }
+a.bazar-card {
+  text-decoration: none !important;
+}
 .bazar-card:hover .visual-area:not(.placeholder) {
   filter: brightness(1.05) contrast(1.05);
 }


### PR DESCRIPTION
Je sais pas si c'était fait exprès ou juste que c'est un side effect qui traine depuis un ùmoment, mais en mode "modal" quand on passe la souris sur la card tout devient souligné, ce qui est très moche !