### PR TITLE
Feat/archive

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -76,11 +76,12 @@ jobs:
     - name: Set cache folder writable
       run: sudo chmod -R 0777 ${{ github.workspace }}/cache
 
-    - name: Set private folder for archive
+    - name: Set private folder for archive (and clean previous files)
       run: |
         sudo mkdir -p ${{ github.workspace }}/private/archives
         sudo chown www-data:www-data -R ${{ github.workspace }}/private/archives
         sudo chmod -R 0777 ${{ github.workspace }}/private/archives
+        sudo ls ${{ github.workspace }}/private/archives/* && sudo rm ${{ github.workspace }}/private/archives/* || true
 
     - run: curl http://localhost
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,6 +1,14 @@
 name: PHP Composer
 
 on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'     
+        required: true
+        default: 'warning'
+      tags:
+        description: 'Tags'  
   push:
     branches: [ doryphore, ectoplasme ]
     paths:
@@ -8,7 +16,7 @@ on:
     - '*.php'
     - '.github/workflows/*.yml'
   pull_request:
-    branches: [ doryphore, ectoplasme ]
+    branches: [ doryphore, doryphore-dev, ectoplasme ]
     paths:
     - 'composer.lock'
     - '*.php'
@@ -61,12 +69,16 @@ jobs:
         sudo /etc/init.d/mysql start
         mysql -e 'CREATE DATABASE ${{ env.DB_NAME }};' -uroot -proot
 
+    - name: Append current user in www-data group
+      run: |
+        sudo usermod -aG www-data $USER
+
     - name: Set cache folder writable
       run: sudo chmod -R 0777 ${{ github.workspace }}/cache
 
     - name: Set private folder for archive
       run: |
-        sudo mkdir ${{ github.workspace }}/private/archives
+        sudo mkdir -p ${{ github.workspace }}/private/archives
         sudo chown www-data:www-data -R ${{ github.workspace }}/private/archives
         sudo chmod -R 0777 ${{ github.workspace }}/private/archives
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -92,7 +92,13 @@ jobs:
           -F "admin_email=test@example.com" \
           -F "submit=Continue" \
           "http://localhost/?PagePrincipale&installAction=install"
+    
+    - name: Set wakka.config.php writable
+      run: |
+        sudo chown www-data:www-data ${{ github.workspace }}/wakka.config.php
+        sudo chmod 0777 ${{ github.workspace }}/wakka.config.php
 
     - name: Run test suite
       run: composer test
+      
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -64,6 +64,12 @@ jobs:
     - name: Set cache folder writable
       run: sudo chmod -R 0777 ${{ github.workspace }}/cache
 
+    - name: Set private folder for archive
+      run: |
+        sudo mkdir ${{ github.workspace }}/private/archives
+        sudo chown www-data:www-data -R ${{ github.workspace }}/private/archives
+        sudo chmod -R 0777 ${{ github.workspace }}/private/archives
+
     - run: curl http://localhost
 
     - name: Setup Wiki
@@ -79,6 +85,7 @@ jobs:
           -F "config[mysql_password]=root" \
           -F "config[table_prefix]=yeswiki_" \
           -F "config[allow_raw_html]=1" \
+          -F "config[archive][privatePath]=${{ github.workspace }}/private/archives" \
           -F "admin_name=ActionTest" \
           -F "admin_password=ActionTestPassword" \
           -F "admin_password_conf=ActionTestPassword" \

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,12 @@ themes/*
 !themes/README.md
 custom/*
 !custom/.gitkeep
+private/*
+!private/.htaccess
+!private/backups
+private/backups/*
+!private/backups/.htaccess
+!private/backups/README.md
 
 # tools
 tools/*

--- a/actions/AdminBackupsAction.php
+++ b/actions/AdminBackupsAction.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Admin backups
+ */
+use YesWiki\Core\YesWikiAction;
+
+class AdminBackupsAction extends YesWikiAction
+{
+    public function run()
+    {
+        if (!$this->wiki->UserIsAdmin()) {
+            return $this->render('@templates/alert-message.twig', [
+                'type'=>'danger',
+                'message'=> get_class($this)." : " . _t('BAZ_NEED_ADMIN_RIGHTS')
+            ]) ;
+        }
+        return $this->render('@core/actions/admin-backups.twig', [
+        ]);
+    }
+}

--- a/actions/EditConfigAction.php
+++ b/actions/EditConfigAction.php
@@ -1,7 +1,7 @@
 <?php
 
 use YesWiki\Core\YesWikiAction;
-use YesWiki\Core\Service\Performer;
+use YesWiki\Core\Service\ConfigurationService;
 
 class EditConfigAction extends YesWikiAction
 {
@@ -36,6 +36,8 @@ class EditConfigAction extends YesWikiAction
     private $keys ;
     private $associatedExtensions ;
 
+    protected $configurationService;
+
     public function formatArguments($arg)
     {
         return [
@@ -62,7 +64,8 @@ class EditConfigAction extends YesWikiAction
             ]) ;
         }
 
-        include_once 'tools/templates/libs/Configuration.php';
+        // get services
+        $this->configurationService = $this->getService(ConfigurationService::class);
 
         $output = '';
         if ($this->arguments['saving']) {
@@ -196,7 +199,7 @@ class EditConfigAction extends YesWikiAction
      */
     private function save(): ?string
     {
-        $config = new Configuration('wakka.config.php');
+        $config = $this->configurationService->getConfiguration('wakka.config.php');
         $config->load();
 
         $keysAsArray = $this->convertKeysAsArray($this->getAuthorizedKeys()[0]);
@@ -300,7 +303,7 @@ class EditConfigAction extends YesWikiAction
      */
     private function getDataFromConfigFile(): array
     {
-        $config = new Configuration('wakka.config.php');
+        $config = $this->configurationService->getConfiguration('wakka.config.php');
         $config->load();
 
         $data = [];

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "symfony/dependency-injection": "^5.1",
         "symfony/http-foundation": "^5.1",
         "symfony/http-kernel": "^5.3.12",
+        "symfony/process": "^5.4",
         "symfony/routing": "^5.1",
         "symfony/security-core": "^5.4",
         "symfony/security-csrf": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7aca1f4e8642e2d7f2ad83e33aaa6a0d",
+    "content-hash": "7a3ff9f9de22b9a0cc8dfb2bfb5f47ae",
     "packages": [
         {
             "name": "caxy/php-htmldiff",
@@ -220,31 +220,34 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.13.3",
+            "version": "1.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "648b0343343565c4a056bfc8392201385e8d89f0"
+                "reference": "9e034d7a70032d422169f27d8759e8d84abb4f51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/648b0343343565c4a056bfc8392201385e8d89f0",
-                "reference": "648b0343343565c4a056bfc8392201385e8d89f0",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/9e034d7a70032d422169f27d8759e8d84abb4f51",
+                "reference": "9e034d7a70032d422169f27d8759e8d84abb4f51",
                 "shasum": ""
             },
             "require": {
-                "doctrine/lexer": "1.*",
+                "doctrine/lexer": "^1 || ^2",
                 "ext-tokenizer": "*",
                 "php": "^7.1 || ^8.0",
                 "psr/cache": "^1 || ^2 || ^3"
             },
             "require-dev": {
                 "doctrine/cache": "^1.11 || ^2.0",
-                "doctrine/coding-standard": "^6.0 || ^8.1",
-                "phpstan/phpstan": "^1.4.10 || ^1.8.0",
-                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.1.5",
-                "symfony/cache": "^4.4 || ^5.2",
+                "doctrine/coding-standard": "^9 || ^10",
+                "phpstan/phpstan": "~1.4.10 || ^1.8.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "symfony/cache": "^4.4 || ^5.4 || ^6",
                 "vimeo/psalm": "^4.10"
+            },
+            "suggest": {
+                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
             },
             "type": "library",
             "autoload": {
@@ -287,9 +290,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.13.3"
+                "source": "https://github.com/doctrine/annotations/tree/1.14.1"
             },
-            "time": "2022-07-02T10:48:51+00:00"
+            "time": "2022-12-12T12:46:12+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -391,32 +394,77 @@
             "time": "2022-05-20T20:06:54+00:00"
         },
         {
-            "name": "doctrine/lexer",
-            "version": "1.2.3",
+            "name": "doctrine/deprecations",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/doctrine/lexer.git",
-                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229"
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/c268e882d4dbdd85e36e4ad69e02dc284f89d229",
-                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^7.1|^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9.0",
-                "phpstan/phpstan": "^1.3",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.11"
+                "doctrine/coding-standard": "^9",
+                "phpunit/phpunit": "^7.5|^8.5|^9.5",
+                "psr/log": "^1|^2|^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
+                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
+            },
+            "time": "2022-05-02T15:47:09+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "3cf140b81e55d5d640f73367d829db7e3023ef69"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/3cf140b81e55d5d640f73367d829db7e3023ef69",
+                "reference": "3cf140b81e55d5d640f73367d829db7e3023ef69",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^10",
+                "phpstan/phpstan": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psalm/plugin-phpunit": "^0.18.3",
+                "vimeo/psalm": "^4.11 || ^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -448,7 +496,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/1.2.3"
+                "source": "https://github.com/doctrine/lexer/tree/2.0.0"
             },
             "funding": [
                 {
@@ -464,7 +512,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-28T11:07:21+00:00"
+            "time": "2022-12-11T10:51:23+00:00"
         },
         {
             "name": "enshrined/svg-sanitize",
@@ -804,16 +852,16 @@
         },
         {
             "name": "phpmailer/phpmailer",
-            "version": "v6.7",
+            "version": "v6.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPMailer/PHPMailer.git",
-                "reference": "80fc8686fcd070267b98dae0ec228d5d67d94310"
+                "reference": "49cd7ea3d2563f028d7811f06864a53b1f15ff55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/80fc8686fcd070267b98dae0ec228d5d67d94310",
-                "reference": "80fc8686fcd070267b98dae0ec228d5d67d94310",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/49cd7ea3d2563f028d7811f06864a53b1f15ff55",
+                "reference": "49cd7ea3d2563f028d7811f06864a53b1f15ff55",
                 "shasum": ""
             },
             "require": {
@@ -823,17 +871,18 @@
                 "php": ">=5.5.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "doctrine/annotations": "^1.2",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
+                "doctrine/annotations": "^1.2.6 || ^1.13.3",
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.3.5",
                 "roave/security-advisories": "dev-latest",
                 "squizlabs/php_codesniffer": "^3.7.1",
-                "yoast/phpunit-polyfills": "^1.0.0"
+                "yoast/phpunit-polyfills": "^1.0.4"
             },
             "suggest": {
                 "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
+                "ext-openssl": "Needed for secure SMTP sending and DKIM signing",
                 "greew/oauth2-azure-provider": "Needed for Microsoft Azure XOAUTH2 authentication",
                 "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
                 "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
@@ -871,7 +920,7 @@
             "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
             "support": {
                 "issues": "https://github.com/PHPMailer/PHPMailer/issues",
-                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.7"
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.7.1"
             },
             "funding": [
                 {
@@ -879,7 +928,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-05T10:56:35+00:00"
+            "time": "2022-12-08T13:30:06+00:00"
         },
         {
             "name": "psr/cache",
@@ -2765,6 +2814,68 @@
             "time": "2022-11-03T14:55:06+00:00"
         },
         {
+            "name": "symfony/process",
+            "version": "v5.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "6e75fe6874cbc7e4773d049616ab450eff537bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/6e75fe6874cbc7e4773d049616ab450eff537bf1",
+                "reference": "6e75fe6874cbc7e4773d049616ab450eff537bf1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-06-27T16:58:25+00:00"
+        },
+        {
             "name": "symfony/routing",
             "version": "v5.4.15",
             "source": {
@@ -4304,16 +4415,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.19",
+            "version": "9.2.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559"
+                "reference": "af7463c955007de36db0c5e26d03e2f933c2e980"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c77b56b63e3d2031bd8997fcec43c1925ae46559",
-                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/af7463c955007de36db0c5e26d03e2f933c2e980",
+                "reference": "af7463c955007de36db0c5e26d03e2f933c2e980",
                 "shasum": ""
             },
             "require": {
@@ -4369,7 +4480,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.19"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.20"
             },
             "funding": [
                 {
@@ -4377,7 +4488,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-11-18T07:47:47+00:00"
+            "time": "2022-12-13T07:49:28+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4622,16 +4733,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.26",
+            "version": "9.5.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "851867efcbb6a1b992ec515c71cdcf20d895e9d2"
+                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/851867efcbb6a1b992ec515c71cdcf20d895e9d2",
-                "reference": "851867efcbb6a1b992ec515c71cdcf20d895e9d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a2bc7ffdca99f92d959b3f2270529334030bba38",
+                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38",
                 "shasum": ""
             },
             "require": {
@@ -4704,7 +4815,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.26"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.27"
             },
             "funding": [
                 {
@@ -4720,7 +4831,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-28T06:00:21+00:00"
+            "time": "2022-12-09T07:31:23+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/docs/actions/lang/actionsbuilder_en.inc.php
+++ b/docs/actions/lang/actionsbuilder_en.inc.php
@@ -279,6 +279,7 @@ return [
     // "AB_management_despam_hint_details" => "Ceci permet de rétablir les pages vandalisées ou de supprimer les nouvelles pages créées"
     //         ." par des spams. ATTENTION : la suppression des pages choisies sera DÉFINITITVE.",
     // "AB_management_editconfig_label" => "Modifier des paramètres du fichier de configuration",
+    "AB_management_adminbackups_label" => "Backups management",
     // advanced actions
     // "AB_advanced_actions_label" => "Actions avancées",
     // "AB_advanced_action_backlinks_label" => "Afficher les pages qui ont un lien vers la page courante",

--- a/docs/actions/lang/actionsbuilder_fr.inc.php
+++ b/docs/actions/lang/actionsbuilder_fr.inc.php
@@ -278,6 +278,7 @@ return [
     "AB_management_despam_hint_details" => "Ceci permet de rétablir les pages vandalisées ou de supprimer les nouvelles pages créées"
             ." par des spams. ATTENTION : la suppression des pages choisies sera DÉFINITITVE.",
     "AB_management_editconfig_label" => "Modifier des paramètres du fichier de configuration",
+    "AB_management_adminbackups_label" => "Gestion des sauvegardes",
     // advanced actions
     "AB_advanced_actions_label" => "Actions avancées",
     "AB_advanced_action_backlinks_label" => "Afficher les pages qui ont un lien vers la page courante",

--- a/docs/actions/lang/actionsbuilder_pt.inc.php
+++ b/docs/actions/lang/actionsbuilder_pt.inc.php
@@ -279,6 +279,7 @@ return [
     // "AB_management_despam_hint_details" => "Ceci permet de rétablir les pages vandalisées ou de supprimer les nouvelles pages créées"
     //         ." par des spams. ATTENTION : la suppression des pages choisies sera DÉFINITITVE.",
     // "AB_management_editconfig_label" => "Modifier des paramètres du fichier de configuration",
+    // "AB_management_adminbackups_label" => "Gestion des sauvegardes",
     // advanced actions
     "AB_advanced_actions_label" => "Ações avançadas",
     "AB_advanced_action_backlinks_label" => "Mostrar páginas que possuem um link para a página atual",

--- a/docs/actions/management.yaml
+++ b/docs/actions/management.yaml
@@ -51,3 +51,5 @@ actions:
         doclink: https://yeswiki.net/?LutterContreLeSpam
   filemanager:
     label: _t(AB_management_filemanager_label)
+  adminbackups:
+    label: _t(AB_management_adminbackups_label)

--- a/handlers/UpdateHandler.php
+++ b/handlers/UpdateHandler.php
@@ -130,6 +130,20 @@ class UpdateHandler extends YesWikiHandler
             // replace CalcField value by string
             $output .= $this->calcFieldToString();
 
+            // adding GererSauvegards page
+            $output .= 'ℹ️ Adding GererSauvegardes pages.... ';
+            $page = $this->getService(PageManager::class)->getOne('GererSauvegardes');
+            if (empty($page)) {
+                list($updatePagesState, $message) = $this->updateAdminPages(['GererSauvegardes']);
+                if ($updatePagesState) {
+                    $output .= '✅ Done !<br />';
+                } else {
+                    $output .= '<span class="label label-warning">! '._t('UPDATE_ADMIN_PAGES_ERROR').'</span>'.'<br />'.$message;
+                }
+            } else {
+                $output .= '✅ Done !<br />';
+            }
+
             // propose to update content of admin's pages
             $output .= $this->frontUpdateAdminPages();
         } else {

--- a/handlers/UpdateHandler.php
+++ b/handlers/UpdateHandler.php
@@ -4,6 +4,7 @@ use YesWiki\Bazar\Field\CalcField;
 use YesWiki\Bazar\Service\EntryManager;
 use YesWiki\Bazar\Service\FormManager;
 use YesWiki\Core\Service\AclService;
+use YesWiki\Core\Service\ArchiveService;
 use YesWiki\Core\Service\DbService;
 use YesWiki\Core\Service\LinkTracker;
 use YesWiki\Core\Service\PageManager;
@@ -130,7 +131,7 @@ class UpdateHandler extends YesWikiHandler
             // replace CalcField value by string
             $output .= $this->calcFieldToString();
 
-            // adding GererSauvegards page
+            // adding GererSauvegardes page
             $output .= 'ℹ️ Adding GererSauvegardes pages.... ';
             $page = $this->getService(PageManager::class)->getOne('GererSauvegardes');
             if (empty($page)) {
@@ -140,6 +141,32 @@ class UpdateHandler extends YesWikiHandler
                 } else {
                     $output .= '<span class="label label-warning">! '._t('UPDATE_ADMIN_PAGES_ERROR').'</span>'.'<br />'.$message;
                 }
+            } else {
+                $output .= '✅ Done !<br />';
+            }
+
+            // updating folder 'private'
+            $output .= 'ℹ️ Updating folder \'private\'.... ';
+            if ((file_exists('private') && !is_dir('private')) || (!file_exists('private') && !mkdir('private'))) {
+                $output .= "❌ Not possible to update the folder 'private' !<br/>";
+            } elseif ((file_exists('private/.htaccess') &&
+                    !is_file('private/.htaccess')) || // do not udpate the content if existing but not a file
+                    (!file_exists('private/.htaccess') && !file_put_contents('private/.htaccess', "DENY FROM ALL\n"))
+            ) {
+                $output .= "❌ Not possible to create the file 'private/.htaccess' !<br/>";
+            } elseif ((file_exists('private/backups') && !is_dir('private/backups')) || (!file_exists('private/backups') && !mkdir('private/backups'))) {
+                $output .= "❌ Not possible to update the folder 'private/backups' !<br/>";
+            } elseif ((file_exists('private/backups/.htaccess') &&
+                    !is_file('private/backups/.htaccess')) || // do not udpate the content if existing but not a file
+                    (!file_exists('private/backups/.htaccess') && !file_put_contents('private/backups/.htaccess', "DENY FROM ALL\n"))
+            ) {
+                $output .= "❌ Not possible to create the file 'private/backups/.htaccess' !<br/>";
+            } elseif ((file_exists('private/backups/README.md') &&
+                    !is_file('private/backups/README.md')) || // do not udpate the content if existing but not a file
+                    (!file_exists('private/backups/README.md') &&
+                    !file_put_contents('private/backups/README.md', ArchiveService::PRIVATE_FOLDER_README_DEFAULT_CONTENT))
+            ) {
+                $output .= "❌ Not possible to create the file 'private/backups/README.md' !<br/>";
             } else {
                 $output .= '✅ Done !<br />';
             }

--- a/handlers/UpdateHandler.php
+++ b/handlers/UpdateHandler.php
@@ -10,6 +10,7 @@ use YesWiki\Core\Service\PageManager;
 use YesWiki\Core\Service\PasswordHasherFactory;
 use YesWiki\Security\Controller\SecurityController;
 use YesWiki\Core\YesWikiHandler;
+use YesWiki\Core\Service\ConfigurationService;
 use YesWiki\Wiki;
 
 class UpdateHandler extends YesWikiHandler
@@ -246,8 +247,7 @@ class UpdateHandler extends YesWikiHandler
         $output = "ℹ️ Resetting comment acls<br />";
 
         // default acls in wakka.config.php
-        include_once 'tools/templates/libs/Configuration.php';
-        $config = new Configuration('wakka.config.php');
+        $config = $this->getService(ConfigurationService::class)->getConfiguration('wakka.config.php');
         $config->load();
 
         $baseKey = 'default_comment_acl';

--- a/handlers/page/dbutf8.php
+++ b/handlers/page/dbutf8.php
@@ -1,6 +1,7 @@
 <?php
 
 use YesWiki\Security\Controller\SecurityController;
+use YesWiki\Core\Service\ConfigurationService;
 
 if (isset($this)) {
     if ($this->services->get(SecurityController::class)->isWikiHibernated()) {
@@ -91,8 +92,7 @@ if (isset($this)) {
         $output .=  "<h3>Complete ALL</h3>";
 
         // ajout du charset utf8mb4 dans wakka.config.php
-        include_once 'tools/templates/libs/Configuration.php';
-        $config = new Configuration('wakka.config.php');
+        $config = $this->services->get(ConfigurationService::class)->getConfiguration('wakka.config.php');
         $config->load();
         $config->db_charset = 'utf8mb4';
         $config->write();
@@ -241,8 +241,7 @@ if (php_sapi_name() === 'cli') {
     }
 
     // ajout du charset utf8mb4 dans wakka.config.php
-    include_once 'tools/templates/libs/Configuration.php';
-    $config = new Configuration($cwd.'/wakka.config.php');
+    $config = $this->services->get(ConfigurationService::class)->getConfiguration($cwd.'/wakka.config.php');
     $config->load();
     $config->db_charset = 'utf8mb4';
     $config->write();

--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -1204,11 +1204,6 @@ class Wiki
         // See https://www.php.net/manual/fr/features.file-upload.put-method.php
         // TODO properly use the Symfony HttpFoundation component to avoid this
         if (($_SERVER['REQUEST_METHOD'] == 'POST' || $_SERVER['REQUEST_METHOD'] == 'PUT' || $_SERVER['REQUEST_METHOD'] == 'PATCH')) {
-            if ($this->services->get(SecurityController::class)->isWikiHibernated()) {
-                $response = new Response(_t('WIKI_IN_HIBERNATION'), Response::HTTP_UNAUTHORIZED);
-                $response->send();
-                $this->exit();
-            }
             if (empty($_POST)) {
                 $_POST = json_decode(file_get_contents('php://input'), true) ?? [];
             }

--- a/includes/YesWikiInit.php
+++ b/includes/YesWikiInit.php
@@ -209,7 +209,7 @@ class Init
             'htmlPurifierActivated' => false, // TODO ectoplasme set to true
             'favorites_activated' => true,
             ArchiveService::PARAMS_KEY_IN_WAKKA => [
-                ArchiveService::KEY_FOR_ANONYMOUS => ArchiveService::DEFAULT_PARAMS_TO_ANONYMIZE,
+                ArchiveService::KEY_FOR_HIDE_CONFIG_VALUES => ArchiveService::DEFAULT_PARAMS_TO_ANONYMIZE,
                 'authorize_bypass_preupdate_backup' => false,
                 'preupdate_backup_activated' => false,
                 'call_archive_async' => true,

--- a/includes/YesWikiInit.php
+++ b/includes/YesWikiInit.php
@@ -15,6 +15,7 @@ use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
+use YesWiki\Core\Service\ArchiveService;
 
 // TODO put elsewhere
 // https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/src/Routing/AnnotatedRouteControllerLoader.php
@@ -207,6 +208,9 @@ class Init
             'wakka_name' => '', // backup wakka_name if deleted from wakka.config.php
             'htmlPurifierActivated' => false, // TODO ectoplasme set to true
             'favorites_activated' => true,
+            ArchiveService::PARAMS_KEY_IN_WAKKA => [
+                ArchiveService::KEY_FOR_ANONYMOUS => ArchiveService::DEFAULT_PARAMS_TO_ANONYMIZE
+            ],
         );
         unset($_rewrite_mode);
 

--- a/includes/YesWikiInit.php
+++ b/includes/YesWikiInit.php
@@ -209,7 +209,9 @@ class Init
             'htmlPurifierActivated' => false, // TODO ectoplasme set to true
             'favorites_activated' => true,
             ArchiveService::PARAMS_KEY_IN_WAKKA => [
-                ArchiveService::KEY_FOR_ANONYMOUS => ArchiveService::DEFAULT_PARAMS_TO_ANONYMIZE
+                ArchiveService::KEY_FOR_ANONYMOUS => ArchiveService::DEFAULT_PARAMS_TO_ANONYMIZE,
+                'authorize_bypass_preupdate_backup' => false,
+                'call_archive_async' => true,
             ],
         );
         unset($_rewrite_mode);

--- a/includes/YesWikiInit.php
+++ b/includes/YesWikiInit.php
@@ -211,6 +211,7 @@ class Init
             ArchiveService::PARAMS_KEY_IN_WAKKA => [
                 ArchiveService::KEY_FOR_ANONYMOUS => ArchiveService::DEFAULT_PARAMS_TO_ANONYMIZE,
                 'authorize_bypass_preupdate_backup' => false,
+                'preupdate_backup_activated' => false,
                 'call_archive_async' => true,
                 ArchiveService::KEY_FOR_PRIVATE_FOLDER => ArchiveService::PRIVATE_FOLDER_NAME_IN_ZIP,
             ],

--- a/includes/YesWikiInit.php
+++ b/includes/YesWikiInit.php
@@ -211,7 +211,7 @@ class Init
             ArchiveService::PARAMS_KEY_IN_WAKKA => [
                 ArchiveService::KEY_FOR_HIDE_CONFIG_VALUES => ArchiveService::DEFAULT_PARAMS_TO_ANONYMIZE,
                 'authorize_bypass_preupdate_backup' => false,
-                'preupdate_backup_activated' => false,
+                'preupdate_backup_activated' => true,
                 'call_archive_async' => true,
                 ArchiveService::KEY_FOR_PRIVATE_FOLDER => ArchiveService::PRIVATE_FOLDER_NAME_IN_ZIP,
                 'max_nb_files' => 10,

--- a/includes/YesWikiInit.php
+++ b/includes/YesWikiInit.php
@@ -214,6 +214,7 @@ class Init
                 'preupdate_backup_activated' => false,
                 'call_archive_async' => true,
                 ArchiveService::KEY_FOR_PRIVATE_FOLDER => ArchiveService::PRIVATE_FOLDER_NAME_IN_ZIP,
+                'max_nb_files' => 10,
             ],
         );
         unset($_rewrite_mode);

--- a/includes/YesWikiInit.php
+++ b/includes/YesWikiInit.php
@@ -212,6 +212,7 @@ class Init
                 ArchiveService::KEY_FOR_ANONYMOUS => ArchiveService::DEFAULT_PARAMS_TO_ANONYMIZE,
                 'authorize_bypass_preupdate_backup' => false,
                 'call_archive_async' => true,
+                ArchiveService::KEY_FOR_PRIVATE_FOLDER => ArchiveService::PRIVATE_FOLDER_NAME_IN_ZIP,
             ],
         );
         unset($_rewrite_mode);

--- a/includes/autoload.inc.php
+++ b/includes/autoload.inc.php
@@ -43,9 +43,7 @@ spl_autoload_register(function ($className) {
                     }
                     break;
                 case 'Commands':
-                    if ($matches[1] != "Core") {
-                        require "$basePath/commands/{$matches[3]}.php";
-                    }
+                    require "$basePath/commands/{$matches[3]}.php";
                     break;
                 case 'Entity':
                     require "$basePath/entities/{$matches[3]}.php";

--- a/includes/commands/ArchiveCommand.php
+++ b/includes/commands/ArchiveCommand.php
@@ -40,6 +40,7 @@ class ArchiveCommand extends Command
             ->addOption('nosavedatabase', 'f', InputOption::VALUE_NONE, 'Do not save database')
             ->addOption('extrafiles', 'e', InputOption::VALUE_REQUIRED, 'Extrafiles, path relative to root, coma separated')
             ->addOption('excludedfiles', 'x', InputOption::VALUE_REQUIRED, 'Excludedfiles, path relative to root, coma separated')
+            ->addOption('anonymous', 'a', InputOption::VALUE_REQUIRED, 'Params to anonymize in wakka.config.php, json_encoded')
         ;
     }
 
@@ -55,8 +56,16 @@ class ArchiveCommand extends Command
 
         $extrafiles = $this->prepareFileList($input->getOption('extrafiles'));
         $excludedfiles = $this->prepareFileList($input->getOption('excludedfiles'));
+        $rawAnonymous = $input->getOption('anonymous');
+        $anonymous = null;
+        if (!empty($rawAnonymous)) {
+            $rawAnonymous = json_decode($rawAnonymous, true);
+            if (is_array($rawAnonymous)) {
+                $anonymous = $rawAnonymous;
+            }
+        }
 
-        $location = $this->archiveService->archive($output, !$nosavefiles, !$nosavedatabase, $extrafiles, $excludedfiles);
+        $location = $this->archiveService->archive($output, !$nosavefiles, !$nosavedatabase, $extrafiles, $excludedfiles, $anonymous);
 
         return Command::SUCCESS;
     }

--- a/includes/commands/ArchiveCommand.php
+++ b/includes/commands/ArchiveCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace YesWiki\Core\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use YesWiki\Core\Service\ArchiveService;
+use YesWiki\Wiki;
+
+class ArchiveCommand extends Command
+{
+    // the name of the command (the part after "bin/console")
+    protected static $defaultName = 'core:archive';
+
+    protected $archiveService;
+    protected $wiki;
+
+    public function __construct(Wiki &$wiki)
+    {
+        parent::__construct();
+        $this->archiveService = $wiki->services->get(ArchiveService::class);
+        $this->wiki = $wiki;
+    }
+
+    protected function configure()
+    {
+        $this
+            // the short description shown while running "php bin/console list"
+            ->setDescription('Create archive of the YesWiki.')
+
+            // the full command description shown when running the command with
+            // the "--help" option
+            ->setHelp("Create archive of the YesWiki.\n".
+                "To not save files use '--nosavefiles'\n".
+                "To not save database use '--nosavedatabase'\n")
+            
+            ->addOption('nosavefiles', 'd', InputOption::VALUE_NONE, 'Do not save files of the wiki')
+            ->addOption('nosavedatabase', 'f', InputOption::VALUE_NONE, 'Do not save database')
+            ->addOption('extrafiles', 'e', InputOption::VALUE_REQUIRED, 'Extrafiles, path relative to root, coma separated')
+            ->addOption('excludedfiles', 'x', InputOption::VALUE_REQUIRED, 'Excludedfiles, path relative to root, coma separated')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $nosavefiles = $input->getOption('nosavefiles');
+        $nosavedatabase = $input->getOption('nosavedatabase');
+
+        if ($nosavefiles && $nosavedatabase) {
+            $output->writeln("Invalid options : It is not possible to use --nosavefiles and --nosavedatabase options in same time.");
+            return Command::INVALID;
+        }
+
+        $extrafiles = $this->prepareFileList($input->getOption('extrafiles'));
+        $excludedfiles = $this->prepareFileList($input->getOption('excludedfiles'));
+
+        $location = $this->archiveService->archive($output, !$nosavefiles, !$nosavedatabase, $extrafiles, $excludedfiles);
+
+        return Command::SUCCESS;
+    }
+
+    private function prepareFileList($list): array
+    {
+        if (empty($list)) {
+            $list = [];
+        } else {
+            $list = array_filter(array_map('trim', explode(',', $list)));
+        }
+        return $list;
+    }
+}

--- a/includes/commands/ArchiveCommand.php
+++ b/includes/commands/ArchiveCommand.php
@@ -40,7 +40,7 @@ class ArchiveCommand extends Command
             ->addOption('nosavedatabase', 'f', InputOption::VALUE_NONE, 'Do not save database')
             ->addOption('extrafiles', 'e', InputOption::VALUE_REQUIRED, 'Extrafiles, path relative to root, coma separated')
             ->addOption('excludedfiles', 'x', InputOption::VALUE_REQUIRED, 'Excludedfiles, path relative to root, coma separated')
-            ->addOption('anonymous', 'a', InputOption::VALUE_REQUIRED, 'Params to anonymize in wakka.config.php, json_encoded')
+            ->addOption('hideConfigValues', 'a', InputOption::VALUE_REQUIRED, 'Params to anonymize in wakka.config.php, json_encoded')
             ->addOption('uid', 'u', InputOption::VALUE_REQUIRED, 'uid to retrive input and ouput files')
         ;
     }
@@ -57,18 +57,18 @@ class ArchiveCommand extends Command
 
         $extrafiles = $this->prepareFileList($input->getOption('extrafiles'));
         $excludedfiles = $this->prepareFileList($input->getOption('excludedfiles'));
-        $rawAnonymous = $input->getOption('anonymous');
-        $anonymous = null;
-        if (!empty($rawAnonymous)) {
-            $rawAnonymous = json_decode($rawAnonymous, true);
-            if (is_array($rawAnonymous)) {
-                $anonymous = $rawAnonymous;
+        $rawHideConfigValues = $input->getOption('hideConfigValues');
+        $hideConfigValues = null;
+        if (!empty($rawHideConfigValues)) {
+            $rawHideConfigValues = json_decode($rawHideConfigValues, true);
+            if (is_array($rawHideConfigValues)) {
+                $hideConfigValues = $rawHideConfigValues;
             }
         }
         $uid = $input->getOption('uid');
         $uid = empty($uid) ? "" : $uid;
 
-        $location = $this->archiveService->archive($output, !$nosavefiles, !$nosavedatabase, $extrafiles, $excludedfiles, $anonymous, $uid);
+        $location = $this->archiveService->archive($output, !$nosavefiles, !$nosavedatabase, $extrafiles, $excludedfiles, $hideConfigValues, $uid);
 
         return Command::SUCCESS;
     }

--- a/includes/commands/ArchiveCommand.php
+++ b/includes/commands/ArchiveCommand.php
@@ -41,6 +41,7 @@ class ArchiveCommand extends Command
             ->addOption('extrafiles', 'e', InputOption::VALUE_REQUIRED, 'Extrafiles, path relative to root, coma separated')
             ->addOption('excludedfiles', 'x', InputOption::VALUE_REQUIRED, 'Excludedfiles, path relative to root, coma separated')
             ->addOption('anonymous', 'a', InputOption::VALUE_REQUIRED, 'Params to anonymize in wakka.config.php, json_encoded')
+            ->addOption('uid', 'u', InputOption::VALUE_REQUIRED, 'uid to retrive input and ouput files')
         ;
     }
 
@@ -64,8 +65,10 @@ class ArchiveCommand extends Command
                 $anonymous = $rawAnonymous;
             }
         }
+        $uid = $input->getOption('uid');
+        $uid = empty($uid) ? "" : $uid;
 
-        $location = $this->archiveService->archive($output, !$nosavefiles, !$nosavedatabase, $extrafiles, $excludedfiles, $anonymous);
+        $location = $this->archiveService->archive($output, !$nosavefiles, !$nosavedatabase, $extrafiles, $excludedfiles, $anonymous, $uid);
 
         return Command::SUCCESS;
     }

--- a/includes/commands/DbCommand.php
+++ b/includes/commands/DbCommand.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace YesWiki\Core\Commands;
+
+use Exception;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Throwable;
+use YesWiki\Core\Service\ConsoleService;
+use YesWiki\Wiki;
+
+class DbCommand extends Command
+{
+    // the name of the command (the part after "php includes/commands/console")
+    protected static $defaultName = 'core:exportdb';
+
+    protected $consoleService;
+    protected $params;
+    protected $wiki;
+
+    public function __construct(Wiki &$wiki)
+    {
+        parent::__construct();
+        $this->consoleService = $wiki->services->get(ConsoleService::class);
+        $this->params = $wiki->services->get(ParameterBagInterface::class);
+        $this->wiki = $wiki;
+    }
+
+    protected function configure()
+    {
+        $this
+            // the short description shown while running "php includes/commands/console list"
+            ->setDescription('Manage database of the YesWiki.')
+
+            // the full command description shown when running the command with
+            // the "--help" option
+            ->setHelp("Manage database of the YesWiki.\n".
+                "To test use '--test'\n")
+
+            ->addOption('test', 't', InputOption::VALUE_NONE, 'Test the connection to mysqldump (return OK/NOK)')
+            ->addOption('filepath', 'f', InputOption::VALUE_REQUIRED, '.sql file path where export db')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $isTest = $input->getOption('test');
+        $filepath = $input->getOption('filepath');
+
+        if (!$isTest && (empty($filepath) || substr($filepath, -4) != ".sql")) {
+            $output->writeln("Invalid options : option '--filepath' is required and should end by '.sql' if not testing.");
+            return Command::INVALID;
+        }
+
+        if ($isTest) {
+            return $this->test($output);
+        }
+        return $this->export($output, $filepath);
+    }
+
+    /**
+     * export db via mysqldump
+     * @param OutputInterface $output
+     * @param string $filepath
+     * @return int Command:code
+     * @throws Exception
+     * @throws Throwable
+     */
+    private function export(OutputInterface $output, string $filepath): int
+    {
+        $realFilePath = realpath(dirname($filepath)).DIRECTORY_SEPARATOR.basename($filepath);
+        $hostname = $this->params->get('mysql_host');
+        $this->assertParamIsNotEmptyString('mysql_host', $hostname);
+
+        $databasename = $this->params->get('mysql_database');
+        $this->assertParamIsNotEmptyString('mysql_database', $databasename);
+
+        $tablePrefix = $this->params->get('table_prefix');
+        $this->assertParamIsNotEmptyString('table_prefix', $tablePrefix);
+
+        $username = $this->params->get('mysql_user');
+        $this->assertParamIsString('mysql_user', $username);
+
+        $password = $this->params->get('mysql_password');
+        $this->assertParamIsString('mysql_password', $password);
+        try {
+            $results = $this->consoleService->findAndStartExecutableSync(
+                "mysqldump",
+                [
+                    "--host=$hostname",
+                    "--user=$username",
+                    "--password=$password",
+                    "--result-file=$realFilePath",
+                    $databasename, // databasename
+                    "{$tablePrefix}users", // tables
+                    "{$tablePrefix}pages", // tables
+                    "{$tablePrefix}nature", // tables
+                    "{$tablePrefix}triples", // tables
+                    "{$tablePrefix}acls", // tables
+                    "{$tablePrefix}links", // tables
+                    "{$tablePrefix}referrers", // tables
+                ], // args
+                "", // subfolder
+                $this->getExtaDirs(), // extraDirsWhereSearch
+                120 // timeoutInSec (2 minutes)
+            );
+            $err = $this->getErr($results);
+            if (empty($err)) {
+                return Command::SUCCESS;
+            } else {
+                $output->writeln($err);
+            }
+        } catch (Throwable $ex) {
+            $output->writeln("System error when testing mysqldump : {$ex->getMessage()}");
+        }
+        return Command::FAILURE;
+    }
+
+    /**
+     * test connection to mysqldump
+     * @param OutputInterface $output
+     * @return int Command:code
+     * @throws Throwable
+     */
+    private function test(OutputInterface $output): int
+    {
+        try {
+            $results = $this->consoleService->findAndStartExecutableSync(
+                "mysqldump",
+                [
+                    "-V", // output version
+                ], // args
+                "", // subfolder
+                $this->getExtaDirs(), // extraDirsWhereSearch
+                10 // timeoutInSec
+            );
+            $outputResult = $this->getOutput($results);
+            if (preg_match("/^mysqldump(?:\.exe)?\s*Ver\s*\d+\.?\d*.*/i", $outputResult)) {
+                $output->writeln("OK");
+                return Command::SUCCESS;
+            }
+        } catch (Throwable $ex) {
+            $output->writeln("System error when testing mysqldump : {$ex->getMessage()} in {$ex->getFile()}, line {$ex->getLine()}");
+        }
+        $output->writeln("NOK");
+        return Command::FAILURE;
+    }
+
+    private function getOutput($results): string
+    {
+        $outputResult = (!empty($results) && is_array($results)) ? ($results[array_key_first($results)]['stdout'] ?? '') : '';
+        return $outputResult;
+    }
+    private function getErr($results): string
+    {
+        return (!empty($results) && is_array($results)) ? ($results[array_key_first($results)]['stderr'] ?? '') : '';
+    }
+
+    private function getExtaDirs(): array
+    {
+        return '\\' === DIRECTORY_SEPARATOR ? ["c:\\xampp\\mysql\\bin\\"] : ["/usr/bin/","/usr/local/bin/"];
+    }
+
+    /**
+    * assert param is a not empty string
+    * @param string $name
+    * @param mixed $param
+    * @throws Exception
+    */
+   protected function assertParamIsNotEmptyString(string $name, $param)
+   {
+       if (empty($param)) {
+           throw new Exception("'$name' should not be empty in 'wakka.config.php'");
+       }
+       $this->assertParamIsString($name, $param);
+   }
+
+    /**
+     * assert param is a string
+     * @param string $name
+     * @param mixed $param
+     * @throws Exception
+     */
+    protected function assertParamIsString(string $name, $param)
+    {
+        if (!is_string($param)) {
+            throw new Exception("'$name' should be a string in 'wakka.config.php'");
+        }
+    }
+}

--- a/includes/commands/TestConsoleServiceCommand.php
+++ b/includes/commands/TestConsoleServiceCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace YesWiki\Core\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use YesWiki\Core\Service\ConsoleService;
+use YesWiki\Wiki;
+
+class TestConsoleServiceCommand extends Command
+{
+    // the name of the command (the part after "bin/console")
+    protected static $defaultName = 'core:testconsoleservice';
+
+    protected $wiki;
+
+    public function __construct(Wiki &$wiki)
+    {
+        parent::__construct();
+        $this->wiki = $wiki;
+    }
+
+    protected function configure()
+    {
+        $this
+            // the short description shown while running "php bin/console list"
+            ->setDescription('Offer tests for ConsoleService.')
+
+            // the full command description shown when running the command with
+            // the "--help" option
+            ->setHelp("This command offers tests for ConsoleService.\nIf the option --childtext is empty, wait 2 seconds before appending text.")
+            
+            ->addOption('file', 'f', InputOption::VALUE_REQUIRED, 'Filename where append text')
+            ->addOption('text', 't', InputOption::VALUE_REQUIRED, 'Text to append')
+            ->addOption('childtext', 'c', InputOption::VALUE_OPTIONAL, 'Text to append for child')
+            ->addOption('wait', 'w', InputOption::VALUE_REQUIRED, 'Time to wait (s)')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $file = basename($input->getOption('file'));
+        $text = $input->getOption('text');
+        $wait = abs(intval($input->getOption('wait')));
+        // force file to be in cache folder
+        if (empty($file) || empty($text) || is_dir("cache/$file") || empty($wait)){
+            return Command::FAIL;
+        }
+        $childtext = $input->getOption('childtext');
+        if (empty($childtext)){
+            sleep($wait);
+            $this->writeToFile("cache/$file",$text);
+            exit();
+        } else {
+            $consoleService = $this->wiki->services->get(ConsoleService::class);
+            $consoleService->startConsoleAsync('core:testconsoleservice',["-f",$file,"-t",$childtext,"-w",$wait]);
+            $this->writeToFile("cache/$file",$text);
+            exit();
+        }
+        return Command::SUCCESS;
+    }
+
+    private function writeToFile(string $file, string $content)
+    {
+        file_put_contents($file,$content,FILE_APPEND);
+    }
+}

--- a/includes/commands/TestConsoleServiceCommand.php
+++ b/includes/commands/TestConsoleServiceCommand.php
@@ -46,7 +46,7 @@ class TestConsoleServiceCommand extends Command
         $wait = abs(intval($input->getOption('wait')));
         // force file to be in cache folder
         if (empty($file) || empty($text) || is_dir("cache/$file") || empty($wait)){
-            return Command::FAIL;
+            return Command::FAILURE;
         }
         $childtext = $input->getOption('childtext');
         if (empty($childtext)){

--- a/includes/commands/console
+++ b/includes/commands/console
@@ -4,7 +4,6 @@
 namespace YesWiki\Core\Commands;
 
 use Symfony\Component\Console\Application;
-use YesWiki\Core\Commands\CallServiceCommand;
 use YesWiki\Core\YesWikiLoader;
 
 if (!file_exists('wakka.config.php')) {

--- a/includes/commands/console
+++ b/includes/commands/console
@@ -1,0 +1,60 @@
+#!/usr/bin/env php
+<?php
+
+namespace YesWiki\Core\Commands;
+
+use Symfony\Component\Console\Application;
+use YesWiki\Core\Commands\CallServiceCommand;
+use YesWiki\Core\YesWikiLoader;
+
+if (!file_exists('wakka.config.php')) {
+    exit("\e[31mThe command should be launched from your YesWiki root directory\e[0m");
+}
+
+include_once('wakka.config.php');
+// fake $_SERVER vars
+$_SERVER['REQUEST_URI'] = $wakkaConfig['base_url'].$wakkaConfig['root_page'];
+$_SERVER['HTTP_HOST'] = parse_url($wakkaConfig['base_url'], PHP_URL_HOST);
+$_SERVER['REQUEST_METHOD'] = 'GET';
+// fake wiki page
+$_REQUEST['wiki'] = $wakkaConfig['root_page'];
+
+// Load YesWiki
+require_once 'includes/YesWikiLoader.php';
+$wiki = YesWikiLoader::getWiki();
+
+// create Application
+$application = new Application();
+
+// ... register commands
+foreach ([
+        'core' => 'includes/commands/*.php',
+        'custom' => 'custom/commands/*.php',
+        'tools' => 'tools/*/commands/*.php',
+    ] as $type => $search) {
+    $files = glob($search);
+    foreach ($files as $filePath) {
+        $filename = pathinfo($filePath)['filename'];
+        switch ($type) {
+            case 'core':
+                $className = "\\YesWiki\\Core\\Commands\\$filename";
+                break;
+            case 'custom':
+                $className = "\\YesWiki\\Custom\\Commands\\$filename";
+                break;
+            case 'tools':
+                $toolName = ucfirst(strtolower(basename(dirname(dirname($filePath)))));
+                $className = "\\YesWiki\\$toolName\\Commands\\$filename";
+                break;
+            default:
+                $className = "";
+                break;
+        }
+        $command = new $className($wiki);
+        if ($command) {
+            $application->add($command);
+        }
+    }
+}
+
+$application->run();

--- a/includes/controllers/ApiController.php
+++ b/includes/controllers/ApiController.php
@@ -837,6 +837,17 @@ class ApiController extends YesWikiController
     }
 
     /**
+     * @Route("/api/archives/archivingStatus/", methods={"GET"}, options={"acl":{"public", "@admins"}},priority=3)
+     */
+    public function getArchivingStatus()
+    {
+        return new ApiResponse(
+            $this->getService(ArchiveService::class)->getArchivingStatus(),
+            Response::HTTP_OK
+        );
+    }
+
+    /**
      * @Route("/api/archives/", methods={"GET"}, options={"acl":{"public", "@admins"}})
      * @Route("/api/archives", methods={"GET"}, options={"acl":{"public", "@admins"}})
      */

--- a/includes/controllers/ApiController.php
+++ b/includes/controllers/ApiController.php
@@ -833,11 +833,14 @@ class ApiController extends YesWikiController
      */
     public function getArchiveStatus($uid)
     {
-        return $this->getService(ArchiveController::class)->getArchiveStatus($uid);
+        return $this->getService(ArchiveController::class)->getArchiveStatus(
+            $uid,
+            empty($_GET['forceStarted']) ? false : in_array($_GET['forceStarted'],[1,true,"1","true"],true)
+        );
     }
 
     /**
-     * @Route("/api/archives/archivingStatus/", methods={"GET"}, options={"acl":{"public", "@admins"}},priority=3)
+     * @Route("/api/archives/archivingStatus/", methods={"GET"}, options={"acl":{"public", "@admins"}})
      */
     public function getArchivingStatus()
     {
@@ -846,6 +849,19 @@ class ApiController extends YesWikiController
             Response::HTTP_OK
         );
     }
+    
+    /**
+     * @Route("/api/archives/forcedUpdateToken/", methods={"GET"}, options={"acl":{"public", "@admins"}})
+     */
+    public function getForcedUpdateToken()
+    {
+        $token = $this->getService(ArchiveService::class)->getForcedUpdateToken();
+        return new ApiResponse(
+            ['token'=>$token],
+            empty($token) ? Response::HTTP_INTERNAL_SERVER_ERROR : Response::HTTP_OK
+        );
+    }
+
 
     /**
      * @Route("/api/archives/", methods={"GET"}, options={"acl":{"public", "@admins"}})

--- a/includes/controllers/ApiController.php
+++ b/includes/controllers/ApiController.php
@@ -827,6 +827,14 @@ class ApiController extends YesWikiController
     {
         return $this->getService(ArchiveController::class)->getArchive($id);
     }
+    
+    /**
+     * @Route("/api/archives/uidstatus/{uid}", methods={"GET"}, options={"acl":{"public", "@admins"}})
+     */
+    public function getArchiveStatus($uid)
+    {
+        return $this->getService(ArchiveController::class)->getArchiveStatus($uid);
+    }
 
     /**
      * @Route("/api/archives/", methods={"GET"}, options={"acl":{"public", "@admins"}})

--- a/includes/controllers/ArchiveController.php
+++ b/includes/controllers/ArchiveController.php
@@ -91,15 +91,15 @@ class ArchiveController extends YesWikiController
                     );
                 }
                 $params = (isset($_POST['params']) && is_array($_POST['params'])) ? $_POST['params'] : [];
-                $pid = $this->startArchiveAsync($params);
-                if (empty($pid)) {
+                $uid = $this->startArchiveAsync($params);
+                if (empty($uid)) {
                     return new ApiResponse(
                         ['error' => 'no process created when starting archive action'],
                         Response::HTTP_INTERNAL_SERVER_ERROR
                     );
                 }
                 return new ApiResponse(
-                    ['pid' => $pid],
+                    ['uid' => $uid],
                     Response::HTTP_OK
                 );
                 break;
@@ -109,13 +109,6 @@ class ArchiveController extends YesWikiController
                     Response::HTTP_OK
                 );
                 break;
-            case 'archiveStatus':
-                return new ApiResponse(
-                    [],
-                    Response::HTTP_OK
-                );
-                break;
-            
             case 'restore':
                 if (empty($id)) {
                     return new ApiResponse(
@@ -139,6 +132,20 @@ class ArchiveController extends YesWikiController
         }
     }
 
+    public function getArchiveStatus(string $uid)
+    {
+        if (empty($uid)) {
+            return new ApiResponse(
+                ['error' => "\$uid should not be empty"],
+                Response::HTTP_BAD_REQUEST
+            );
+        }
+        return new ApiResponse(
+            $this->archiveService->getUIDStatus($uid),
+            Response::HTTP_OK
+        );
+    }
+
     /**
      * start archive async via CLI
      * @param array $params
@@ -147,7 +154,7 @@ class ArchiveController extends YesWikiController
      * @param bool $savedatabase
      * @param array $extrafiles
      * @param array $excludedfiles
-     * @return string PID
+     * @return string uid
      */
     protected function startArchiveAsync(
         array $params = []
@@ -160,13 +167,11 @@ class ArchiveController extends YesWikiController
         $extrafiles = array_filter($extrafiles, 'is_string');
         $excludedfiles = array_filter($excludedfiles, 'is_string');
 
-        $process = $this->archiveService->startArchiveAsync(
+        return $this->archiveService->startArchiveAsync(
             $savefiles,
             $savedatabase,
             $extrafiles,
             $excludedfiles
         );
-        $processId = empty($process) ? "" : $process->getPid();
-        return empty($processId) ? "" : $processId;
     }
 }

--- a/includes/controllers/ArchiveController.php
+++ b/includes/controllers/ArchiveController.php
@@ -84,8 +84,22 @@ class ArchiveController extends YesWikiController
                 );
                 break;
             case 'startArchive':
+                if (isset($_POST['params']) && !is_array($_POST['params'])) {
+                    return new ApiResponse(
+                        ['error' => "\$_POST['params'] should be set and be an array for action 'startArchive'"],
+                        Response::HTTP_BAD_REQUEST
+                    );
+                }
+                $params = (isset($_POST['params']) && is_array($_POST['params'])) ? $_POST['params'] : [];
+                $pid = $this->startArchiveAsync($params);
+                if (empty($pid)) {
+                    return new ApiResponse(
+                        ['error' => 'no process created when starting archive action'],
+                        Response::HTTP_INTERNAL_SERVER_ERROR
+                    );
+                }
                 return new ApiResponse(
-                    [],
+                    ['pid' => $pid],
                     Response::HTTP_OK
                 );
                 break;
@@ -123,5 +137,36 @@ class ArchiveController extends YesWikiController
                 );
                 break;
         }
+    }
+
+    /**
+     * start archive async via CLI
+     * @param array $params
+     *
+     * @param bool $savefiles
+     * @param bool $savedatabase
+     * @param array $extrafiles
+     * @param array $excludedfiles
+     * @return string PID
+     */
+    protected function startArchiveAsync(
+        array $params = []
+    ): string {
+        $savefiles = (isset($params['savefiles']) && in_array($params['savefiles'], [1,"1",true,'true'], true));
+        $savedatabase = (isset($params['savedatabase']) && in_array($params['savedatabase'], [1,"1",true,'true'], true));
+        $extrafiles = (isset($params['extrafiles']) && is_array($params['extrafiles'])) ? $params['extrafiles'] : [];
+        $excludedfiles = (isset($params['excludedfiles']) && is_array($params['excludedfiles'])) ? $params['excludedfiles'] : [];
+
+        $extrafiles = array_filter($extrafiles, 'is_string');
+        $excludedfiles = array_filter($excludedfiles, 'is_string');
+
+        $process = $this->archiveService->startArchiveAsync(
+            $savefiles,
+            $savedatabase,
+            $extrafiles,
+            $excludedfiles
+        );
+        $processId = empty($process) ? "" : $process->getPid();
+        return empty($processId) ? "" : $processId;
     }
 }

--- a/includes/controllers/ArchiveController.php
+++ b/includes/controllers/ArchiveController.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace YesWiki\Core\Controller;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpFoundation\Response;
+use YesWiki\Core\ApiResponse;
+use YesWiki\Core\Service\ArchiveService;
+use YesWiki\Core\YesWikiController;
+
+class ArchiveController extends YesWikiController
+{
+    protected $archiveService;
+    protected $params;
+
+    public function __construct(
+        ArchiveService $archiveService,
+        ParameterBagInterface $params
+    ) {
+        $this->archiveService = $archiveService;
+        $this->params = $params;
+    }
+
+    public function getArchive(string $id)
+    {
+        $filePath = $this->archiveService->getFilePath($id);
+        if (empty($filePath)) {
+            return new ApiResponse(
+                ['error' => "Not existing file ".htmlspecialchars($id)],
+                Response::HTTP_BAD_REQUEST
+            );
+        } else {
+            $zipContent = file_get_contents($filePath) ;
+            $zipSize = filesize($filePath);
+            // to prevent existing headers because of handlers /show or others
+            $nbObLevels = ob_get_level();
+            for ($i=1; $i < $nbObLevels; $i++) {
+                ob_end_clean();
+            }
+            for ($i=1; $i < $nbObLevels; $i++) {
+                ob_start();
+            }
+
+            return new Response(
+                $zipContent, // content
+                Response::HTTP_OK,
+                [   // headers
+                    'Access-Control-Allow-Origin' => '*',
+                    'Access-Control-Allow-Credentials' => 'true',
+                    'Access-Control-Allow-Headers' => 'X-Requested-With, Location, Slug, Accept, Content-Type',
+                    'Access-Control-Expose-Headers' => 'Location, Slug, Accept, Content-Type',
+                    'Access-Control-Allow-Methods' => 'POST, GET, OPTIONS, DELETE, PUT, PATCH',
+                    'Access-Control-Max-Age' => '86400',
+                    // end of part inspired from ApiResponse
+                    //Set the Content-Type, Content-Disposition and Content-Length headers.
+                    "Content-Type" => "application/zip",
+                    "Content-Disposition" => "attachment; filename=$id",
+                    "Content-Length" => $zipSize
+                ]
+            );
+        }
+    }
+
+    public function manageArchiveAction(?string $id = null)
+    {
+        $action = filter_input(INPUT_POST, 'action', FILTER_UNSAFE_RAW);
+        $action = in_array($action, [false,null], true) ? "" : htmlspecialchars(strip_tags($action));
+        switch ($action) {
+            case 'delete':
+                if (!empty($id)) {
+                    $filenames = [$id];
+                } elseif (isset($_POST['filesnames']) && is_array($_POST['filesnames'])) {
+                    $filenames = $_POST['filesnames'];
+                } else {
+                    return new ApiResponse(
+                        ['error' => "\$_POST['filesnames'] should be set and be an array for action 'delete'"],
+                        Response::HTTP_BAD_REQUEST
+                    );
+                }
+                $results = $this->archiveService->deleteArchives($filenames);
+                return new ApiResponse(
+                    $results,
+                    $results['main'] ? Response::HTTP_OK : Response::HTTP_BAD_REQUEST
+                );
+                break;
+            case 'startArchive':
+                return new ApiResponse(
+                    [],
+                    Response::HTTP_OK
+                );
+                break;
+            case 'stopArchive':
+                return new ApiResponse(
+                    [],
+                    Response::HTTP_OK
+                );
+                break;
+            case 'archiveStatus':
+                return new ApiResponse(
+                    [],
+                    Response::HTTP_OK
+                );
+                break;
+            
+            default:
+                return new ApiResponse(
+                    ['error' => "Not supported action : $action"],
+                    Response::HTTP_BAD_REQUEST
+                );
+                break;
+        }
+    }
+}

--- a/includes/controllers/ArchiveController.php
+++ b/includes/controllers/ArchiveController.php
@@ -102,6 +102,20 @@ class ArchiveController extends YesWikiController
                 );
                 break;
             
+            case 'restore':
+                if (empty($id)) {
+                    return new ApiResponse(
+                        ['error' => "\"api/archives/{id}\" should have not empty {id} when using action \"restore\""],
+                        Response::HTTP_BAD_REQUEST
+                    );
+                }
+                // TODO update code here when restore will work
+                return new ApiResponse(
+                    ['error' => 'action not defined'],
+                    Response::HTTP_BAD_REQUEST
+                );
+                break;
+            
             default:
                 return new ApiResponse(
                     ['error' => "Not supported action : $action"],

--- a/includes/controllers/ArchiveController.php
+++ b/includes/controllers/ArchiveController.php
@@ -131,6 +131,14 @@ class ArchiveController extends YesWikiController
                 );
                 break;
             
+            case 'futureDeletedArchives':
+                $files = $this->archiveService->archivesToDelete(true);
+                return new ApiResponse(
+                    ['files' => $files],
+                    Response::HTTP_OK
+                );
+                break;
+            
             default:
                 return new ApiResponse(
                     ['error' => "Not supported action : $action"],

--- a/includes/controllers/ArchiveController.php
+++ b/includes/controllers/ArchiveController.php
@@ -104,9 +104,17 @@ class ArchiveController extends YesWikiController
                 );
                 break;
             case 'stopArchive':
+                if (empty($_POST['uid']) || !is_string($_POST['uid'])) {
+                    return new ApiResponse(
+                        ['error' => "\$_POST['uid'] should be set and be an string for action 'stopArchive'"],
+                        Response::HTTP_BAD_REQUEST
+                    );
+                }
+                $uid = htmlspecialchars($_POST['uid']);
+                $result = $this->archiveService->stopArchive($uid);
                 return new ApiResponse(
                     [],
-                    Response::HTTP_OK
+                    $result ? Response::HTTP_OK : Response::HTTP_BAD_REQUEST
                 );
                 break;
             case 'restore':

--- a/includes/controllers/AuthController.php
+++ b/includes/controllers/AuthController.php
@@ -3,6 +3,7 @@
 namespace YesWiki\Core\Controller;
 
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use YesWiki\Core\Controller\UserController;
 use YesWiki\Core\Entity\User;
 use YesWiki\Core\Exception\BadFormatPasswordException;
 use YesWiki\Core\Service\PasswordHasherFactory;
@@ -236,6 +237,25 @@ class AuthController extends YesWikiController
         }
     }
 
+    /**
+     * connect the firstAdmin and return if
+     * SHOULD NOT BE USED but, waiting an alternative, this hack exists
+     * @return null|User $firtAdmin
+     */
+    public function connectFirstAdmin(): ?User
+    {
+        $firstAdminName = $this->wiki->services->get(UserController::class)->getFirstAdmin();
+        if (empty($firstAdminName)) {
+            return null;
+        }
+        $firstAdmin = $this->userManager->getOneByName($firstAdminName);
+        if (empty($firstAdmin)) {
+            return null;
+        }
+        $this->login($firstAdmin);
+        return $firstAdmin;
+    }
+    
     private function updateSessionCookieExpires(int $expires)
     {
         $sessionParams = session_get_cookie_params();

--- a/includes/entities/ConfigurationFile.php
+++ b/includes/entities/ConfigurationFile.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace YesWiki\Core\Entity;
+
+use ArrayAccess;
+use Countable;
+use Iterator;
+use YesWiki\Core\Service\ConfigurationService;
+
+class ConfigurationFile implements ArrayAccess, Iterator, Countable
+{
+    private $_file = "";
+    protected $_parameters;
+    protected $configurationService;
+
+    /**
+     * @param $file 
+     * @param ConfigurationService|null $configurationService
+     */
+    public function __construct($file,?ConfigurationService $configurationService = null)
+    {
+        $this->_file = $file;
+        $this->_parameters = [];
+        if ($configurationService instanceof ConfigurationService){
+            $this->configurationService = $configurationService;
+        } elseif (isset($GLOBALS["wiki"])) {
+            $this->configurationService = $GLOBALS["wiki"]->services->get(ConfigurationService::class);
+        }
+    }
+
+    public function __get($name)
+    {
+        if ($name == "_file") {
+            return $this->_file;
+        } elseif ($name == "_parameters") {
+            return $this->_parameters;
+        }
+        if (isset($this->_parameters[$name])) {
+            return $this->_parameters[$name];
+        }
+        throw new \Exception("Paramètre inconnu Configuration::$name", 1);
+    }
+
+    public function __isset($name)
+    {
+        return isset($this->_parameters[$name]);
+    }
+
+    public function __set($name, $value)
+    {
+        if ($name != "_file") {
+            $this->_parameters[$name] = $value;
+        }
+    }
+
+    public function __unset($name)
+    {
+        unset($this->_parameters[$name]);
+    }
+
+    public function load($arrayName = "wakkaConfig")
+    {
+        if (!is_file($this->_file)) {
+            return;
+        }
+
+        require $this->_file;
+
+        if (isset($$arrayName)) {
+            $this->_parameters = $$arrayName;
+        }
+    }
+
+    /**
+     * écrit le fichier de configuration
+     * @param string|null $file
+     * @param string $arrayName
+     * @return bool
+     */
+    public function write($file = null, $arrayName = "wakkaConfig")
+    {
+        return $this->configurationService->write($this,$file, $arrayName);
+    }
+
+    /***************************************************************************
+     * ArrayAccess
+     **************************************************************************/
+    #[\ReturnTypeWillChange]
+    public function offsetSet($offset, $value)
+    {
+        if (is_null($offset)) {
+            $this->_parameters[] = $value;
+            return;
+        }
+        $this->_parameters[$offset] = $value;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetExists($offset)
+    {
+        return isset($this->_parameters[$offset]);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($offset)
+    {
+        unset($this->_parameters[$offset]);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+        return isset($this->_parameters[$offset]) ? $this->_parameters[$offset] : null;
+    }
+
+    /***************************************************************************
+     * Iterator
+     **************************************************************************/
+    #[\ReturnTypeWillChange]
+    public function rewind()
+    {
+        return reset($this->_parameters);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function current()
+    {
+        return current($this->_parameters);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function key()
+    {
+        return key($this->_parameters);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function valid()
+    {
+        return isset($this->_parameters[$this->key()]);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function next()
+    {
+        return next($this->_parameters);
+    }
+
+    /*************************************************************************
+     * Countable
+     ************************************************************************/
+    #[\ReturnTypeWillChange]
+    public function count()
+    {
+        return count($this->_parameters);
+    }
+}

--- a/includes/exceptions/StopArchiveException.php
+++ b/includes/exceptions/StopArchiveException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace YesWiki\Core\Exception;
+
+use Exception;
+
+class StopArchiveException extends Exception
+{
+}

--- a/includes/services/ArchiveService.php
+++ b/includes/services/ArchiveService.php
@@ -7,6 +7,7 @@ use DateInterval;
 use Exception;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Process\Process;
 use YesWiki\Security\Controller\SecurityController;
 use YesWiki\Core\Entity\ConfigurationFile;
 use YesWiki\Core\Service\ConfigurationService;
@@ -143,6 +144,42 @@ class ArchiveService
         // clean oldest files
         $this->cleanOldestFiles();
         return $location;
+    }
+
+    /**
+     * start archive async via CLI
+     *
+     * @param bool $savefiles
+     * @param bool $savedatabase
+     * @param array $extrafiles
+     * @param array $excludedfiles
+     * @return null|Process
+     */
+    public function startArchiveAsync(
+        bool $savefiles = true,
+        bool $savedatabase = true,
+        array $extrafiles = [],
+        array $excludedfiles = []
+    ): ?Process {
+        $args = [];
+        if (!$savefiles) {
+            $args[] = "-d";
+        }
+        if (!$savedatabase) {
+            $args[] = "-f";
+        }
+        if (!empty($extrafiles)) {
+            $args[] = "-e";
+            $args[] = implode(",", $extrafiles);
+        }
+        if (!empty($excludedfiles)) {
+            $args[] = "-x";
+            $args[] = implode(",", $excludedfiles);
+        }
+        return $this->consoleService->startConsoleAsync(
+            'core:archive',
+            $args
+        );
     }
 
     /**

--- a/includes/services/ArchiveService.php
+++ b/includes/services/ArchiveService.php
@@ -223,6 +223,11 @@ class ArchiveService
      */
     public function hasValidatedBackup($token): bool
     {
+        $archiveParams = $this->getArchiveParams();
+        // skip backup if not activated
+        if (empty($archiveParams['preupdate_backup_activated'])) {
+            return true;
+        }
         $status = $this->getArchivingStatus();
         // skip backup if not writable, because could be bloking otherwise
         if (!$status['canArchive'] && !$status['privatePathWritable']) {

--- a/includes/services/ArchiveService.php
+++ b/includes/services/ArchiveService.php
@@ -189,6 +189,45 @@ class ArchiveService
         $this->cleanOldestFiles();
         return $location;
     }
+    
+    /**
+     * retrieve the current status to archive
+     * @return array ['canArchive' => bool,'archiving' => bool, 'hibernated' => bool, 'privatePathWritable' => true]
+     */
+    public function getArchivingStatus(): array
+    {
+        $canArchive = true;
+        $archiving = false;
+        $hibernated = false;
+        $privatePathWritable = true;
+        if ($this->securityController->isWikiHibernated()) {
+            $canArchive = false;
+            switch ($this->params->get('wiki_status')) {
+                case 'archiving':
+                    $archiving = true;
+                    break;
+                case 'hibernate':
+                    $hibernated = true;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+        try {
+            $privatePath = $this->getPrivateFolder();
+        } catch (Exception $th) {
+            $privatePathWritable = false;
+            $canArchive = false;
+            $privatePath = "";
+        }
+        if (!empty($privatePath) && !is_writable($privatePath)) {
+            $privatePathWritable = false;
+            $canArchive = false;
+        }
+        return compact(['canArchive','archiving','hibernated','privatePathWritable']);
+    }
+
 
     /**
      * start archive async via CLI

--- a/includes/services/ArchiveService.php
+++ b/includes/services/ArchiveService.php
@@ -79,7 +79,7 @@ class ArchiveService
      * @throws Exception
      */
     public function archive(
-        string|OutputInterface &$output,
+        &$output,
         bool $savefiles = true,
         bool $savedatabase = true,
         array $extrafiles = [],
@@ -147,7 +147,7 @@ class ArchiveService
     protected function createZip(
         string $zipPath,
         array $dataFiles,
-        string|OutputInterface &$output,
+        &$output,
         string $sqlContent,
         bool $onlyDb = false
     ) {
@@ -386,12 +386,14 @@ class ArchiveService
      * @param string $text
      * @param bool $newline
      */
-    private function writeOutput(string|OutputInterface &$output, string $text, bool $newline = true)
+    private function writeOutput(&$output, string $text, bool $newline = true)
     {
         if ($output instanceof OutputInterface) {
             $output->write($text, $newline);
-        } else {
+        } elseif (is_string($output)) {
             $output .= $text . ($newline ? "\n" : "");
+        } else {
+            throw new Exception("\"\$output\" should be string or OutputInterface !");
         }
     }
 

--- a/includes/services/ArchiveService.php
+++ b/includes/services/ArchiveService.php
@@ -1050,7 +1050,7 @@ class ArchiveService
                 "{$tablePrefix}referrers", // tables
             ], // args
             "", // subfolder
-            ('\\' === DIRECTORY_SEPARATOR ? ["c:\\xampp\\mysql\\bin\\"] : ["/usr/bin/"]), // extraDirsWhereSearch
+            ('\\' === DIRECTORY_SEPARATOR ? ["c:\\xampp\\mysql\\bin\\"] : ["/usr/bin/","/usr/local/bin/"]), // extraDirsWhereSearch
             60 // timeoutInSec
         );
 

--- a/includes/services/ArchiveService.php
+++ b/includes/services/ArchiveService.php
@@ -1034,7 +1034,7 @@ class ArchiveService
 
         $resultFile = tempnam($privatePath, 'tmp_sql_file_to_delete');
         $results = $this->consoleService->findAndStartExecutableSync(
-            "/usr/bin/mysqldump",
+            "mysqldump",
             [
                 "--host=$hostname",
                 "--user=$username",
@@ -1050,7 +1050,7 @@ class ArchiveService
                 "{$tablePrefix}referrers", // tables
             ], // args
             "", // subfolder
-            ('\\' === DIRECTORY_SEPARATOR ? ["c:\\xampp\\mysql\\bin\\"] : []), // extraDirsWhereSearch
+            ('\\' === DIRECTORY_SEPARATOR ? ["c:\\xampp\\mysql\\bin\\"] : ["/usr/bin/"]), // extraDirsWhereSearch
             60 // timeoutInSec
         );
 

--- a/includes/services/ArchiveService.php
+++ b/includes/services/ArchiveService.php
@@ -826,8 +826,6 @@ class ArchiveService
         if ($folderPath != "%TMP") {
             if (is_dir($folderPath) &&
             $this->canWriteFolder($folderPath)) {
-                // TODO check if the private folder is included in root path
-                // then check if this private folder is not accessible from internet
                 return preg_replace("/(\/|\\\\)$/", "", $folderPath);
             } else {
                 throw new Exception("Not writable ".self::PARAMS_KEY_IN_WAKKA."[".self::KEY_FOR_PRIVATE_FOLDER."]");

--- a/includes/services/ArchiveService.php
+++ b/includes/services/ArchiveService.php
@@ -24,7 +24,7 @@ class ArchiveService
         'tools/*/node_modules',
         '.git',
         'tools/*/.git',
-        "cache"
+        "cache/*"
     ];
     public const DEFAULT_PARAMS_TO_ANONYMIZE = [
         'mysql_host' => '',

--- a/includes/services/ArchiveService.php
+++ b/includes/services/ArchiveService.php
@@ -160,7 +160,7 @@ class ArchiveService
                 return "";
             }
         } else {
-            $dataFiles = [];
+            $dataFiles = ['preparedExcludedFiles' => [],'extrafiles' => [], 'excludedfiles' => [], 'onlyChildren' =>[]];
         }
 
         if ($this->checkIfNeedStop($inputFile)) {
@@ -1034,7 +1034,7 @@ class ArchiveService
 
         $resultFile = tempnam($privatePath, 'tmp_sql_file_to_delete');
         $results = $this->consoleService->findAndStartExecutableSync(
-            "mysqldump",
+            "/usr/bin/mysqldump",
             [
                 "--host=$hostname",
                 "--user=$username",

--- a/includes/services/ArchiveService.php
+++ b/includes/services/ArchiveService.php
@@ -1146,7 +1146,7 @@ class ArchiveService
             !is_scalar($archiveParams['max_nb_files']) ||
             intval($archiveParams['max_nb_files']) < 3)
             ? 10
-            : $archiveParams['max_nb_files'];
+            : intval($archiveParams['max_nb_files']);
     }
 
     /**

--- a/includes/services/ArchiveService.php
+++ b/includes/services/ArchiveService.php
@@ -1064,7 +1064,7 @@ class ArchiveService
      */
     protected function getSQLContent(string $privatePath): string
     {
-        $resultFile = $privatePath.self::SQL_FILENAME_IN_PRIVATE_FOLDER_IN_ZIP;
+        $resultFile = $privatePath.'/'.self::SQL_FILENAME_IN_PRIVATE_FOLDER_IN_ZIP;
         try {
             if ($this->testDb()) {
                 $results = $this->consoleService->startConsoleSync('core:exportdb', [
@@ -1079,7 +1079,7 @@ class ArchiveService
             } else {
                 $results = $this->dbService->getSQLContentBackupMethod();
                 if (empty($results['sql'])) {
-                    throw new Exception(empty($results['error']) ? "SQL not exported" : $results['error']);
+                    throw new Exception(empty($results['error']) ? "SQL not exported (and mysqldump not found)" : $results['error']);
                 } else {
                     return $results['sql'];
                 }

--- a/includes/services/ConfigurationService.php
+++ b/includes/services/ConfigurationService.php
@@ -31,23 +31,18 @@ class ConfigurationService
         if (is_null($file)) {
             $file = $config->_file;
         }
-        $content = $this->getContentToWrite($config,$file, $arrayName);
+        $content = $this->getContentToWrite($config, $arrayName);
         return (file_put_contents($file, $content) !== false);
     }
     
     /**
      * extract content to write tto config file
      * @param ConfigurationFile $config
-     * @param string|null $file
      * @param string $arrayName
      * @return string
      */
-    public function getContentToWrite(ConfigurationFile $config, ?string $file = null, string $arrayName = "wakkaConfig"): string
+    public function getContentToWrite(ConfigurationFile $config, string $arrayName = "wakkaConfig"): string
     {
-        if (is_null($file)) {
-            $file = $config->_file;
-        }
-
         $content = "<?php\n\n\$$arrayName = ";
 
         $content .= $this->customVarExport($config->_parameters, true);

--- a/includes/services/ConfigurationService.php
+++ b/includes/services/ConfigurationService.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace YesWiki\Core\Service;
+
+use YesWiki\Core\Entity\ConfigurationFile;
+
+class ConfigurationService
+{
+    public function __construct()
+    {
+    }
+
+    /**
+     * @param string $filePath
+     * @return ConfigurationFile
+     */
+    public function getConfiguration(string $filePath): ConfigurationFile
+    {
+        return new ConfigurationFile($filePath, $this);
+    }
+
+    /**
+     * write config
+     * @param ConfigurationFile $config
+     * @param string|null $file
+     * @param string $arrayName
+     * @return bool
+     */
+    public function write(ConfigurationFile $config, ?string $file = null, string $arrayName = "wakkaConfig")
+    {
+        if (is_null($file)) {
+            $file = $config->_file;
+        }
+        $content = $this->getContentToWrite($config,$file, $arrayName);
+        return (file_put_contents($file, $content) !== false);
+    }
+    
+    /**
+     * extract content to write tto config file
+     * @param ConfigurationFile $config
+     * @param string|null $file
+     * @param string $arrayName
+     * @return string
+     */
+    public function getContentToWrite(ConfigurationFile $config, ?string $file = null, string $arrayName = "wakkaConfig"): string
+    {
+        if (is_null($file)) {
+            $file = $config->_file;
+        }
+
+        $content = "<?php\n\n\$$arrayName = ";
+
+        $content .= $this->customVarExport($config->_parameters, true);
+        $content .= ";\n";
+        return $content;
+    }
+    
+    /**
+     * PHP var_export() with short array syntax (square brackets) indented 2 spaces.
+     * tips : https://www.php.net/manual/en/function.var-export.php#124194
+     * NOTE: The only issue is when a string value has `=>\n[`, it will get converted to `=> [`
+     * @param mixed $expression
+     * @param bool $return
+     * @return null|string
+     */
+    protected function customVarExport($expression, bool $return = false): ?string
+    {
+        $expression = $this->sanitizeToScalar($expression);
+        $export = var_export($expression, true);
+        $patterns = [
+            "/array \(/" => '[',
+            "/^([ ]*)\)(,?)$/m" => '$1]$2',
+            "/=>[ ]?\n[ ]+\[/" => '=> [',
+            "/([ ]*)(\'[^\']+\') => ([\[\'])/" => '$1$2 => $3',
+        ];
+        $export = preg_replace(array_keys($patterns), array_values($patterns), $export);
+        if ((bool)$return) {
+            return $export;
+        } else {
+            echo $export;
+            return null;
+        }
+    }
+
+    /**
+     * sanitize $value to keep only arrays, string, bool, null, int, float
+     * @param mixed $value
+     * @return mixed
+     */
+    private function sanitizeToScalar($value)
+    {
+        if (is_array($value)) {
+            return array_map(function ($subValue) {
+                return $this->sanitizeToScalar($subValue);
+            }, $value);
+        } elseif (is_null($value) || is_string($value) || is_bool($value) || is_int($value) || is_float($value)) {
+            return $value;
+        } else {
+            return (string) $value;
+        }
+    }
+
+}

--- a/includes/services/ConsoleService.php
+++ b/includes/services/ConsoleService.php
@@ -2,6 +2,7 @@
 
 namespace YesWiki\Core\Service;
 
+use Exception;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\ExecutableFinder;
@@ -138,7 +139,7 @@ class ConsoleService
     {
         $executable = $this->findExecutable($executableName, $extraDirsWhereSearch);
         if (empty($executable)) {
-            throw new Exception("Excutable \"$executableName\" not found !");
+            throw new Exception("Executable \"$executableName\" not found !");
         }
         return $this->startRawCommandAsync($executable, $args, $subfolder, $newConsole, $timeoutInSec);
     }

--- a/includes/services/ConsoleService.php
+++ b/includes/services/ConsoleService.php
@@ -27,10 +27,11 @@ class ConsoleService
      * @param string $command
      * @param array $args
      * @param string $subfolder
-     * @param bool $newConsole;
+     * @param bool $newConsole
+     * @param int $timeoutInSec
      * @return array ['command'=>['stdout|stderr' => $output]]
      */
-    public function startConsoleAsync(string $command, array $args = [], string $subfolder = "", bool $newConsole = true): ?Process
+    public function startConsoleAsync(string $command, array $args = [], string $subfolder = "", bool $newConsole = true, int $timeoutInSec = 60): ?Process
     {
         if (empty($command)) {
             return null;
@@ -45,7 +46,9 @@ class ConsoleService
             $params[] = $arg;
         }
         $process = new Process($params, $folder);
-        // $process->setTimeout(60); // default 60s
+        if ($timeoutInSec > 0) {
+            $process->setTimeout($timeoutInSec); // default 60s
+        }
         // this option allows a subprocess to continue running after the main script exited
         if ($newConsole) {
             $process->setOptions(['create_new_console' => true]);
@@ -71,11 +74,12 @@ class ConsoleService
      * @param string $command
      * @param array $args
      * @param string $subfolder
+     * @param int $timeoutInSec
      * @return array ['stdout|stderr' => $output]
      */
-    public function startConsoleSync(string $command, array $args = [], string $subfolder = ""): array
+    public function startConsoleSync(string $command, array $args = [], string $subfolder = "", int $timeoutInSec = 60): array
     {
-        $process = $this->startConsoleAsync($command, $args, $subfolder, false);
+        $process = $this->startConsoleAsync($command, $args, $subfolder, false, $timeoutInSec);
         if (!$process) {
             return null;
         }

--- a/includes/services/ConsoleService.php
+++ b/includes/services/ConsoleService.php
@@ -186,7 +186,7 @@ class ConsoleService
     protected function findExecutable(string $name, array $extraDirs = []): string
     {
         if (empty($name)) {
-            throw new Exception("'name' should nt be empty !");
+            throw new Exception("'name' should not be empty !");
         }
         return $this->executableFinder->find($name, "", $extraDirs);
     }

--- a/includes/services/ConsoleService.php
+++ b/includes/services/ConsoleService.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace YesWiki\Core\Service;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+use YesWiki\Wiki;
+
+class ConsoleService
+{
+    protected const CONSOLE_BIN = 'includes/commands/console';
+
+    protected $wiki;
+    protected $params;
+    protected $phpBinaryFinder;
+
+    public function __construct(Wiki $wiki, ParameterBagInterface $params)
+    {
+        $this->wiki = $wiki;
+        $this->params = $params;
+        $this->phpBinaryFinder = new PhpExecutableFinder();
+    }
+
+    /**
+     * @param string $command
+     * @param array $args
+     * @param string $subfolder
+     * @param bool $newConsole;
+     * @return array ['command'=>['stdout|stderr' => $output]]
+     */
+    public function startConsoleAsync(string $command, array $args = [], string $subfolder = "", bool $newConsole = true): ?Process
+    {
+        if (empty($command)) {
+            return null;
+        }
+        if (!empty($subfolder) && !is_dir(basename($subfolder))) {
+            return null;
+        }
+        $folder = getcwd(). (empty($subfolder) ? '' : (DIRECTORY_SEPARATOR . basename($subfolder)));
+        $phpBinaryPath = $this->phpBinaryFinder->find();
+        $params = [$phpBinaryPath,self::CONSOLE_BIN,$command];
+        foreach ($args as $arg) {
+            $params[] = $arg;
+        }
+        $process = new Process($params, $folder);
+        // $process->setTimeout(60); // default 60s
+        // this option allows a subprocess to continue running after the main script exited
+        if ($newConsole) {
+            $process->setOptions(['create_new_console' => true]);
+        }
+        $process->start();
+        return $process;
+    }
+
+    public function getProcessOut(Process $process): array
+    {
+        $results = [];
+        foreach ($process as $type => $data) {
+            if ($process::OUT === $type) {
+                $results[] = ['stdout' => $data];
+            } else { // $process::ERR === $type
+                $results[] = ['stderr' => $data];
+            }
+        }
+        return $results;
+    }
+
+    /**
+     * @param string $command
+     * @param array $args
+     * @param string $subfolder
+     * @return array ['stdout|stderr' => $output]
+     */
+    public function startConsoleSync(string $command, array $args = [], string $subfolder = ""): array
+    {
+        $process = $this->startConsoleAsync($command, $args, $subfolder, false);
+        if (!$process) {
+            return null;
+        }
+        $process->wait();
+        return $this->getProcessOut($process);
+    }
+}

--- a/includes/services/ConsoleService.php
+++ b/includes/services/ConsoleService.php
@@ -162,6 +162,22 @@ class ConsoleService
     }
 
     /**
+     * format html for CLI
+     * @param string $input
+     * @return string $output
+     */
+    public function formatHtmlForCLI(string $input): string
+    {
+        $bufferedOutput = strip_tags($input, '<br><hr><em><strong>');
+        $output = preg_replace(
+            ['#<[bh]r ?/?>#Ui', '/<(em|strong)>/Ui', '#</ ?(em|strong)>#Ui'],
+            ["\n", "\e[1m", "\e[0m"],
+            $bufferedOutput
+        );
+        return $output;
+    }
+
+    /**
      * @param string $name
      * @param array $extraDirs wherer search
      * @return string

--- a/includes/services/ConsoleService.php
+++ b/includes/services/ConsoleService.php
@@ -4,6 +4,7 @@ namespace YesWiki\Core\Service;
 
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 use YesWiki\Wiki;
@@ -14,12 +15,14 @@ class ConsoleService
 
     protected $wiki;
     protected $params;
+    protected $executableFinder;
     protected $phpBinaryFinder;
 
     public function __construct(Wiki $wiki, ParameterBagInterface $params)
     {
         $this->wiki = $wiki;
         $this->params = $params;
+        $this->executableFinder = new ExecutableFinder();
         $this->phpBinaryFinder = new PhpExecutableFinder();
     }
 
@@ -29,32 +32,17 @@ class ConsoleService
      * @param string $subfolder
      * @param bool $newConsole
      * @param int $timeoutInSec
-     * @return array ['command'=>['stdout|stderr' => $output]]
+     * @return null|Process
      */
     public function startConsoleAsync(string $command, array $args = [], string $subfolder = "", bool $newConsole = true, int $timeoutInSec = 60): ?Process
     {
-        if (empty($command)) {
-            return null;
-        }
-        if (!empty($subfolder) && !is_dir(basename($subfolder))) {
-            return null;
-        }
-        $folder = getcwd(). (empty($subfolder) ? '' : (DIRECTORY_SEPARATOR . basename($subfolder)));
         $phpBinaryPath = $this->phpBinaryFinder->find();
-        $params = [$phpBinaryPath,self::CONSOLE_BIN,$command];
+        $newCommand = $phpBinaryPath;
+        $newArgs = [self::CONSOLE_BIN,$command];
         foreach ($args as $arg) {
-            $params[] = $arg;
+            $newArgs[] = $arg;
         }
-        $process = new Process($params, $folder);
-        if ($timeoutInSec > 0) {
-            $process->setTimeout($timeoutInSec); // default 60s
-        }
-        // this option allows a subprocess to continue running after the main script exited
-        if ($newConsole) {
-            $process->setOptions(['create_new_console' => true]);
-        }
-        $process->start();
-        return $process;
+        return $this->startRawCommandAsync($newCommand, $newArgs, $subfolder, $newConsole, $timeoutInSec);
     }
 
     public function getProcessOut(Process $process): array
@@ -75,9 +63,9 @@ class ConsoleService
      * @param array $args
      * @param string $subfolder
      * @param int $timeoutInSec
-     * @return array ['stdout|stderr' => $output]
+     * @return null|array ['stdout|stderr' => $output]
      */
-    public function startConsoleSync(string $command, array $args = [], string $subfolder = "", int $timeoutInSec = 60): array
+    public function startConsoleSync(string $command, array $args = [], string $subfolder = "", int $timeoutInSec = 60): ?array
     {
         $process = $this->startConsoleAsync($command, $args, $subfolder, false, $timeoutInSec);
         if (!$process) {
@@ -85,5 +73,105 @@ class ConsoleService
         }
         $process->wait();
         return $this->getProcessOut($process);
+    }
+
+    /**
+     * @param string $command
+     * @param array $args
+     * @param string $subfolder
+     * @param bool $newConsole
+     * @param int $timeoutInSec
+     * @return null|Process
+     */
+    public function startRawCommandAsync(string $command, array $args = [], string $subfolder = "", bool $newConsole = true, int $timeoutInSec = 60): ?Process
+    {
+        if (empty($command)) {
+            return null;
+        }
+        if (!empty($subfolder) && !is_dir(basename($subfolder))) {
+            return null;
+        }
+        $folder = getcwd(). (empty($subfolder) ? '' : (DIRECTORY_SEPARATOR . basename($subfolder)));
+        $params = [$command];
+        foreach ($args as $arg) {
+            $params[] = $arg;
+        }
+        $process = new Process($params, $folder);
+        if ($timeoutInSec > 0) {
+            $process->setTimeout($timeoutInSec); // default 60s
+        }
+        // this option allows a subprocess to continue running after the main script exited
+        if ($newConsole) {
+            $process->setOptions(['create_new_console' => true]);
+        }
+        $process->start();
+        return $process;
+    }
+    
+    /**
+     * @param string $command
+     * @param array $args
+     * @param string $subfolder
+     * @param int $timeoutInSec
+     * @return null|array ['stdout|stderr' => $output]
+     */
+    public function startRawCommandSync(string $command, array $args = [], string $subfolder = "", int $timeoutInSec = 60): ?array
+    {
+        $process = $this->startRawCommandAsync($command, $args, $subfolder, false, $timeoutInSec);
+        if (!$process) {
+            return null;
+        }
+        $process->wait();
+        return $this->getProcessOut($process);
+    }
+
+    /**
+     * @param string $executableName
+     * @param array $args
+     * @param string $subfolder
+     * @param array $extraDirsWhereSearch
+     * @param bool $newConsole
+     * @param int $timeoutInSec
+     * @return null|Process
+     */
+    public function findAndStartExecutableAsync(string $executableName, array $args = [], string $subfolder = "", array $extraDirsWhereSearch=[], bool $newConsole = true, int $timeoutInSec = 60): ?Process
+    {
+        $executable = $this->findExecutable($executableName, $extraDirsWhereSearch);
+        if (empty($executable)) {
+            throw new Exception("Excutable \"$executableName\" not found !");
+        }
+        return $this->startRawCommandAsync($executable, $args, $subfolder, $newConsole, $timeoutInSec);
+    }
+
+    /**
+     * @param string $executableName
+     * @param array $args
+     * @param string $subfolder
+     * @param array $extraDirsWhereSearch
+     * @param int $timeoutInSec
+     * @return null|array ['command'=>['stdout|stderr' => $output]]
+     */
+    public function findAndStartExecutableSync(string $executableName, array $args = [], string $subfolder = "", array $extraDirsWhereSearch=[], int $timeoutInSec = 60): ?array
+    {
+        $process = $this->findAndStartExecutableAsync($executableName, $args, $subfolder, $extraDirsWhereSearch, false, $timeoutInSec);
+        if (!$process) {
+            return null;
+        }
+        $process->wait();
+        return $this->getProcessOut($process);
+    }
+
+    /**
+     * @param string $name
+     * @param array $extraDirs wherer search
+     * @return string
+     * @throws Exception
+     */
+    protected function findExecutable(string $name, array $extraDirs = []): string
+    {
+        if (empty($name)) {
+            throw new Exception("'name' should nt be empty !");
+        }
+        return $this->executableFinder->find($name, "", $extraDirs);
     }
 }

--- a/includes/services/DbService.php
+++ b/includes/services/DbService.php
@@ -167,4 +167,160 @@ class DbService
         }
         return $tz;
     }
+
+
+    /**
+     * get SQL content : backup method ; preferer mysqldump way it available
+     * @return array ['sql' => string, 'error' => string]
+     *
+     */
+    public function getSQLContentBackupMethod(): array
+    {
+        $sql = "";
+        $error = "";
+        try {
+            $tablesPrefix = trim($this->prefixTable(''));
+            $tablesPostfix = [];
+            // get Tables
+            $tables = $this->loadAll("show tables");
+            if (!is_array($tables)) {
+                throw new Exception("Error in '".__METHOD__."' (line ".__LINE__.") : 'show tables' sql command did not return an array !");
+            }
+
+            foreach ($tables as  $tableInfo) {
+                if (!is_array($tableInfo)) {
+                    throw new Exception("Error in '".__METHOD__."' (line ".__LINE__.") : '\$tableInfo' sql command did not return an array !");
+                }
+                $tableName = array_values($tableInfo)[0];
+                if (strpos($tableName, $tablesPrefix) === 0) {
+                    $tablesPostfix[] = $tableName;
+                }
+            }
+
+            // generate file
+            $date = (new \DateTime())->format('c');
+            $phpVersion = phpversion();
+
+            $sql =
+            <<<SQL
+            -- SQL Dump
+            -- ArchiveService:getSQLBackup Version
+            -- 
+            -- Generated on : $date
+            -- PHP version : $phpVersion
+
+            SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+            SET AUTOCOMMIT = 0;
+            START TRANSACTION;
+
+            /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+            /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+            /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+            /*!40101 SET NAMES utf8mb4 */;
+            /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+            /*!40103 SET TIME_ZONE='+00:00' */;
+            
+            -- --------------------------------------------------------
+
+
+            SQL;
+
+            // For each table
+            foreach ($tablesPostfix as $tableName) {
+                // DUMP CREATE TABLE
+
+                // HEADER
+                $sql .=
+                <<<SQL
+
+                -- 
+                -- Structure of table : `$tableName`
+                -- 
+
+                SQL;
+                // END HEADER
+
+                $createTableResult = $this->query("show create table " . $tableName);
+
+                while ($creationTable = mysqli_fetch_array($createTableResult)) {
+                    $sql .= $creationTable[1].";\n\n";
+                }
+
+                // DUMP DATA
+
+                //    HEADER
+                $sql .=
+                <<<SQL
+
+                -- 
+                -- Data of table : `$tableName`
+                -- 
+
+                SQL;
+                // END HEADER
+
+                $rawData = $this->query("select * from " . $tableName);
+
+                $firstRow = true ;
+                while ($row = mysqli_fetch_array($rawData)) {
+                    if ($firstRow) {
+                        $sql .= "INSERT INTO `$tableName` ";
+                        $sql .= "(";
+                        for ($i=0; $i < mysqli_num_fields($rawData); $i++) {
+                            if ($i != 0) {
+                                $sql .=  ", ";
+                            }
+                            $sql .= "`" . mysqli_fetch_field_direct($rawData, $i)->name . "`";
+                        }
+                        $sql .= ") VALUES\n";
+                        $firstRow = false ;
+                    } else {
+                        $sql .= ",\n";
+                    }
+                    $sql .= "(";
+                    for ($i=0; $i < mysqli_num_fields($rawData); $i++) {
+                        if ($i != 0) {
+                            $sql .=  ", ";
+                        }
+                        $strAdd = '';
+                        $field = mysqli_fetch_field_direct($rawData, $i);
+                        if ($field->type == 252 // text or blob cf https://www.php.net/manual/fr/mysqli-result.fetch-field-direct.php
+                            || $field->type == 253 // varchar
+                            || $field->type == 254 // char
+                            || $field->type == 10 // date
+                            || $field->type == 11 // time
+                            || $field->type == 12 // datetime
+                            || $field->type == 13 // year
+                        ) {
+                            $strAdd =  "'";
+                        }
+                        $sql .=  $strAdd . $this->escape($row[$i] ?? '') . $strAdd ;
+                    }
+                    $sql .=  ")";
+                }
+                $sql .= ";\n" ;
+                $sql .=
+                <<<SQL
+
+                -- --------------------------------------------------------
+
+                SQL;
+            }
+
+            $sql .=
+            <<<SQL
+
+            COMMIT;
+            
+            /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+            /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+            /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+            /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+
+            SQL;
+        } catch (Throwable $th) {
+            $error = $th->getMessage();
+        }
+        return compact(['sql','error']);
+    }
 }

--- a/javascripts/actions/admin-backups.js
+++ b/javascripts/actions/admin-backups.js
@@ -48,7 +48,7 @@ let appParams = {
             archiveApp.messageClass = {alert:true,['alert-info']:true};
             $.ajax({
                 method: "GET",
-                url: wiki.url(`api/archives`),
+                url: wiki.url(`?api/archives`),
                 success: function(data){
                     archiveApp.archives = {};
                     let archiveNames = [];
@@ -79,7 +79,7 @@ let appParams = {
             archiveApp.messageClass = {alert:true,['alert-info']:true};
             $.ajax({
                 method: "POST",
-                url: wiki.url(`api/archives/${archive.filename}`),
+                url: wiki.url(`?api/archives/${archive.filename}`),
                 data: {
                     action: 'delete'
                 },
@@ -120,7 +120,7 @@ let appParams = {
                 archiveApp.messageClass = {alert:true,['alert-info']:true};
                 $.ajax({
                     method: "POST",
-                    url: wiki.url(`api/archives`),
+                    url: wiki.url(`?api/archives`),
                     data: {
                         action: 'delete',
                         filesnames: archiveApp.selectedArchivesToDelete
@@ -170,7 +170,7 @@ let appParams = {
             archiveApp.messageClass = {alert:true,['alert-info']:true};
             $.ajax({
                 method: "POST",
-                url: wiki.url(`api/archives/${archive.filename}`),
+                url: wiki.url(`?api/archives/${archive.filename}`),
                 data: {
                     action: 'restore'
                 },
@@ -196,7 +196,7 @@ let appParams = {
             archiveApp.archiveMessageClass = {alert:true,['alert-info']:true};
             $.ajax({
                 method: "GET",
-                url: wiki.url(`api/archives/archivingStatus/`),
+                url: wiki.url(`?api/archives/archivingStatus/`),
                 cache: false,
                 success: function(data){
                     if (typeof data != "object" || !data.hasOwnProperty('canArchive')){
@@ -253,7 +253,7 @@ let appParams = {
             }
             let ajaxOptions = {
                 method: "POST",
-                url: wiki.url(`api/archives`),
+                url: wiki.url(`?api/archives`),
                 data: {
                     action: 'startArchive',
                     params: {
@@ -295,7 +295,7 @@ let appParams = {
             let archiveApp = this;
             $.ajax({
                 method: "POST",
-                url: wiki.url(`api/archives`),
+                url: wiki.url(`?api/archives`),
                 data: {
                     action: 'futureDeletedArchives',
                 },
@@ -337,7 +337,7 @@ let appParams = {
             let archiveApp = this;
             $.ajax({
                 method: "POST",
-                url: wiki.url(`api/archives`),
+                url: wiki.url(`?api/archives`),
                 cache: false,
                 data: {
                     action: 'stopArchive',
@@ -364,7 +364,7 @@ let appParams = {
                 }
                 $.ajax({
                     method: "GET",
-                    url: wiki.url(`api/archives/uidstatus/${archiveApp.currentArchiveUid}`),
+                    url: wiki.url(`?api/archives/uidstatus/${archiveApp.currentArchiveUid}`),
                     cache: false,
                     data: getData,
                     success: function(data){
@@ -402,7 +402,7 @@ let appParams = {
                 }
                 $.ajax({
                     method: "GET",
-                    url: wiki.url(`api/archives/uidstatus/${archiveApp.currentArchiveUid}`),
+                    url: wiki.url(`?api/archives/uidstatus/${archiveApp.currentArchiveUid}`),
                     cache: false,
                     data: getData,
                     success: function(data){
@@ -463,7 +463,7 @@ let appParams = {
             return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
         },
         downloadUrl: function(archive){
-            return wiki.url(`api/archives/${archive.filename}`);
+            return wiki.url(`?api/archives/${archive.filename}`);
         },
         updateType: function (){
             if (this.$refs.adminBackupsTypeFull.checked){
@@ -514,7 +514,7 @@ let appParams = {
             let archiveApp = this;
             $.ajax({
                 method: "GET",
-                url: wiki.url(`api/archives/forcedUpdateToken/`),
+                url: wiki.url(`?api/archives/forcedUpdateToken/`),
                 cache: false,
                 success: function(data){
                     if (

--- a/javascripts/actions/admin-backups.js
+++ b/javascripts/actions/admin-backups.js
@@ -187,7 +187,6 @@ let appParams = {
                 }
             });
         },
-        
         startArchive: function (){
             let archiveApp = this;
             archiveApp.updating = true;
@@ -332,7 +331,6 @@ let appParams = {
                 success: function(data){
                     archiveApp.archiveMessage = _t('ADMIN_BACKUPS_STOPPING_ARCHIVE');
                     archiveApp.archiveMessageClass = {alert:true,['alert-warning']:true};
-                    setTimeout(archiveApp.updateStoppingStatus, 1000);
                 },
                 error: function(xhr,status,error){
                     archiveApp.archiveMessage = _t('ADMIN_BACKUPS_STOP_BACKUP_ERROR');
@@ -340,35 +338,6 @@ let appParams = {
                     archiveApp.stoppingArchive = false;
                 }
             });
-        },
-        updateStoppingStatus: function(){
-            if (this.currentArchiveUid.length > 0){
-                let archiveApp= this;
-                $.ajax({
-                    method: "GET",
-                    url: wiki.url(`api/archives/uidstatus/${archiveApp.currentArchiveUid}`),
-                    success: function(data){
-                        if (data.stopped){
-                            archiveApp.endUpdatingStatus(_t('ADMIN_BACKUPS_UID_STATUS_STOP'),'success');
-                        } else if (data.finished){
-                            archiveApp.endUpdatingStatus(_t('ADMIN_BACKUPS_UID_STATUS_FINISHED'),'success');
-                        } else if (!data.running) {
-                            archiveApp.endUpdatingStatus(_t('ADMIN_BACKUPS_UID_STATUS_NOT_FINISHED'),'danger');
-                        } else if (archiveApp.stoppingArchive) {
-                            archiveApp.archiveMessage = _t('ADMIN_BACKUPS_STOPPING_ARCHIVE');
-                            archiveApp.archiveMessage += "<pre>"+data.output.split("\n").slice(-5).join("<br>")+"</pre>";
-                            setTimeout(archiveApp.updateStoppingStatus, 1000);
-                        }
-                    },
-                    error: function(xhr,status,error){
-                        archiveApp.stoppingArchive = false;
-                        archiveApp.endUpdatingStatus(_t('ADMIN_BACKUPS_UPDATE_UID_STATUS_ERROR'),'danger');
-                        setTimeout(archiveApp.loadArchives, 3000);
-                    }
-                });
-            } else {
-                this.endUpdatingStatus();
-            }
         },
         updateStatus: function(){
             if (this.currentArchiveUid.length > 0){
@@ -566,13 +535,17 @@ let appParams = {
 if (isVueJS3){
     let app = Vue.createApp(appParams);
     rootsElements.forEach(elem => {
-        app.mount(elem);
+        if ($(elem).length > 0){
+            app.mount(elem);
+        }
     });
 } else {
     rootsElements.forEach(elem => {
-        new Vue({
-            ...{el:elem},
-            ...appParams
-        });
+        if ($(elem).length > 0){
+            new Vue({
+                ...{el:elem},
+                ...appParams
+            });
+        }
     });
 }

--- a/javascripts/actions/admin-backups.js
+++ b/javascripts/actions/admin-backups.js
@@ -1,0 +1,101 @@
+
+import SpinnerLoader from '../../tools/bazar/presentation/javascripts/components/SpinnerLoader.js'
+
+let rootsElements = ['.admin-backups-container'];
+let isVueJS3 = (typeof Vue.createApp == "function");
+
+let appParams = {
+    components: { SpinnerLoader },
+    data: function() {
+        return {
+            archives: {},
+            ready: false,
+            updating: false,
+            message: "",
+            messageClass: {
+                alert: true,
+                ['alert-info']: true
+            }
+        };
+    },
+    methods: {
+        loadArchives: function() {
+            let archiveApp = this;
+            archiveApp.message = "Chargement de la liste des archives";
+            archiveApp.messageClass = {alert:true,['alert-info']:true};
+            $.ajax({
+                method: "GET",
+                url: wiki.url(`api/archives`),
+                success: function(data){
+                    archiveApp.archives = {};
+                    if (Array.isArray(data)){
+                        for (let key of data.keys()) {
+                            archiveApp.archives[key] = data[key];
+                          }
+                    }
+                    archiveApp.message = "";
+                },
+                error: function(xhr,status,error){
+                    archiveApp.message = "IMpossible de mettre à jour la liste des archives";
+                    archiveApp.messageClass = {alert:true,['alert-danger']:true};
+                },
+                complete: function(){
+                    archiveApp.ready = true;
+                    archiveApp.updating = false;
+                }
+            });
+        },
+        deleteArchive: function(archive) {
+            let archiveApp = this;
+            archiveApp.updating = true;
+            archiveApp.message = `Suppression de ${archive.filename}`;
+            archiveApp.messageClass = {alert:true,['alert-info']:true};
+            $.ajax({
+                method: "POST",
+                url: wiki.url(`api/archives/${archive.filename}`),
+                data: {
+                    action: 'delete'
+                },
+                success: function(data){
+                    archiveApp.message = "";
+                    archiveApp.loadArchives();
+                    if (Array.isArray(data) 
+                        || !data.main){
+                        toastMessage(
+                            `Une erreur pourrait avoir eu lieu en supprimant ${archive.filename}`
+                            ,1500,
+                            "alert alert-warning");
+                    } else {
+                        toastMessage(
+                            `Suppression réussie de ${archive.filename}`
+                            ,1500,
+                            "alert alert-success");
+                    }
+                    
+                },
+                error: function(xhr,status,error){
+                    archiveApp.message = `Suppression impossible de ${archive.filename}`;
+                    archiveApp.messageClass = {alert:true,['alert-danger']:true};
+                    archiveApp.updating = false;
+                }
+            });
+        }
+    },
+    mounted (){
+        this.loadArchives();
+    }
+};
+
+if (isVueJS3){
+    let app = Vue.createApp(appParams);
+    rootsElements.forEach(elem => {
+        app.mount(elem);
+    });
+} else {
+    rootsElements.forEach(elem => {
+        new Vue({
+            ...{el:elem},
+            ...appParams
+        });
+    });
+}

--- a/javascripts/actions/admin-backups.js
+++ b/javascripts/actions/admin-backups.js
@@ -221,6 +221,9 @@ let appParams = {
                     } else if (data.hasOwnProperty('notAvailableOnTheInternet') && !data.notAvailableOnTheInternet) {
                         archiveApp.endStartingUpdateError(_t('ADMIN_BACKUPS_START_BACKUP_FOLDER_AVAILABLE').replace(/\n/g,'<br>'));
                         return ;
+                    } else if (data.hasOwnProperty('enoughSpace') && !data.enoughSpace) {
+                        archiveApp.endStartingUpdateError(_t('ADMIN_BACKUPS_START_BACKUP_NOT_ENOUGH_SPACE').replace(/\n/g,'<br>'));
+                        return ;
                     }
                     archiveApp.endStartingUpdateError();
                 },

--- a/javascripts/actions/admin-backups.js
+++ b/javascripts/actions/admin-backups.js
@@ -218,6 +218,9 @@ let appParams = {
                     } else if (data.hasOwnProperty('canExec') && !data.canExec) {
                         archiveApp.endStartingUpdateError(_t('ADMIN_BACKUPS_START_BACKUP_CANNOT_EXEC').replace(/\n/g,'<br>'));
                         return ;
+                    } else if (data.hasOwnProperty('notAvailableOnTheInternet') && !data.notAvailableOnTheInternet) {
+                        archiveApp.endStartingUpdateError(_t('ADMIN_BACKUPS_START_BACKUP_FOLDER_AVAILABLE').replace(/\n/g,'<br>'));
+                        return ;
                     }
                     archiveApp.endStartingUpdateError();
                 },

--- a/javascripts/actions/admin-backups.js
+++ b/javascripts/actions/admin-backups.js
@@ -224,6 +224,9 @@ let appParams = {
                     } else if (data.hasOwnProperty('enoughSpace') && !data.enoughSpace) {
                         archiveApp.endStartingUpdateError(_t('ADMIN_BACKUPS_START_BACKUP_NOT_ENOUGH_SPACE').replace(/\n/g,'<br>'));
                         return ;
+                    } else if (data.hasOwnProperty('dB') && !data.dB) {
+                        archiveApp.endStartingUpdateError(_t('ADMIN_BACKUPS_START_BACKUP_NOT_DB').replace(/\n/g,'<br>'));
+                        return ;
                     }
                     archiveApp.endStartingUpdateError();
                 },

--- a/javascripts/actions/admin-backups.js
+++ b/javascripts/actions/admin-backups.js
@@ -136,6 +136,31 @@ let appParams = {
                 this.selectedArchivesToDelete.push(filename);
             }
         },
+        restoreArchive: function (archive){
+            // TODO update this part then restore will work
+            let archiveApp = this;
+            archiveApp.updating = true;
+            archiveApp.message = `Restauration de ${archive.filename}`;
+            archiveApp.messageClass = {alert:true,['alert-info']:true};
+            $.ajax({
+                method: "POST",
+                url: wiki.url(`api/archives/${archive.filename}`),
+                data: {
+                    action: 'restore'
+                },
+                success: function(data){
+                    archiveApp.message = "";
+                    archiveApp.loadArchives();
+                },
+                error: function(xhr,status,error){
+                    archiveApp.message = `Restauration impossible de ${archive.filename}`;
+                    archiveApp.messageClass = {alert:true,['alert-danger']:true};
+                    archiveApp.updating = false;
+                },
+                complete: function(){
+                }
+            });
+        },
         formatFileSize: function (bytes,decimalPoint) {
             if(bytes == 0) return '0';
             var k = 1024,

--- a/javascripts/actions/admin-backups.js
+++ b/javascripts/actions/admin-backups.js
@@ -22,6 +22,7 @@ let appParams = {
     methods: {
         loadArchives: function() {
             let archiveApp = this;
+            archiveApp.updating = true;
             archiveApp.message = "Chargement de la liste des archives";
             archiveApp.messageClass = {alert:true,['alert-info']:true};
             $.ajax({

--- a/javascripts/actions/admin-backups.js
+++ b/javascripts/actions/admin-backups.js
@@ -16,7 +16,12 @@ let appParams = {
                 alert: true,
                 ['alert-info']: true
             },
-            selectedArchivesToDelete: []
+            selectedArchivesToDelete: [],
+            savefiles: true,
+            savedatabase: true,
+            excludedfiles: [],
+            extrafiles: [],
+            showAdvancedParams: false
         };
     },
     methods: {
@@ -161,6 +166,36 @@ let appParams = {
                 }
             });
         },
+        startArchive: function (){
+            let archiveApp = this;
+            archiveApp.updating = true;
+            archiveApp.message = `Lancement d'une sauvegarde`;
+            archiveApp.messageClass = {alert:true,['alert-info']:true};
+            $.ajax({
+                method: "POST",
+                url: wiki.url(`api/archives`),
+                data: {
+                    action: 'startArchive',
+                    params: {
+                        savefiles: archiveApp.savefiles,
+                        savedatabase: archiveApp.savedatabase,
+                        extrafiles: archiveApp.extrafiles,
+                        excludedfiles: archiveApp.excludedfiles
+                    }
+                },
+                success: function(data){
+                    archiveApp.message = "";
+                    archiveApp.loadArchives();
+                },
+                error: function(xhr,status,error){
+                    archiveApp.message = `Lancement de la sauvegarde impossible`;
+                    archiveApp.messageClass = {alert:true,['alert-danger']:true};
+                },
+                complete: function(){
+                    archiveApp.updating = false;
+                }
+            });
+        },
         formatFileSize: function (bytes,decimalPoint) {
             if(bytes == 0) return '0';
             var k = 1024,
@@ -171,6 +206,51 @@ let appParams = {
         },
         downloadUrl: function(archive){
             return wiki.url(`api/archives/${archive.filename}`);
+        },
+        updateType: function (){
+            if (this.$refs.adminBackupsTypeFull.checked){
+                this.savefiles = true;
+                this.savedatabase = true;
+            } else if(this.$refs.adminBackupsTypeOnlyFiles.checked) {
+                this.savefiles = true;
+                this.savedatabase = false;
+            } else if(this.$refs.adminBackupsTypeOnlyDb.checked) {
+                this.savefiles = false;
+                this.savedatabase = true;
+            } else {
+                this.savefiles = false;
+                this.savedatabase = false;
+            }
+        },
+        removeExtraFile: function (file){
+            this.extrafiles = this.extrafiles.filter(e => e != file);
+        },
+        updateExtraFiles: function (){
+            let newVal = this.$refs.newExtraFile.value;
+            let newFiles = newVal.split(',');
+            if (newFiles.length > 0){
+                for (let index = 0; index < newFiles.length; index++) {
+                    if (!this.extrafiles.includes(newFiles[index])){
+                        this.extrafiles.push(newFiles[index]);
+                    }
+                }
+            }
+            this.$refs.newExtraFile.value = "";
+        },
+        removeExcludedFile: function (file){
+            this.excludedfiles = this.excludedfiles.filter(e => e != file);
+        },
+        updateExcludedFiles: function (){
+            let newVal = this.$refs.newExcludedFile.value;
+            let newFiles = newVal.split(',');
+            if (newFiles.length > 0){
+                for (let index = 0; index < newFiles.length; index++) {
+                    if (!this.excludedfiles.includes(newFiles[index])){
+                        this.excludedfiles.push(newFiles[index]);
+                    }
+                }
+            }
+            this.$refs.newExcludedFile.value = "";
         }
     },
     mounted (){

--- a/javascripts/actions/admin-backups.js
+++ b/javascripts/actions/admin-backups.js
@@ -28,7 +28,7 @@ let appParams = {
         loadArchives: function() {
             let archiveApp = this;
             archiveApp.updating = true;
-            archiveApp.message = "Chargement de la liste des archives";
+            archiveApp.message = _t('ADMIN_BACKUPS_LOADING_LIST');
             archiveApp.messageClass = {alert:true,['alert-info']:true};
             $.ajax({
                 method: "GET",
@@ -46,7 +46,7 @@ let appParams = {
                     archiveApp.selectedArchivesToDelete = archiveApp.selectedArchivesToDelete.filter(e => archiveNames.includes(e));
                 },
                 error: function(xhr,status,error){
-                    archiveApp.message = "Impossible de mettre à jour la liste des archives";
+                    archiveApp.message = _t('ADMIN_BACKUPS_NOT_POSSIBLE_TO_LOAD_LIST');
                     archiveApp.messageClass = {alert:true,['alert-danger']:true};
                     archiveApp.selectedArchivesToDelete = [];
                 },
@@ -59,7 +59,7 @@ let appParams = {
         deleteArchive: function(archive) {
             let archiveApp = this;
             archiveApp.updating = true;
-            archiveApp.message = `Suppression de ${archive.filename}`;
+            archiveApp.message = _t('ADMIN_BACKUPS_DELETE_ARCHIVE',{filename:archive.filename});
             archiveApp.messageClass = {alert:true,['alert-info']:true};
             $.ajax({
                 method: "POST",
@@ -73,19 +73,19 @@ let appParams = {
                     if (Array.isArray(data) 
                         || !data.main){
                         toastMessage(
-                            `Une erreur pourrait avoir eu lieu en supprimant ${archive.filename}`
+                            _t('ADMIN_BACKUPS_DELETE_ARCHIVE_POSSIBLE_ERROR',{filename:archive.filename})
                             ,3000,
                             "alert alert-warning");
                     } else {
                         toastMessage(
-                            `Suppression réussie de ${archive.filename}`
+                            _t('ADMIN_BACKUPS_DELETE_ARCHIVE_SUCCESS',{filename:archive.filename})
                             ,3000,
                             "alert alert-success");
                     }
                     
                 },
                 error: function(xhr,status,error){
-                    archiveApp.message = `Suppression impossible de ${archive.filename}`;
+                    archiveApp.message = _t('ADMIN_BACKUPS_DELETE_ARCHIVE_ERROR',{filename:archive.filename});
                     archiveApp.messageClass = {alert:true,['alert-danger']:true};
                     archiveApp.updating = false;
                 },
@@ -96,11 +96,11 @@ let appParams = {
         },
         deleteSelectedArchives: function (){
             if (this.selectedArchivesToDelete.length == 0){
-                toastMessage('Aucune archive à supprimer', 2000, 'alert alert-info')
+                toastMessage(_t('ADMIN_BACKUPS_NO_ARCHIVE_TO_DELETE'), 2000, 'alert alert-info')
             } else {
                 let archiveApp = this;
                 archiveApp.updating = true;
-                archiveApp.message = `Suppression des archives sélectionnées`;
+                archiveApp.message = _t('ADMIN_BACKUPS_DELETE_SELECTED_ARCHIVES');
                 archiveApp.messageClass = {alert:true,['alert-info']:true};
                 $.ajax({
                     method: "POST",
@@ -115,21 +115,22 @@ let appParams = {
                         if (Array.isArray(data) 
                             || !data.main){
                             toastMessage(
-                                `Une erreur pourrait avoir eu lieu en supprimant ${archiveApp.selectedArchivesToDelete.join(',')}`
+                                _t('ADMIN_BACKUPS_DELETE_ARCHIVE_POSSIBLE_ERROR',{filename:archiveApp.selectedArchivesToDelete.join(',')})
                                 ,3000,
                                 "alert alert-warning");
                         } else {
                             toastMessage(
-                                `Suppression réussie de ${archiveApp.selectedArchivesToDelete.join(',')}`
+                                _t('ADMIN_BACKUPS_DELETE_ARCHIVE_SUCCESS',{filename:archiveApp.selectedArchivesToDelete.join(',')})
                                 ,3000,
                                 "alert alert-success");
                         }
                         
                     },
                     error: function(xhr,status,error){
-                        archiveApp.message = `Suppression impossible de ${archiveApp.selectedArchivesToDelete.join(',')}`;
+                        archiveApp.message = _t('ADMIN_BACKUPS_DELETE_ARCHIVE_ERROR',{filename:archiveApp.selectedArchivesToDelete.join(',')});
                         archiveApp.messageClass = {alert:true,['alert-danger']:true};
                         archiveApp.updating = false;
+                        archiveApp.loadArchives();
                     }
                 });
             }
@@ -145,7 +146,7 @@ let appParams = {
             // TODO update this part then restore will work
             let archiveApp = this;
             archiveApp.updating = true;
-            archiveApp.message = `Restauration de ${archive.filename}`;
+            archiveApp.message = _t('ADMIN_BACKUPS_RESTORE_ARCHIVE',{filename:archive.filename});
             archiveApp.messageClass = {alert:true,['alert-info']:true};
             $.ajax({
                 method: "POST",
@@ -158,7 +159,7 @@ let appParams = {
                     archiveApp.loadArchives();
                 },
                 error: function(xhr,status,error){
-                    archiveApp.message = `Restauration impossible de ${archive.filename}`;
+                    archiveApp.message = _t('ADMIN_BACKUPS_RESTORE_ARCHIVE_ERROR',{filename:archive.filename});
                     archiveApp.messageClass = {alert:true,['alert-danger']:true};
                     archiveApp.updating = false;
                 },
@@ -169,7 +170,7 @@ let appParams = {
         startArchive: function (){
             let archiveApp = this;
             archiveApp.updating = true;
-            archiveApp.message = `Lancement d'une sauvegarde`;
+            archiveApp.message = _t('ADMIN_BACKUPS_START_BACKUP');
             archiveApp.messageClass = {alert:true,['alert-info']:true};
             $.ajax({
                 method: "POST",
@@ -188,7 +189,7 @@ let appParams = {
                     archiveApp.loadArchives();
                 },
                 error: function(xhr,status,error){
-                    archiveApp.message = `Lancement de la sauvegarde impossible`;
+                    archiveApp.message = _t('ADMIN_BACKUPS_START_BACKUP_ERROR');
                     archiveApp.messageClass = {alert:true,['alert-danger']:true};
                 },
                 complete: function(){

--- a/lang/yeswiki_ca.php
+++ b/lang/yeswiki_ca.php
@@ -60,6 +60,8 @@ return [
     'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Cintura',
     'ADMIN_BACKUPS_CREATE' => 'Crear una còpia de seguretat',
     'ADMIN_BACKUPS_START' => 'Començar',
+    'ADMIN_BACKUPS_STOP' => 'Parar',
+    'ADMIN_BACKUPS_STOP_BACKUP' => 'Aturar la còpia de seguretat',
     'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Configuració avançada',
     'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Fitxers exclosos',
     'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Fitxers addicionals',

--- a/lang/yeswiki_ca.php
+++ b/lang/yeswiki_ca.php
@@ -3,6 +3,7 @@
 return [
 
     // Commons
+    // 'ARCHIVES' => 'Sauvegardes',
     // 'CAUTION' => 'Attention',
     'BY' => 'per',
     // 'CLEAN' => 'Nettoyer',
@@ -14,6 +15,8 @@ return [
     // 'INVERT' => 'Inverser',
     // 'MODIFY' => 'Modifier',
     // 'NAME' => 'Nom',
+    // 'ONLY_FOR_ADMINS' => 'Seulement pour les administrateurs',
+    // 'PAGES' => 'Pages',
     // 'SUBSCRIPTION' => 'Inscription',
     'TRIPLES' => 'Triples',
     'UNKNOWN' => 'Desconegut',

--- a/lang/yeswiki_ca.php
+++ b/lang/yeswiki_ca.php
@@ -49,6 +49,21 @@ return [
     'NO_TOOL_AVAILABLE' => 'No hi ha cap eina disponible o activa',
     'LIST_OF_ACTIVE_TOOLS' => 'Llista d\'extensions actives',
 
+    // actions/AdminBackupsAtion.php
+    'ADMIN_BACKUPS_TITLE' => 'Gestió de còpies de seguretat',
+    'ADMIN_BACKUPS_ARCHIVES_LIST' => 'Llista de còpies de seguretat',
+    'ADMIN_BACKUPS_ARCHIVE_FILENAME' => 'Nom del fitxer',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE' => 'Tipus',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_FULL' => 'Còpia de seguretat completa',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_FILES' => 'Només fitxers',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_DATABASES' => 'Només la base de dades',
+    'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Cintura',
+    'ADMIN_BACKUPS_CREATE' => 'Crear una còpia de seguretat',
+    'ADMIN_BACKUPS_START' => 'Començar',
+    'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Configuració avançada',
+    'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Fitxers exclosos',
+    'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Fitxers addicionals',
+
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Pàgines que enllacen amb',
     'PAGES_WITH_LINK_TO_CURRENT_PAGE' => 'Pàgines que enllacen a l\'actual',

--- a/lang/yeswiki_ca.php
+++ b/lang/yeswiki_ca.php
@@ -286,6 +286,11 @@ return [
     // templates/actions/my-favorites-table.twig
     'FAVORITES_TITLE' => 'Títol',
     'FAVORITES_LINK' => 'Lligam',
+    
+    // templates/preupdate-backups.twig
+    // 'ADMIN_BACKUPS_CREATING' => 'Création d\'une sauvegarde',
+    // 'ADMIN_BACKUPS_FORCE_UPDATE' => 'Forcer une mise à jour sans sauvegarde',
+    // 'ADMIN_BACKUPS_BY_PASS' => 'Mettre à jour sans sauvegarde',
 
     // setup/header.php
     'OK' => 'D\'acord',

--- a/lang/yeswiki_ca.php
+++ b/lang/yeswiki_ca.php
@@ -65,6 +65,7 @@ return [
     'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Configuració avançada',
     'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Fitxers exclosos',
     'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Fitxers addicionals',
+    'ADMIN_BACKUPS_CONFIRM_DELETE_FILES' => 'Confirmar la supressió del fitxer',
 
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Pàgines que enllacen amb',

--- a/lang/yeswiki_en.php
+++ b/lang/yeswiki_en.php
@@ -64,6 +64,8 @@ return [
     'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Size',
     'ADMIN_BACKUPS_CREATE' => 'Create backup',
     'ADMIN_BACKUPS_START' => 'Start',
+    'ADMIN_BACKUPS_STOP' => 'Stop',
+    'ADMIN_BACKUPS_STOP_BACKUP' => 'Stop backup',
     'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Advanced parameters',
     'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Excluded files',
     'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Extra files',

--- a/lang/yeswiki_en.php
+++ b/lang/yeswiki_en.php
@@ -5,6 +5,7 @@
 return [
 
     // Commons
+    'ARCHIVES' => 'Archives',
     'ANSWER' => 'Answer',
     'BY' => 'by',
     'CAUTION' => 'Caution',
@@ -18,6 +19,7 @@ return [
     'INVERT' => 'Invert',
     'MODIFY' => 'Modify',
     'NAME' => 'Name',
+    'ONLY_FOR_ADMINS' => 'Only for administrators',
     'PAGES' => 'Pages',
     'SUBSCRIPTION' => 'Subscription',
     'TRIPLES' => 'Triples',

--- a/lang/yeswiki_en.php
+++ b/lang/yeswiki_en.php
@@ -69,6 +69,7 @@ return [
     'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Advanced parameters',
     'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Excluded files',
     'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Extra files',
+    'ADMIN_BACKUPS_CONFIRM_DELETE_FILES' => 'Confirm delete files',
 
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Pages with link to',

--- a/lang/yeswiki_en.php
+++ b/lang/yeswiki_en.php
@@ -290,6 +290,11 @@ return [
     'FAVORITES_TITLE' => 'Title',
     'FAVORITES_LINK' => 'Link',
     
+    // templates/preupdate-backups.twig
+    'ADMIN_BACKUPS_CREATING' => 'Backup creation',
+    'ADMIN_BACKUPS_FORCE_UPDATE' => 'Force an update without backup',
+    'ADMIN_BACKUPS_BY_PASS' => 'Update without backup',
+    
     // setup/header.php
     'OK' => 'OK',
     'FAIL' => 'FAIL',

--- a/lang/yeswiki_en.php
+++ b/lang/yeswiki_en.php
@@ -53,6 +53,21 @@ return [
     'NO_TOOL_AVAILABLE' => 'No extensions available or active',
     'LIST_OF_ACTIVE_TOOLS' => 'Activated extensions list',
 
+    // actions/AdminBackupsAtion.php
+    'ADMIN_BACKUPS_TITLE' => 'Backups management',
+    'ADMIN_BACKUPS_ARCHIVES_LIST' => 'Backups list',
+    'ADMIN_BACKUPS_ARCHIVE_FILENAME' => 'Filename',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE' => 'Type',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_FULL' => 'Full backup',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_FILES' => 'Only files',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_DATABASES' => 'Only database',
+    'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Size',
+    'ADMIN_BACKUPS_CREATE' => 'Create backup',
+    'ADMIN_BACKUPS_START' => 'Start',
+    'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Advanced parameters',
+    'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Excluded files',
+    'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Extra files',
+
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Pages with link to',
     'PAGES_WITH_LINK_TO_CURRENT_PAGE' => 'Pages with link to current page',

--- a/lang/yeswiki_es.php
+++ b/lang/yeswiki_es.php
@@ -68,6 +68,7 @@ return [
     'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Configuración avanzada',
     'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Archivos excluidos',
     'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Archivos adicionales',
+    'ADMIN_BACKUPS_CONFIRM_DELETE_FILES' => 'Confirmar la eliminación de archivos',
 
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Paginas teniendo un enlace hacia',

--- a/lang/yeswiki_es.php
+++ b/lang/yeswiki_es.php
@@ -52,6 +52,21 @@ return [
     'NO_TOOL_AVAILABLE' => 'Ninguna herramienta esta disponible o activa',
     'LIST_OF_ACTIVE_TOOLS' => 'Lista de las extensiones activas',
 
+    // actions/AdminBackupsAtion.php
+    'ADMIN_BACKUPS_TITLE' => 'Administración de copias de seguridad',
+    'ADMIN_BACKUPS_ARCHIVES_LIST' => 'Lista de copias de seguridad',
+    'ADMIN_BACKUPS_ARCHIVE_FILENAME' => 'Nombre de archivo',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE' => 'Tipo',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_FULL' => 'Copia de seguridad completa',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_FILES' => 'Sólo archivos',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_DATABASES' => 'Sólo la base de datos',
+    'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Cintura',
+    'ADMIN_BACKUPS_CREATE' => 'Crear una copia de seguridad',
+    'ADMIN_BACKUPS_START' => 'Empezar',
+    'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Configuración avanzada',
+    'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Archivos excluidos',
+    'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Archivos adicionales',
+
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Paginas teniendo un enlace hacia',
     'PAGES_WITH_LINK_TO_CURRENT_PAGE' => 'Paginas teniendo un enlace hacia la página corriente',

--- a/lang/yeswiki_es.php
+++ b/lang/yeswiki_es.php
@@ -287,6 +287,11 @@ return [
     // templates/actions/my-favorites-table.twig
     'FAVORITES_TITLE' => 'Título',
     'FAVORITES_LINK' => 'Enlace',
+    
+    // templates/preupdate-backups.twig
+    // 'ADMIN_BACKUPS_CREATING' => 'Création d\'une sauvegarde',
+    // 'ADMIN_BACKUPS_FORCE_UPDATE' => 'Forcer une mise à jour sans sauvegarde',
+    // 'ADMIN_BACKUPS_BY_PASS' => 'Mettre à jour sans sauvegarde',
 
     // setup/header.php
     'OK' => 'OK',

--- a/lang/yeswiki_es.php
+++ b/lang/yeswiki_es.php
@@ -63,6 +63,8 @@ return [
     'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Cintura',
     'ADMIN_BACKUPS_CREATE' => 'Crear una copia de seguridad',
     'ADMIN_BACKUPS_START' => 'Empezar',
+    'ADMIN_BACKUPS_STOP' => 'Parar',
+    'ADMIN_BACKUPS_STOP_BACKUP' => 'Parar la copia de seguridad',
     'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Configuración avanzada',
     'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Archivos excluidos',
     'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Archivos adicionales',

--- a/lang/yeswiki_es.php
+++ b/lang/yeswiki_es.php
@@ -3,6 +3,7 @@
 return [
 
     // Commons
+    // 'ARCHIVES' => 'Sauvegardes',
     // 'CAUTION' => 'Attention',
     'BY' => 'por',
     // 'CLEAN' => 'Nettoyer',
@@ -14,6 +15,8 @@ return [
     // 'INVERT' => 'Inverser',
     // 'MODIFY' => 'Modifier',
     // 'NAME' => 'Nom',
+    // 'PAGES' => 'Pages',
+    // 'ONLY_FOR_ADMINS' => 'Seulement pour les administrateurs',
     // 'SUBSCRIPTION' => 'Inscription',
     'TRIPLES' => 'Triples',
     'UNKNOWN' => 'Desconocido',

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -3,6 +3,7 @@
 return [
 
     // Commons
+    'ARCHIVES' => 'Sauvegardes',
     'ANSWER' => 'Répondre',
     'BY' => 'par',
     'CAUTION' => 'Attention',
@@ -17,6 +18,7 @@ return [
     'INVERT' => 'Inverser',
     'MODIFY' => 'Modifier',
     'NAME' => 'Nom',
+    'ONLY_FOR_ADMINS' => 'Seulement pour les administrateurs',
     'PAGES' => 'Pages',
     'SUBSCRIPTION' => 'Inscription',
     'TRIPLES' => 'Triples',

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -63,6 +63,8 @@ return [
     'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Taille',
     'ADMIN_BACKUPS_CREATE' => 'Créer une sauvegarde',
     'ADMIN_BACKUPS_START' => 'Démarrer',
+    'ADMIN_BACKUPS_STOP' => 'Arrêter',
+    'ADMIN_BACKUPS_STOP_BACKUP' => 'Arrêter la sauvegarde',
     'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Paramètres avancés',
     'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Fichiers exclus',
     'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Fichiers supplémentaires',

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -293,6 +293,11 @@ return [
     // templates/actions/my-favorites-table.twig
     'FAVORITES_TITLE' => 'Titre',
     'FAVORITES_LINK' => 'Lien',
+    
+    // templates/preupdate-backups.twig
+    'ADMIN_BACKUPS_CREATING' => 'Création d\'une sauvegarde',
+    'ADMIN_BACKUPS_FORCE_UPDATE' => 'Forcer une mise à jour sans sauvegarde',
+    'ADMIN_BACKUPS_BY_PASS' => 'Mettre à jour sans sauvegarde',
 
     // setup/header.php
     'OK' => 'OK',

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -52,6 +52,12 @@ return [
     'NO_TOOL_AVAILABLE' => 'Aucun outil n\'est disponible ou actif',
     'LIST_OF_ACTIVE_TOOLS' => 'Liste des extensions actives',
 
+    // actions/AdminBackupsAtion.php
+    'ADMIN_BACKUPS_TITLE' => 'Gestion des sauvegardes',
+    'ADMIN_BACKUPS_ARCHIVES_LIST' => 'Liste des archives',
+    'ADMIN_BACKUPS_ARCHIVE_FILENAME' => 'Nom du fichier',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE' => 'Type',
+    
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Pages ayant un lien vers',
     'PAGES_WITH_LINK_TO_CURRENT_PAGE' => 'Pages ayant un lien vers la page courante',

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -57,7 +57,15 @@ return [
     'ADMIN_BACKUPS_ARCHIVES_LIST' => 'Liste des archives',
     'ADMIN_BACKUPS_ARCHIVE_FILENAME' => 'Nom du fichier',
     'ADMIN_BACKUPS_ARCHIVE_TYPE' => 'Type',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_FULL' => 'Sauvegarde complète',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_FILES' => 'Seulement les fichiers',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_DATABASES' => 'Seulement la base de données',
     'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Taille',
+    'ADMIN_BACKUPS_CREATE' => 'Créer une archive',
+    'ADMIN_BACKUPS_START' => 'Démarrer',
+    'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Paramètres avancés',
+    'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Fichiers exclus',
+    'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Fichiers supplémentaires',
     
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Pages ayant un lien vers',

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -54,14 +54,14 @@ return [
 
     // actions/AdminBackupsAtion.php
     'ADMIN_BACKUPS_TITLE' => 'Gestion des sauvegardes',
-    'ADMIN_BACKUPS_ARCHIVES_LIST' => 'Liste des archives',
+    'ADMIN_BACKUPS_ARCHIVES_LIST' => 'Liste des sauvegardes',
     'ADMIN_BACKUPS_ARCHIVE_FILENAME' => 'Nom du fichier',
     'ADMIN_BACKUPS_ARCHIVE_TYPE' => 'Type',
     'ADMIN_BACKUPS_ARCHIVE_TYPE_FULL' => 'Sauvegarde complète',
     'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_FILES' => 'Seulement les fichiers',
     'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_DATABASES' => 'Seulement la base de données',
     'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Taille',
-    'ADMIN_BACKUPS_CREATE' => 'Créer une archive',
+    'ADMIN_BACKUPS_CREATE' => 'Créer une sauvegarde',
     'ADMIN_BACKUPS_START' => 'Démarrer',
     'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Paramètres avancés',
     'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Fichiers exclus',

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -57,6 +57,7 @@ return [
     'ADMIN_BACKUPS_ARCHIVES_LIST' => 'Liste des archives',
     'ADMIN_BACKUPS_ARCHIVE_FILENAME' => 'Nom du fichier',
     'ADMIN_BACKUPS_ARCHIVE_TYPE' => 'Type',
+    'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Taille',
     
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Pages ayant un lien vers',

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -68,6 +68,7 @@ return [
     'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Paramètres avancés',
     'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Fichiers exclus',
     'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Fichiers supplémentaires',
+    'ADMIN_BACKUPS_CONFIRM_DELETE_FILES' => 'Confirmer la suppression des fichiers',
     
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Pages ayant un lien vers',

--- a/lang/yeswiki_nl.php
+++ b/lang/yeswiki_nl.php
@@ -3,6 +3,7 @@
 return [
 
     // Commons
+    // 'ARCHIVES' => 'Sauvegardes',
     // 'CAUTION' => 'Attention',
     'BY' => 'door',
     // 'CLEAN' => 'Nettoyer',
@@ -14,6 +15,8 @@ return [
     // 'INVERT' => 'Inverser',
     // 'MODIFY' => 'Modifier',
     // 'NAME' => 'Nom',
+    // 'PAGES' => 'Pages',
+    // 'ONLY_FOR_ADMINS' => 'Seulement pour les administrateurs',
     // 'SUBSCRIPTION' => 'Inscription',
     'TRIPLES' => 'Triples',
     'UNKNOWN' => 'Onbekend',

--- a/lang/yeswiki_nl.php
+++ b/lang/yeswiki_nl.php
@@ -65,6 +65,7 @@ return [
     'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Geavanceerde instellingen',
     'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Uitgesloten bestanden',
     'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Aanvullende bestanden',
+    'ADMIN_BACKUPS_CONFIRM_DELETE_FILES' => 'Het verwijderen van bestanden bevestigen',
 
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Pagina’s met een koppeling naar',

--- a/lang/yeswiki_nl.php
+++ b/lang/yeswiki_nl.php
@@ -49,6 +49,21 @@ return [
     'NO_TOOL_AVAILABLE' => 'Er is geen enkel instrument beschikbaar of actief',
     'LIST_OF_ACTIVE_TOOLS' => 'Lijst met actieve extensies',
 
+    // actions/AdminBackupsAtion.php
+    'ADMIN_BACKUPS_TITLE' => 'Back-upbeheer',
+    'ADMIN_BACKUPS_ARCHIVES_LIST' => 'Lijst met back-ups',
+    'ADMIN_BACKUPS_ARCHIVE_FILENAME' => 'Bestandsnaam',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE' => 'Type',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_FULL' => 'Volledige back-up',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_FILES' => 'Alleen bestanden',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_DATABASES' => 'Alleen de database',
+    'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Middel',
+    'ADMIN_BACKUPS_CREATE' => 'Een back-up maken',
+    'ADMIN_BACKUPS_START' => 'Beginnen',
+    'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Geavanceerde instellingen',
+    'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Uitgesloten bestanden',
+    'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Aanvullende bestanden',
+
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Pagina’s met een koppeling naar',
     'PAGES_WITH_LINK_TO_CURRENT_PAGE' => 'Pagina’s met een koppeling naar de huidige pagina',

--- a/lang/yeswiki_nl.php
+++ b/lang/yeswiki_nl.php
@@ -60,6 +60,8 @@ return [
     'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Middel',
     'ADMIN_BACKUPS_CREATE' => 'Een back-up maken',
     'ADMIN_BACKUPS_START' => 'Beginnen',
+    'ADMIN_BACKUPS_STOP' => 'Stoppen',
+    'ADMIN_BACKUPS_STOP_BACKUP' => 'Back-up stoppen',
     'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Geavanceerde instellingen',
     'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Uitgesloten bestanden',
     'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Aanvullende bestanden',

--- a/lang/yeswiki_nl.php
+++ b/lang/yeswiki_nl.php
@@ -285,6 +285,11 @@ return [
     // templates/actions/my-favorites-table.twig
     'FAVORITES_TITLE' => 'Titel',
     'FAVORITES_LINK' => 'Verbinden',
+    
+    // templates/preupdate-backups.twig
+    // 'ADMIN_BACKUPS_CREATING' => 'Création d\'une sauvegarde',
+    // 'ADMIN_BACKUPS_FORCE_UPDATE' => 'Forcer une mise à jour sans sauvegarde',
+    // 'ADMIN_BACKUPS_BY_PASS' => 'Mettre à jour sans sauvegarde',
 
     // setup/header.php
     'OK' => 'OK',

--- a/lang/yeswiki_pt.php
+++ b/lang/yeswiki_pt.php
@@ -48,6 +48,21 @@ return [
     'NO_TOOL_AVAILABLE' => 'Nenhuma ferramenta está disponível ou ativa',
     'LIST_OF_ACTIVE_TOOLS' => 'Lista de extensões ativas',
 
+    // actions/AdminBackupsAtion.php
+    'ADMIN_BACKUPS_TITLE' => 'Gestão de cópias de segurança',
+    'ADMIN_BACKUPS_ARCHIVES_LIST' => 'Lista de cópias de segurança',
+    'ADMIN_BACKUPS_ARCHIVE_FILENAME' => 'Nome do arquivo',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE' => 'Tipo',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_FULL' => 'Backup completo',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_FILES' => 'Apenas ficheiros',
+    'ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_DATABASES' => 'Apenas a base de dados',
+    'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Cintura',
+    'ADMIN_BACKUPS_CREATE' => 'Criar uma cópia de segurança',
+    'ADMIN_BACKUPS_START' => 'Começar',
+    'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Configurações avançadas',
+    'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Ficheiros excluídos',
+    'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Ficheiros adicionais',
+
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Páginas que apontam para',
     'PAGES_WITH_LINK_TO_CURRENT_PAGE' => 'Páginas que apontam para a página atual',

--- a/lang/yeswiki_pt.php
+++ b/lang/yeswiki_pt.php
@@ -64,6 +64,7 @@ return [
     'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Configurações avançadas',
     'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Ficheiros excluídos',
     'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Ficheiros adicionais',
+    'ADMIN_BACKUPS_CONFIRM_DELETE_FILES' => 'Confirmar a eliminação de ficheiros',
 
     // actions/backlinks.php
     'PAGES_WITH_LINK' => 'Páginas que apontam para',

--- a/lang/yeswiki_pt.php
+++ b/lang/yeswiki_pt.php
@@ -3,6 +3,7 @@
 return [
 
     // Commons
+    // 'ARCHIVES' => 'Sauvegardes',
     'BY' => 'por',
     // 'CLEAN' => 'Nettoyer',
     // 'DELETE' => 'Supprimer',
@@ -13,6 +14,8 @@ return [
     // 'INVERT' => 'Inverser',
     // 'MODIFY' => 'Modifier',
     // 'NAME' => 'Nom',
+    // 'PAGES' => 'Pages',
+    // 'ONLY_FOR_ADMINS' => 'Seulement pour les administrateurs',
     // 'SUBSCRIPTION' => 'Inscription',
     'TRIPLES' => 'Triplos',
     'UNKNOWN' => 'Desconhecido',

--- a/lang/yeswiki_pt.php
+++ b/lang/yeswiki_pt.php
@@ -59,6 +59,8 @@ return [
     'ADMIN_BACKUPS_ARCHIVE_SIZE' => 'Cintura',
     'ADMIN_BACKUPS_CREATE' => 'Criar uma cópia de segurança',
     'ADMIN_BACKUPS_START' => 'Começar',
+    'ADMIN_BACKUPS_STOP' => 'Parar',
+    'ADMIN_BACKUPS_STOP_BACKUP' => 'Parar o cópia de segurança',
     'ADMIN_BACKUPS_ADVANCED_PARAMS' => 'Configurações avançadas',
     'ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES' => 'Ficheiros excluídos',
     'ADMIN_BACKUPS_ADVANCED_EXTRA_FILES' => 'Ficheiros adicionais',

--- a/lang/yeswiki_pt.php
+++ b/lang/yeswiki_pt.php
@@ -283,6 +283,11 @@ return [
     // templates/actions/my-favorites-table.twig
     'FAVORITES_TITLE' => 'Título',
     'FAVORITES_LINK' => 'Ligação',
+    
+    // templates/preupdate-backups.twig
+    // 'ADMIN_BACKUPS_CREATING' => 'Création d\'une sauvegarde',
+    // 'ADMIN_BACKUPS_FORCE_UPDATE' => 'Forcer une mise à jour sans sauvegarde',
+    // 'ADMIN_BACKUPS_BY_PASS' => 'Mettre à jour sans sauvegarde',
 
     // setup/header.php
     'OK' => 'OK',

--- a/lang/yeswikijs_en.php
+++ b/lang/yeswikijs_en.php
@@ -62,6 +62,8 @@ return [
     "ADMIN_BACKUPS_UID_STATUS_STOP" => "Backup aborted",
     "ADMIN_BACKUPS_STOP_BACKUP_ERROR" => "Error : not possible to stop backup",
     "ADMIN_BACKUPS_STOPPING_ARCHIVE" => "Backup stopping",
+    "ADMIN_BACKUPS_CONFIRMATION_TO_DELETE" => "Following files will be deleted by the backup.\n".
+        "Could you confirm their deletion by checking the box below.\n<pre>{files}</pre>",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Changes done by this revision",

--- a/lang/yeswikijs_en.php
+++ b/lang/yeswikijs_en.php
@@ -38,6 +38,22 @@ return [
     'WEDNESDAY' => 'Wednesday',
     "YES" => "Yes",
 
+    // /javascripts/actions/admin-backups.js
+    "ADMIN_BACKUPS_LOADING_LIST" => "Loading list of backups",
+    "ADMIN_BACKUPS_NOT_POSSIBLE_TO_LOAD_LIST" => "Not possible to update list of backups",
+    "ADMIN_BACKUPS_DELETE_ARCHIVE" => "Delete {filename}",
+    "ADMIN_BACKUPS_DELETE_ARCHIVE_POSSIBLE_ERROR" => "An error could occur when deleting {filename}",
+    "ADMIN_BACKUPS_DELETE_ARCHIVE_SUCCESS" => "{filename} successfully deleted",
+    "ADMIN_BACKUPS_DELETE_ARCHIVE_ERROR" => "Not possible to delete {filename}",
+    "ADMIN_BACKUPS_NO_ARCHIVE_TO_DELETE" => "No backup to delete",
+    "ADMIN_BACKUPS_DELETE_SELECTED_ARCHIVES" => "Deleting selected backups",
+    "ADMIN_BACKUPS_RESTORE_ARCHIVE" => "Restore {filename}",
+    "ADMIN_BACKUPS_RESTORE_ARCHIVE_POSSIBLE_ERROR" => "An error could occur when restoring {filename}",
+    "ADMIN_BACKUPS_RESTORE_ARCHIVE_SUCCESS" => "{filename} successfully restored",
+    "ADMIN_BACKUPS_RESTORE_ARCHIVE_ERROR" => "Not possible to restore {filename}",
+    "ADMIN_BACKUPS_START_BACKUP" => "Start a backup",
+    "ADMIN_BACKUPS_START_BACKUP_ERROR" => "`Not possible to start backup",
+
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Changes done by this revision",
     "REVISIONS_DIFF" => "Comparison to the current revision",

--- a/lang/yeswikijs_en.php
+++ b/lang/yeswikijs_en.php
@@ -59,6 +59,9 @@ return [
     "ADMIN_BACKUPS_UID_STATUS_RUNNING" => "Running backup",
     "ADMIN_BACKUPS_UID_STATUS_FINISHED" => "Finished backup",
     "ADMIN_BACKUPS_UID_STATUS_NOT_FINISHED" => "Trouble backup is not running but not finished",
+    "ADMIN_BACKUPS_UID_STATUS_STOP" => "Backup aborted",
+    "ADMIN_BACKUPS_STOP_BACKUP_ERROR" => "Error : not possible to stop backup",
+    "ADMIN_BACKUPS_STOPPING_ARCHIVE" => "Backup stopping",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Changes done by this revision",

--- a/lang/yeswikijs_en.php
+++ b/lang/yeswikijs_en.php
@@ -87,9 +87,11 @@ return [
     "because it is not possible to launch console commands on this serversur le serveur.\n".
     " - Check that 'exec', 'proc_open', 'proc_terminate' ... commands can be executed for php\n".
     " - It is possible to pass in direct mode by typing 'false' for parameter 'call_archive_async' (panel 'Security')",
-    "ADMIN_BACKUPS_START_BACKUP_FOLDER_AVAILABLE" => "ot possible to start backup \n".
+    "ADMIN_BACKUPS_START_BACKUP_FOLDER_AVAILABLE" => "Not possible to start backup \n".
         "because backups folder is reachable on the internet.\n".
         "Check that the folder indicated in option 'archive[privatePath]' contains needed files '.htaccess' or is configured with Nginx or Apache to deny access !",
+    "ADMIN_BACKUPS_START_BACKUP_NOT_ENOUGH_SPACE" => "Not possible to start backup \n".
+        "There is not enough free space available for a new backup.",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Changes done by this revision",

--- a/lang/yeswikijs_en.php
+++ b/lang/yeswikijs_en.php
@@ -92,6 +92,8 @@ return [
         "Check that the folder indicated in option 'archive[privatePath]' contains needed files '.htaccess' or is configured with Nginx or Apache to deny access !",
     "ADMIN_BACKUPS_START_BACKUP_NOT_ENOUGH_SPACE" => "Not possible to start backup \n".
         "There is not enough free space available for a new backup.",
+    "ADMIN_BACKUPS_START_BACKUP_NOT_DB" => "Not possible to start backup \n".
+        "Database export program ('mysqldump') was not found.",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Changes done by this revision",

--- a/lang/yeswikijs_en.php
+++ b/lang/yeswikijs_en.php
@@ -52,7 +52,13 @@ return [
     "ADMIN_BACKUPS_RESTORE_ARCHIVE_SUCCESS" => "{filename} successfully restored",
     "ADMIN_BACKUPS_RESTORE_ARCHIVE_ERROR" => "Not possible to restore {filename}",
     "ADMIN_BACKUPS_START_BACKUP" => "Start a backup",
-    "ADMIN_BACKUPS_START_BACKUP_ERROR" => "`Not possible to start backup",
+    "ADMIN_BACKUPS_STARTED" => "Backup started",
+    "ADMIN_BACKUPS_START_BACKUP_ERROR" => "Not possible to start backup",
+    "ADMIN_BACKUPS_UPDATE_UID_STATUS_ERROR" => "Not possible to update backup status",
+    "ADMIN_BACKUPS_UID_STATUS_NOT_FOUND" => "Data about backup was not found",
+    "ADMIN_BACKUPS_UID_STATUS_RUNNING" => "Running backup",
+    "ADMIN_BACKUPS_UID_STATUS_FINISHED" => "Finished backup",
+    "ADMIN_BACKUPS_UID_STATUS_NOT_FINISHED" => "Trouble backup is not running but not finished",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Changes done by this revision",

--- a/lang/yeswikijs_en.php
+++ b/lang/yeswikijs_en.php
@@ -52,6 +52,9 @@ return [
     "ADMIN_BACKUPS_RESTORE_ARCHIVE_SUCCESS" => "{filename} successfully restored",
     "ADMIN_BACKUPS_RESTORE_ARCHIVE_ERROR" => "Not possible to restore {filename}",
     "ADMIN_BACKUPS_START_BACKUP" => "Start a backup",
+    "ADMIN_BACKUPS_START_BACKUP_SYNC" => "Start directly a backup (less stable)\n".
+        "It will not be possibile to update the status in direct.\n".
+        "Do not close nor refresh the window !",
     "ADMIN_BACKUPS_STARTED" => "Backup started",
     "ADMIN_BACKUPS_START_BACKUP_ERROR" => "Not possible to start backup",
     "ADMIN_BACKUPS_UPDATE_UID_STATUS_ERROR" => "Not possible to update backup status",
@@ -77,6 +80,11 @@ return [
         " - Check the validity of 'archive[privatePath]' parameter in page 'GererConfig' (part 'Sécurity')\n".
         " - if this parameter is empty, fill it with a path not reachable grom the internet\n".
         " - Check that this path is writable for 'php' (if 'archive[privatePath]' is empty, '/tmp' folder is used)",
+    "ADMIN_BACKUPS_FORCED_UPDATE_NOT_POSSIBLE" => "Not possible to force the update",
+    "ADMIN_BACKUPS_UID_STATUS_FINISHED_THEN_UPDATING" => "Update started (please wait)",
+    "ADMIN_BACKUPS_START_BACKUP_CANNOT_EXEC" => "Not possible to start backup \n" .
+    "because it is not possible to launch console commands on this serversur le serveur.\n".
+    " - Check that 'exec', 'proc_open', 'proc_terminate' ... commands can be executed for php",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Changes done by this revision",

--- a/lang/yeswikijs_en.php
+++ b/lang/yeswikijs_en.php
@@ -64,6 +64,19 @@ return [
     "ADMIN_BACKUPS_STOPPING_ARCHIVE" => "Backup stopping",
     "ADMIN_BACKUPS_CONFIRMATION_TO_DELETE" => "Following files will be deleted by the backup.\n".
         "Could you confirm their deletion by checking the box below.\n<pre>{files}</pre>",
+    "ADMIN_BACKUPS_START_BACKUP_ERROR_ARCHIVING" => "Not possible to start backup \n" .
+        "because a backup is currently in course.\n".
+        "If it is not the case, go to page 'GererConfig' to empty the value\n".
+        "of `wiki_status` parameter in `Security` part",
+    "ADMIN_BACKUPS_START_BACKUP_ERROR_HIBERNATE" => "Not possible to start backup \n" .
+        "because the website is hibernated.\n".
+        "To go out this state, go to page 'GererConfig' to empty the value\n".
+        "of `wiki_status` parameter in `Security` part",
+    "ADMIN_BACKUPS_START_BACKUP_PATH_NOT_WRITABLE" => "Not possible to start backup \n" .
+        "bacuse the backups' folder is not writable.\n".
+        " - Check the validity of 'archive[privatePath]' parameter in page 'GererConfig' (part 'Sécurity')\n".
+        " - if this parameter is empty, fill it with a path not reachable grom the internet\n".
+        " - Check that this path is writable for 'php' (if 'archive[privatePath]' is empty, '/tmp' folder is used)",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Changes done by this revision",

--- a/lang/yeswikijs_en.php
+++ b/lang/yeswikijs_en.php
@@ -77,14 +77,19 @@ return [
         "of `wiki_status` parameter in `Security` part",
     "ADMIN_BACKUPS_START_BACKUP_PATH_NOT_WRITABLE" => "Not possible to start backup \n" .
         "bacuse the backups' folder is not writable.\n".
-        " - Check the validity of 'archive[privatePath]' parameter in page 'GererConfig' (part 'Sécurity')\n".
-        " - if this parameter is empty, fill it with a path not reachable grom the internet\n".
-        " - Check that this path is writable for 'php' (if 'archive[privatePath]' is empty, '/tmp' folder is used)",
+        " - Check the validity of 'archive[privatePath]' parameter in page 'GererConfig' (part 'Security')\n".
+        " - if this parameter is empty, fill it with a path not reachable grom the internet (a relative path does not begin by /)\n".
+        " - Check that this path is writable for 'php' (if 'archive[privatePath]' is empty, 'private/backups/' folder is used)\n".
+        " - it is possible to use system temporary folder by typing '%TMP'",
     "ADMIN_BACKUPS_FORCED_UPDATE_NOT_POSSIBLE" => "Not possible to force the update",
     "ADMIN_BACKUPS_UID_STATUS_FINISHED_THEN_UPDATING" => "Update started (please wait)",
     "ADMIN_BACKUPS_START_BACKUP_CANNOT_EXEC" => "Not possible to start backup \n" .
     "because it is not possible to launch console commands on this serversur le serveur.\n".
-    " - Check that 'exec', 'proc_open', 'proc_terminate' ... commands can be executed for php",
+    " - Check that 'exec', 'proc_open', 'proc_terminate' ... commands can be executed for php\n".
+    " - It is possible to pass in direct mode by typing 'false' for parameter 'call_archive_async' (panel 'Security')",
+    "ADMIN_BACKUPS_START_BACKUP_FOLDER_AVAILABLE" => "ot possible to start backup \n".
+        "because backups folder is reachable on the internet.\n".
+        "Check that the folder indicated in option 'archive[privatePath]' contains needed files '.htaccess' or is configured with Nginx or Apache to deny access !",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Changes done by this revision",

--- a/lang/yeswikijs_fr.php
+++ b/lang/yeswikijs_fr.php
@@ -62,6 +62,8 @@ return [
     "ADMIN_BACKUPS_UID_STATUS_STOP" => "Sauvegarde arrêtée",
     "ADMIN_BACKUPS_STOP_BACKUP_ERROR" => "Erreur : impossible d'arrêter la sauvegarde",
     "ADMIN_BACKUPS_STOPPING_ARCHIVE" => "Arrêt en cours de la sauvegarde",
+    "ADMIN_BACKUPS_CONFIRMATION_TO_DELETE" => "Les fichiers suivants seront supprimés par la sauvegarde.\n".
+        "Veuillez confirmer leur suppression en cochant la case ci-dessous.\n<pre>{files}</pre>",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Modifs apportées par cette version",

--- a/lang/yeswikijs_fr.php
+++ b/lang/yeswikijs_fr.php
@@ -59,6 +59,9 @@ return [
     "ADMIN_BACKUPS_UID_STATUS_RUNNING" => "Sauvegarde en cours",
     "ADMIN_BACKUPS_UID_STATUS_FINISHED" => "Sauvegarde terminée",
     "ADMIN_BACKUPS_UID_STATUS_NOT_FINISHED" => "Il y a un problème car la sauvegarde n'est plus en cours et elle n'est pas terminée !",
+    "ADMIN_BACKUPS_UID_STATUS_STOP" => "Sauvegarde arrêtée",
+    "ADMIN_BACKUPS_STOP_BACKUP_ERROR" => "Erreur : impossible d'arrêter la sauvegarde",
+    "ADMIN_BACKUPS_STOPPING_ARCHIVE" => "Arrêt en cours de la sauvegarde",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Modifs apportées par cette version",

--- a/lang/yeswikijs_fr.php
+++ b/lang/yeswikijs_fr.php
@@ -64,6 +64,19 @@ return [
     "ADMIN_BACKUPS_STOPPING_ARCHIVE" => "Arrêt en cours de la sauvegarde",
     "ADMIN_BACKUPS_CONFIRMATION_TO_DELETE" => "Les fichiers suivants seront supprimés par la sauvegarde.\n".
         "Veuillez confirmer leur suppression en cochant la case ci-dessous.\n<pre>{files}</pre>",
+    "ADMIN_BACKUPS_START_BACKUP_ERROR_ARCHIVING" => "Lancement de la sauvegarde impossible \n" .
+        "Car une sauvegarde semble être déjà en cours.\n".
+        "Si ça n'est pas le cas, se rendre dans la page 'GererConfig' pour vider la valeur\n".
+        "du paramètre `wiki_status` dans la partie `Sécurité`",
+    "ADMIN_BACKUPS_START_BACKUP_ERROR_HIBERNATE" => "Lancement de la sauvegarde impossible \n" .
+        "Car le site est en hibernation.\n".
+        "Pour le sortir de cet état, se rendre dans la page 'GererConfig' pour vider la valeur\n".
+        "du paramètre `wiki_status` dans la partie `Sécurité`",
+    "ADMIN_BACKUPS_START_BACKUP_PATH_NOT_WRITABLE" => "Lancement de la sauvegarde impossible \n" .
+        "Car le dossier de sauvegarde n'est pas accessible en écriture.\n".
+        " - Vérifier la validité du paramètre 'archive[privatePath]', dans la page 'GererConfig' (rubrique 'Sécutité')\n".
+        " - si ce paramètre est vide, le remplir avec un chemin non accessible sur le internet\n".
+        " - Vérifier que le dossier est bien accessible pour 'php' (si 'archive[privatePath]' est vide, c'est le dossier '/tmp' qui est utilisé)",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Modifs apportées par cette version",

--- a/lang/yeswikijs_fr.php
+++ b/lang/yeswikijs_fr.php
@@ -38,6 +38,22 @@ return [
     'WEDNESDAY' => 'Mercredi',
     "YES" => "Oui",
 
+    // /javascripts/actions/admin-backups.js
+    "ADMIN_BACKUPS_LOADING_LIST" => "Chargement de la liste des sauvegardes",
+    "ADMIN_BACKUPS_NOT_POSSIBLE_TO_LOAD_LIST" => "Impossible de mettre à jour la liste des sauvegardes",
+    "ADMIN_BACKUPS_DELETE_ARCHIVE" => "Suppression de {filename}",
+    "ADMIN_BACKUPS_DELETE_ARCHIVE_POSSIBLE_ERROR" => "Une erreur pourrait avoir eu lieu en supprimant {filename}",
+    "ADMIN_BACKUPS_DELETE_ARCHIVE_SUCCESS" => "Suppression réussie de {filename}",
+    "ADMIN_BACKUPS_DELETE_ARCHIVE_ERROR" => "Suppression impossible de {filename}",
+    "ADMIN_BACKUPS_NO_ARCHIVE_TO_DELETE" => "Aucune sauvegarde à supprimer",
+    "ADMIN_BACKUPS_DELETE_SELECTED_ARCHIVES" => "Suppression des sauvegardes sélectionnées",
+    "ADMIN_BACKUPS_RESTORE_ARCHIVE" => "Restauration de {filename}",
+    "ADMIN_BACKUPS_RESTORE_ARCHIVE_POSSIBLE_ERROR" => "Une erreur pourrait avoir eu lieu en restraurant {filename}",
+    "ADMIN_BACKUPS_RESTORE_ARCHIVE_SUCCESS" => "Restauration réussie de {filename}",
+    "ADMIN_BACKUPS_RESTORE_ARCHIVE_ERROR" => "Restauration impossible de {filename}",
+    "ADMIN_BACKUPS_START_BACKUP" => "Lancement d'une sauvegarde",
+    "ADMIN_BACKUPS_START_BACKUP_ERROR" => "Lancement de la sauvegarde impossible",
+
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Modifs apportées par cette version",
     "REVISIONS_DIFF" => "Comparaison avec version actuelle",

--- a/lang/yeswikijs_fr.php
+++ b/lang/yeswikijs_fr.php
@@ -90,6 +90,8 @@ return [
     "ADMIN_BACKUPS_START_BACKUP_FOLDER_AVAILABLE" => "Lancement de la sauvegarde impossible \n".
         "Car le dossier de sauvegarde est accessible sur internet.\n".
         "Vérifier que le dossier indiqué dans l'option 'archive[privatePath]' contient bien les fichiers '.htaccess' nécessaires ou est bien configuré avec Nginx ou Apache pour empêcher l'accès !",
+    "ADMIN_BACKUPS_START_BACKUP_NOT_ENOUGH_SPACE" => "Lancement de la sauvegarde impossible \n".
+        "Il n'y a plus assez d'espace disque disponible pour une nouvelle sauvegarde.",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Modifs apportées par cette version",

--- a/lang/yeswikijs_fr.php
+++ b/lang/yeswikijs_fr.php
@@ -52,7 +52,13 @@ return [
     "ADMIN_BACKUPS_RESTORE_ARCHIVE_SUCCESS" => "Restauration réussie de {filename}",
     "ADMIN_BACKUPS_RESTORE_ARCHIVE_ERROR" => "Restauration impossible de {filename}",
     "ADMIN_BACKUPS_START_BACKUP" => "Lancement d'une sauvegarde",
+    "ADMIN_BACKUPS_STARTED" => "Sauvegarde lancée",
     "ADMIN_BACKUPS_START_BACKUP_ERROR" => "Lancement de la sauvegarde impossible",
+    "ADMIN_BACKUPS_UPDATE_UID_STATUS_ERROR" => "Impossible de mettre à jour le statut de la sauvegarde",
+    "ADMIN_BACKUPS_UID_STATUS_NOT_FOUND" => "Les informations de suivi n'ont pas été trouvées",
+    "ADMIN_BACKUPS_UID_STATUS_RUNNING" => "Sauvegarde en cours",
+    "ADMIN_BACKUPS_UID_STATUS_FINISHED" => "Sauvegarde terminée",
+    "ADMIN_BACKUPS_UID_STATUS_NOT_FINISHED" => "Il y a un problème car la sauvegarde n'est plus en cours et elle n'est pas terminée !",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Modifs apportées par cette version",

--- a/lang/yeswikijs_fr.php
+++ b/lang/yeswikijs_fr.php
@@ -92,6 +92,8 @@ return [
         "Vérifier que le dossier indiqué dans l'option 'archive[privatePath]' contient bien les fichiers '.htaccess' nécessaires ou est bien configuré avec Nginx ou Apache pour empêcher l'accès !",
     "ADMIN_BACKUPS_START_BACKUP_NOT_ENOUGH_SPACE" => "Lancement de la sauvegarde impossible \n".
         "Il n'y a plus assez d'espace disque disponible pour une nouvelle sauvegarde.",
+    "ADMIN_BACKUPS_START_BACKUP_NOT_DB" => "Lancement de la sauvegarde impossible \n".
+        "L'utilitaire d'export de base de données ('mysqldump') n'est pas accessible.",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Modifs apportées par cette version",

--- a/lang/yeswikijs_fr.php
+++ b/lang/yeswikijs_fr.php
@@ -77,14 +77,19 @@ return [
         "du paramètre `wiki_status` dans la partie `Sécurité`",
     "ADMIN_BACKUPS_START_BACKUP_PATH_NOT_WRITABLE" => "Lancement de la sauvegarde impossible \n" .
         "Car le dossier de sauvegarde n'est pas accessible en écriture.\n".
-        " - Vérifier la validité du paramètre 'archive[privatePath]', dans la page 'GererConfig' (rubrique 'Sécutité')\n".
-        " - si ce paramètre est vide, le remplir avec un chemin non accessible sur le internet\n".
-        " - Vérifier que le dossier est bien accessible pour 'php' (si 'archive[privatePath]' est vide, c'est le dossier '/tmp' qui est utilisé)",
+        " - Vérifier la validité du paramètre 'archive[privatePath]', dans la page 'GererConfig' (rubrique 'Sécurité')\n".
+        " - si ce paramètre est vide, le remplir avec un chemin non accessible sur le internet (un chemin relatif ne commence pas par /)\n".
+        " - Vérifier que le dossier est bien accessible pour 'php' (si 'archive[privatePath]' est vide, c'est le dossier 'private/backups/' qui est utilisé)\n".
+        " - il est possible d'utiliser le dossier temporaire du système en tapant '%TMP'",
     "ADMIN_BACKUPS_FORCED_UPDATE_NOT_POSSIBLE" => "Mise à jour forcée impossible",
     "ADMIN_BACKUPS_UID_STATUS_FINISHED_THEN_UPDATING" => "Mise à jour lancée (veuillez patienter)",
     "ADMIN_BACKUPS_START_BACKUP_CANNOT_EXEC" => "Lancement de la sauvegarde impossible \n" .
     "Car il n'est pas possible de lancer des commandes console sur le serveur.\n".
-    " - Vérifier que les commandes 'exec', 'proc_open', 'proc_terminate' ... sont autorisées pour php",
+    " - Vérifier que les commandes 'exec', 'proc_open', 'proc_terminate' ... sont autorisées pour php\n".
+    " - Vous pouvez éventuellement passer en mode direct en mettant 'false' pour le paramètre 'call_archive_async' (rubrique 'Sécurité')",
+    "ADMIN_BACKUPS_START_BACKUP_FOLDER_AVAILABLE" => "Lancement de la sauvegarde impossible \n".
+        "Car le dossier de sauvegarde est accessible sur internet.\n".
+        "Vérifier que le dossier indiqué dans l'option 'archive[privatePath]' contient bien les fichiers '.htaccess' nécessaires ou est bien configuré avec Nginx ou Apache pour empêcher l'accès !",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Modifs apportées par cette version",
@@ -101,7 +106,7 @@ return [
     'FAVORITES_REMOVE' => 'Retirer des favoris',
     'FAVORITES_ADDED' => 'Favori ajouté',
     'FAVORITES_REMOVED' => 'Favori supprimé',
-    
+
     // javascripts/multidelete.js
     "MULTIDELETE_END" => "Suppressions réalisées",
     "MULTIDELETE_ERROR" => "L'élément {itemId} n'a pas été supprimé ! {error}",

--- a/lang/yeswikijs_fr.php
+++ b/lang/yeswikijs_fr.php
@@ -52,6 +52,9 @@ return [
     "ADMIN_BACKUPS_RESTORE_ARCHIVE_SUCCESS" => "Restauration réussie de {filename}",
     "ADMIN_BACKUPS_RESTORE_ARCHIVE_ERROR" => "Restauration impossible de {filename}",
     "ADMIN_BACKUPS_START_BACKUP" => "Lancement d'une sauvegarde",
+    "ADMIN_BACKUPS_START_BACKUP_SYNC" => "Lancement d'une sauvegarde en direct (moins stable)\n".
+        "Il ne sera pas possible de mettre à jour le statut en direct\n".
+        "Ne pas fermer, ni rafraîchir cette fenêtre !",
     "ADMIN_BACKUPS_STARTED" => "Sauvegarde lancée",
     "ADMIN_BACKUPS_START_BACKUP_ERROR" => "Lancement de la sauvegarde impossible",
     "ADMIN_BACKUPS_UPDATE_UID_STATUS_ERROR" => "Impossible de mettre à jour le statut de la sauvegarde",
@@ -77,6 +80,11 @@ return [
         " - Vérifier la validité du paramètre 'archive[privatePath]', dans la page 'GererConfig' (rubrique 'Sécutité')\n".
         " - si ce paramètre est vide, le remplir avec un chemin non accessible sur le internet\n".
         " - Vérifier que le dossier est bien accessible pour 'php' (si 'archive[privatePath]' est vide, c'est le dossier '/tmp' qui est utilisé)",
+    "ADMIN_BACKUPS_FORCED_UPDATE_NOT_POSSIBLE" => "Mise à jour forcée impossible",
+    "ADMIN_BACKUPS_UID_STATUS_FINISHED_THEN_UPDATING" => "Mise à jour lancée (veuillez patienter)",
+    "ADMIN_BACKUPS_START_BACKUP_CANNOT_EXEC" => "Lancement de la sauvegarde impossible \n" .
+    "Car il n'est pas possible de lancer des commandes console sur le serveur.\n".
+    " - Vérifier que les commandes 'exec', 'proc_open', 'proc_terminate' ... sont autorisées pour php",
 
     // /javascripts/handlers/revisions.js
     "REVISIONS_COMMIT_DIFF" => "Modifs apportées par cette version",

--- a/private/.htaccess
+++ b/private/.htaccess
@@ -1,0 +1,1 @@
+DENY FROM ALL

--- a/private/backups/.htaccess
+++ b/private/backups/.htaccess
@@ -1,0 +1,1 @@
+DENY FROM ALL

--- a/private/backups/README.md
+++ b/private/backups/README.md
@@ -1,0 +1,8 @@
+# Description of the usage of folder private/backups
+
+This folder is **reserved to backups**.
+
+It **MUST NOT** be accessible from the internet.
+
+ - On Apache server, check that the file `.htaccess` is taken in count.
+ - On Nginx server or other, configure the server to **deny all** access on this folder

--- a/setup/sql/default-content.sql
+++ b/setup/sql/default-content.sql
@@ -285,10 +285,10 @@ Voici quelques possibilités autour des annuaires (à copier-coller - adapter)
 ('FacetteRessource',  now(), '{{nav links=\"FacetteRessource, SaisirRessource\" titles=\"Les ressources, Déposer une ressource\"}}
 
 {{bazarliste id=\"4\" template=\"liste_accordeon\" correspondance=\"soustitre=bf_description\" groups=\"checkboxListeType\" titles=\"Tri par type\" voirmenu=\"0\" vue=\"recherche\" }}', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
-('GererConfig',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour\" titles=\"Gestion du site, Droits d\'accès, Look, Utilisateurs et groupes, Mots clefs, Fichier de conf, Mises à jour / extensions\"}}
+('GererConfig',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour, GererSauvegardes\" titles=\"Gestion du site, Droits, Look, Utilisateurs, Mots clefs, Fichier de conf, MAJ / extensions, Sauvegardes\"}}
 
 {{editconfig}}', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
-('GererDroits',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour\" titles=\"Gestion du site, Droits d\'accès, Look, Utilisateurs et groupes, Mots clefs, Fichier de conf, Mises à jour / extensions\"}}
+('GererDroits',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour, GererSauvegardes\" titles=\"Gestion du site, Droits, Look, Utilisateurs, Mots clefs, Fichier de conf, MAJ / extensions, Sauvegardes\"}}
 
 {{button class=\"btn-primary btn-xs pull-right\" hideifnoaccess=\"true\" icon=\"fas fa-arrow-right\" link=\"GererDroitsActions\" text=\"Droits des actions/handlers\" }}===Gérer les droits des pages===
 {{gererdroits}}', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
@@ -304,15 +304,15 @@ Voici quelques possibilités autour des annuaires (à copier-coller - adapter)
 ===Droits d\'accès aux handlers===
 
 {{edithandlersacls}}', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
-('GererMisesAJour',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour\" titles=\"Gestion du site, Droits d\'accès, Look, Utilisateurs et groupes, Mots clefs, Fichier de conf, Mises à jour / extensions\"}}
+('GererMisesAJour',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour, GererSauvegardes\" titles=\"Gestion du site, Droits, Look, Utilisateurs, Mots clefs, Fichier de conf, MAJ / extensions, Sauvegardes\"}}
 
 ===Mises à jour / extensions===
 {{update}}', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
-('GererMotsClef',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour\" titles=\"Gestion du site, Droits d\'accès, Look, Utilisateurs et groupes, Mots clefs, Fichier de conf, Mises à jour / extensions\"}}
+('GererMotsClef',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour, GererSauvegardes\" titles=\"Gestion du site, Droits, Look, Utilisateurs, Mots clefs, Fichier de conf, MAJ / extensions, Sauvegardes\"}}
 
 ===Gestion des mots clés ===
 {{admintag}}', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
-('GererSite',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour\" titles=\"Gestion du site, Droits d\'accès, Look, Utilisateurs et groupes, Mots clefs, Fichier de conf, Mises à jour / extensions\"}}
+('GererSite',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour, GererSauvegardes\" titles=\"Gestion du site, Droits, Look, Utilisateurs, Mots clefs, Fichier de conf, MAJ / extensions, Sauvegardes\"}}
 
 {{attach file=\"modele.jpg\" desc=\"image Dessin_sans_titre.jpg (66.9kB)\" size=\"big\" class=\"right\"}}===Gérer les menus et pages spéciales de ce wiki===
  - [[PageTitre/edit Éditer la Page Titre]]
@@ -324,7 +324,7 @@ Voici quelques possibilités autour des annuaires (à copier-coller - adapter)
 ==Mais aussi==
  - [[PageMenu/edit Éditer le menu vertical]]
  - [[ReglesDeFormatage/edit Éditer le mémo de formatage]]', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
-('GererThemes',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour\" titles=\"Gestion du site, Droits d\'accès, Look, Utilisateurs et groupes, Mots clefs, Fichier de conf, Mises à jour / extensions\"}}
+('GererThemes',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour, GererSauvegardes\" titles=\"Gestion du site, Droits, Look, Utilisateurs, Mots clefs, Fichier de conf, MAJ / extensions, Sauvegardes\"}}
 
 {{button class=\"btn-info btn-block\" link=\"LookWiki\" text=\"Personnaliser le thème de ce wiki (couleurs, police...)\" }}
 {{button class=\"btn-default btn-block\" link=\"PageCss\" text=\"Ajouter du code CSS (zone sensible)\" title=\"Cette page ne peut contenir QUE du Css / voir la doc sur https://yeswiki.net/?DocumentationThemeMargot\" }}
@@ -336,7 +336,7 @@ Voici quelques possibilités autour des annuaires (à copier-coller - adapter)
 -----
 ===Gérer le thème par défaut du wiki===
 {{setwikidefaulttheme}}', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
-('GererUtilisateurs',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour\" titles=\"Gestion du site, Droits d\'accès, Look, Utilisateurs et groupes, Mots clefs, Fichier de conf, Mises à jour / extensions\"}}
+('GererUtilisateurs',  now(), '{{nav links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour, GererSauvegardes\" titles=\"Gestion du site, Droits, Look, Utilisateurs, Mots clefs, Fichier de conf, MAJ / extensions, Sauvegardes\"}}
 
 ===Gérer les groupes d\'utilisateurs===
 {{editgroups}}
@@ -760,7 +760,7 @@ Texte colonne 3
 ('WikiAdmin',  now(), '{{redirect page=\"GererSite\"}}
 ', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
 ('YesWiki',  now(), 'YesWiki', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
-('GererSauvegardes',  now(), '{{nav class=\"nav nav-tabs\" links=\"GererConfig, GererMisesAJour, GererSauvegardes\" titles=\"Fichier de conf,Mises à jour / extensions, Sauvegardes\" }}
+('GererSauvegardes',  now(), '{{nav class=\"nav nav-tabs\" links=\"GererSite, GererDroits, GererThemes, GererUtilisateurs, GererMotsClef, GererConfig, GererMisesAJour, GererSauvegardes\" titles=\"Gestion du site, Droits, Look, Utilisateurs, Mots clefs, Fichier de conf, MAJ / extensions, Sauvegardes\" }}
 
 {{adminbackups}}', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', '');
 # end YesWiki pages

--- a/setup/sql/default-content.sql
+++ b/setup/sql/default-content.sql
@@ -760,7 +760,7 @@ Texte colonne 3
 ('WikiAdmin',  now(), '{{redirect page=\"GererSite\"}}
 ', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
 ('YesWiki',  now(), 'YesWiki', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
-('GererSauvegardes',  now(), '{{nav class=\"nav nav-tabs\" links=\"GererMisesAJour, GererSauvegardes\" titles=\"Mises à jour / extensions, Sauvegardes\" }}
+('GererSauvegardes',  now(), '{{nav class=\"nav nav-tabs\" links=\"GererConfig, GererMisesAJour, GererSauvegardes\" titles=\"Fichier de conf,Mises à jour / extensions, Sauvegardes\" }}
 
 {{adminbackups}}', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', '');
 # end YesWiki pages

--- a/setup/sql/default-content.sql
+++ b/setup/sql/default-content.sql
@@ -759,7 +759,10 @@ Texte colonne 3
 {{bazarliste id=\"2\" template=\"calendar\" }}', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
 ('WikiAdmin',  now(), '{{redirect page=\"GererSite\"}}
 ', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
-('YesWiki',  now(), 'YesWiki', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', '');
+('YesWiki',  now(), 'YesWiki', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', ''),
+('GererSauvegardes',  now(), '{{nav class=\"nav nav-tabs\" links=\"GererMisesAJour, GererSauvegardes\" titles=\"Mises à jour / extensions, Sauvegardes\" }}
+
+{{adminbackups}}', '', '{{WikiName}}', '{{WikiName}}', 'Y', 'page', '');
 # end YesWiki pages
 
 # Bazar forms

--- a/styles/actions/admin-backups.css
+++ b/styles/actions/admin-backups.css
@@ -1,0 +1,14 @@
+.backups-container {
+    display: grid;
+    grid-template-columns: auto 50px 100px;
+    column-gap: 10px;
+    row-gap: 10px;
+}
+
+.backups-container .archive-item {
+    display: inline-grid;
+}
+.backups-container .archive-item.archive-item-title {
+    font-weight: bold;
+    border-bottom: 2px solid var(--primary-color);
+}

--- a/styles/actions/admin-backups.css
+++ b/styles/actions/admin-backups.css
@@ -27,6 +27,7 @@
 .relativeSpinner {
     position: relative;
 }
-.admin-backups-container .alert pre {
+.admin-backups-container .alert pre,
+.preupdate-backups-container .alert pre {
     color: initial;
 }

--- a/styles/actions/admin-backups.css
+++ b/styles/actions/admin-backups.css
@@ -1,14 +1,22 @@
 .backups-container {
     display: grid;
-    grid-template-columns: auto 50px 100px;
+    grid-template-columns: auto auto auto auto auto;
     column-gap: 10px;
     row-gap: 10px;
 }
 
-.backups-container .archive-item {
-    display: inline-grid;
+.backups-container .archive-item.archive-filename {
+    word-break: break-all;
 }
 .backups-container .archive-item.archive-item-title {
     font-weight: bold;
     border-bottom: 2px solid var(--primary-color);
+    padding-bottom: 5px;
+}
+
+@media(max-width: 600px){
+    .backups-container .archive-item.archive-item-title .btn-wrap{
+        max-width: 50px;
+        overflow-x: hidden;
+    }
 }

--- a/styles/actions/admin-backups.css
+++ b/styles/actions/admin-backups.css
@@ -5,6 +5,9 @@
     row-gap: 10px;
 }
 
+.admin-backups-container .archive-buttons {
+    margin-bottom: 5px;
+}
 .backups-container .archive-item.archive-filename {
     word-break: break-all;
 }
@@ -19,4 +22,11 @@
         max-width: 50px;
         overflow-x: hidden;
     }
+}
+
+.relativeSpinner {
+    position: relative;
+}
+.admin-backups-container pre {
+    color: initial;
 }

--- a/styles/actions/admin-backups.css
+++ b/styles/actions/admin-backups.css
@@ -27,6 +27,6 @@
 .relativeSpinner {
     position: relative;
 }
-.admin-backups-container pre {
+.admin-backups-container .alert pre {
     color: initial;
 }

--- a/templates/actions/admin-backups.twig
+++ b/templates/actions/admin-backups.twig
@@ -5,22 +5,25 @@
 <div class="admin-backups-container well">
   <h1>{{ _t('ADMIN_BACKUPS_TITLE') }}</h1>
   <h2>{{ _t('ADMIN_BACKUPS_CREATE') }}</h2>
-  <button 
-      @click="startArchive"
-      class="btn btn-xs btn-primary"
-      :disabled="updating" 
-      data-tooltip="toggle" 
-      title="{{ _t('ADMIN_BACKUPS_CREATE') }}">
-    {{ _t('ADMIN_BACKUPS_START') }}
-  </button>
-  <span @click="showAdvancedParams = !showAdvancedParams">
-    <input 
-      type="checkbox" 
-      name="advanced-params" 
-      value="1" 
-      :checked="showAdvancedParams">
-    <span>{{ _t('ADMIN_BACKUPS_ADVANCED_PARAMS') }}</span>
-  </span>
+  <div class="archive-buttons">
+    <button 
+        @click="startArchive"
+        class="btn btn-xs btn-primary"
+        :disabled="updating || currentArchiveUid.length > 0" 
+        data-tooltip="toggle" 
+        title="{{ _t('ADMIN_BACKUPS_CREATE') }}">
+      {{ _t('ADMIN_BACKUPS_START') }}
+    </button>
+    <span @click="showAdvancedParams = !showAdvancedParams">
+      <input 
+        type="checkbox" 
+        name="advanced-params" 
+        value="1" 
+        :checked="showAdvancedParams">
+      <span>{{ _t('ADMIN_BACKUPS_ADVANCED_PARAMS') }}</span>
+    </span>
+  </div>
+  <div v-if="archiveMessage.length > 0" v-html="archiveMessage" :class="archiveMessageClass"></div>
   <div v-if="showAdvancedParams" class="well">
     <div class="input-group input-group-sm">
       <div class="input-group-prepend">
@@ -70,11 +73,19 @@
     </div>
   </div>
   <hr/>
-  <div class="pull-right btn btn-xs btn-primary" @click="loadArchives" data-tooltip="toogle" title="{{ _t('RELOAD') }}"><i class="fas fa-redo-alt"></i></div>
+  <div 
+    class="pull-right btn btn-xs btn-primary" 
+    @click="loadArchives" 
+    data-tooltip="toogle" 
+    title="{{ _t('RELOAD') }}"
+    :disabled="updating"
+    >
+    <i class="fas fa-redo-alt"></i>
+  </div>
   <h2>{{ _t('ADMIN_BACKUPS_ARCHIVES_LIST') }}</h2>
   <div class="clearfix"></div>
   <div v-if="message.length > 0" v-html="message" :class="messageClass"></div>
-  <div v-if="ready" class="backups-container">
+  <div v-if="ready" class="backups-container" :class="{'relativeSpinner':archiving}">
     <div class="archive-item archive-item-title">{{ _t('ADMIN_BACKUPS_ARCHIVE_FILENAME') }}</div>
     <div class="archive-item archive-item-title">{{ _t('ADMIN_BACKUPS_ARCHIVE_SIZE') }}</div>
     <div class="archive-item archive-item-title">{{ _t('ADMIN_BACKUPS_ARCHIVE_TYPE') }}</div>

--- a/templates/actions/admin-backups.twig
+++ b/templates/actions/admin-backups.twig
@@ -9,7 +9,7 @@
     <button 
         @click="startArchive"
         class="btn btn-xs btn-primary"
-        :disabled="updating || currentArchiveUid.length > 0" 
+        :disabled="updating || currentArchiveUid.length > 0 || archiving" 
         data-tooltip="toggle" 
         title="{{ _t('ADMIN_BACKUPS_CREATE') }}">
       {{ _t('ADMIN_BACKUPS_START') }}
@@ -22,6 +22,15 @@
         :checked="showAdvancedParams">
       <span>{{ _t('ADMIN_BACKUPS_ADVANCED_PARAMS') }}</span>
     </span>
+    <button
+        v-if="currentArchiveUid.length > 0 && archiving"
+        @click="stopArchive"
+        class="btn btn-xs btn-danger"
+        :disabled="stoppingArchive" 
+        data-tooltip="toggle" 
+        title="{{ _t('ADMIN_BACKUPS_STOP_BACKUP') }}">
+      {{ _t('ADMIN_BACKUPS_STOP') }}
+    </button>
   </div>
   <div v-if="archiveMessage.length > 0" v-html="archiveMessage" :class="archiveMessageClass"></div>
   <div v-if="showAdvancedParams" class="well">

--- a/templates/actions/admin-backups.twig
+++ b/templates/actions/admin-backups.twig
@@ -1,0 +1,24 @@
+{{ include_javascript('javascripts/vendor/vue/vue.js') }}
+{{ include_javascript('javascripts/actions/admin-backups.js', false, true) }}
+{{ include_css('styles/actions/admin-backups.css') }}
+
+<div class="admin-backups-container well">
+  <h1>{{ _t('ADMIN_BACKUPS_TITLE') }}</h1>
+  <h2>{{ _t('ADMIN_BACKUPS_ARCHIVES_LIST') }}</h2>
+  <div v-if="message.length > 0" v-html="message" :class="messageClass"></div>
+  <div v-if="ready" class="backups-container">
+    <div class="archive-item archive-item-title">{{ _t('ADMIN_BACKUPS_ARCHIVE_FILENAME') }}</div>
+    <div class="archive-item archive-item-title">{{ _t('ADMIN_BACKUPS_ARCHIVE_TYPE') }}</div>
+    <div class="archive-item archive-item-title"></div>
+    <template v-for="archive in archives">
+      <div class="archive-item" v-html="archive.filename"></div>
+      <div class="archive-item">
+        <i v-if="archive.type == 'only_files'" class="fas fa-copy" data-toggle="tooltip" title="{{ _t('ONLY_FILES') }}"></i>
+        <i v-if="archive.type == 'only_db'" class="fas fa-database" data-toggle="tooltip" title="{{ _t('ONLY_DB') }}"></i>
+      </div>
+      <div class="archive-item"  @click="deleteArchive(archive)"><button>{{ _t('DELETE') }}</button></div>
+    </template>
+    <spinner-loader v-if="updating"></spinner-loader>
+  </div>
+  <spinner-loader v-else height="300"></spinner-loader>
+</div>

--- a/templates/actions/admin-backups.twig
+++ b/templates/actions/admin-backups.twig
@@ -32,6 +32,10 @@
         <button class="btn btn-xs btn-danger" @click="deleteArchive(archive)" data-tooltip="toggle" title="{{ _t('DELETE') }}">
           <i class="fa fa-trash"></i>
         </button>
+        {# TODO uncomment folowwing lines when restore will work #}
+        {# <button class="btn btn-xs btn-secondary-1" @click="restoreArchive(archive)" data-tooltip="toggle" title="{{ _t('RESTORE') }}">
+          <i class="fas fa-upload"></i>
+        </button> #}
       </div>
       <div class="archive-item" @click="toggleSelectedArchive(archive.filename)">
         <input 

--- a/templates/actions/admin-backups.twig
+++ b/templates/actions/admin-backups.twig
@@ -4,6 +4,72 @@
 
 <div class="admin-backups-container well">
   <h1>{{ _t('ADMIN_BACKUPS_TITLE') }}</h1>
+  <h2>{{ _t('ADMIN_BACKUPS_CREATE') }}</h2>
+  <button 
+      @click="startArchive"
+      class="btn btn-xs btn-primary"
+      :disabled="updating" 
+      data-tooltip="toggle" 
+      title="{{ _t('ADMIN_BACKUPS_CREATE') }}">
+    {{ _t('ADMIN_BACKUPS_START') }}
+  </button>
+  <span @click="showAdvancedParams = !showAdvancedParams">
+    <input 
+      type="checkbox" 
+      name="advanced-params" 
+      value="1" 
+      :checked="showAdvancedParams">
+    <span>{{ _t('ADMIN_BACKUPS_ADVANCED_PARAMS') }}</span>
+  </span>
+  <div v-if="showAdvancedParams" class="well">
+    <div class="input-group input-group-sm">
+      <div class="input-group-prepend">
+        <span class="input-group-text">{{ _t('ADMIN_BACKUPS_ARCHIVE_TYPE') }}</span>
+      </div>
+      <label for="adminBackupsTypeFull">
+        <input class="form-control" type="radio" id="adminBackupsTypeFull" value="full" name="adminBackupsType" ref="adminBackupsTypeFull" 
+          @click="updateType" :checked="savefiles && savedatabase"/>
+        <span>{{ _t('ADMIN_BACKUPS_ARCHIVE_TYPE_FULL') }}</span>
+      </label>
+      <label for="adminBackupsTypeOnlyFiles">
+        <input class="control" type="radio" id="adminBackupsTypeOnlyFiles" value="only_files" name="adminBackupsType" ref="adminBackupsTypeOnlyFiles" 
+          @click="updateType" :checked="savefiles && !savedatabase"/>
+        <span>{{ _t('ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_FILES') }}</span>
+      </label>
+      <label for="adminBackupsTypeOnlyDb">
+        <input class="control" type="radio" id="adminBackupsTypeOnlyDb" value="only_db" name="adminBackupsType" ref="adminBackupsTypeOnlyDb"
+          @click="updateType" :checked="!savefiles && savedatabase"/>
+        <span>{{ _t('ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_DATABASES') }}</span>
+      </label>
+    </div>
+    <div>
+      <h3>{{ _t('ADMIN_BACKUPS_ADVANCED_EXTRA_FILES') }}</h3>
+      <template v-for="file in extrafiles">
+        <div>
+          <span v-html="file"></span>
+          <button class="btn btn-xs btn-danger" @click="removeExtraFile(file)">
+            <i class="fas fa-minus"></i>
+          </button>
+        </div>
+      </template>
+      <input class="form-control" type="test" ref="newExtraFile" 
+          @change="updateExtraFiles"/>
+    </div>
+    <div>
+      <h3>{{ _t('ADMIN_BACKUPS_ADVANCED_EXCLUDED_FILES') }}</h3>
+      <template v-for="file in excludedfiles">
+        <div>
+          <span v-html="file"></span>
+          <button class="btn btn-xs btn-danger" @click="removeExcludedFile(file)">
+            <i class="fas fa-minus"></i>
+          </button>
+        </div>
+      </template>
+      <input class="form-control" type="test" ref="newExcludedFile" 
+          @change="updateExcludedFiles"/>
+    </div>
+  </div>
+  <hr/>
   <div class="pull-right btn btn-xs btn-primary" @click="loadArchives" data-tooltip="toogle" title="{{ _t('RELOAD') }}"><i class="fas fa-redo-alt"></i></div>
   <h2>{{ _t('ADMIN_BACKUPS_ARCHIVES_LIST') }}</h2>
   <div class="clearfix"></div>
@@ -14,7 +80,12 @@
     <div class="archive-item archive-item-title">{{ _t('ADMIN_BACKUPS_ARCHIVE_TYPE') }}</div>
     <div class="archive-item archive-item-title"></div>
     <div class="archive-item archive-item-title">
-      <button class="btn btn-xs btn-warning btn-wrap" @click="deleteSelectedArchives" data-toggle="tooltip" title="{{ _t('DELETE_ALL_SELECTED_ITEMS')|e('html_attr') }}">
+      <button 
+          class="btn btn-xs btn-warning btn-wrap"
+          @click="deleteSelectedArchives"
+          data-toggle="tooltip"
+          title="{{ _t('DELETE_ALL_SELECTED_ITEMS')|e('html_attr') }}"
+          :disabled="updating">
         {{ _t('DELETE_SELECTION') }}
       </button>
     </div>
@@ -22,14 +93,19 @@
       <div class="archive-item archive-filename" v-html="archive.filename"></div>
       <div class="archive-item" v-html="formatFileSize(archive.size)"></div>
       <div class="archive-item">
-        <i v-if="archive.type == 'only_files'" class="fas fa-copy" data-toggle="tooltip" title="{{ _t('ONLY_FILES') }}"></i>
-        <i v-if="archive.type == 'only_db'" class="fas fa-database" data-toggle="tooltip" title="{{ _t('ONLY_DB') }}"></i>
+        <i v-if="archive.type == 'only_files'" class="fas fa-copy" data-toggle="tooltip" title="{{ _t('ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_FILES') }}"></i>
+        <i v-if="archive.type == 'only_db'" class="fas fa-database" data-toggle="tooltip" title="{{ _t('ADMIN_BACKUPS_ARCHIVE_TYPE_ONLY_DATABASES') }}"></i>
       </div>
       <div class="archive-item">
         <a :href="downloadUrl(archive)" class="btn btn-xs btn-primary" data-tooltip="toggle" title="{{ _t('DOWNLOAD') }}">
           <i class="fas fa-download"></i>
         </a>
-        <button class="btn btn-xs btn-danger" @click="deleteArchive(archive)" data-tooltip="toggle" title="{{ _t('DELETE') }}">
+        <button 
+            class="btn btn-xs btn-danger" 
+            @click="deleteArchive(archive)" 
+            data-tooltip="toggle" 
+            title="{{ _t('DELETE') }}"
+            :disabled="updating">
           <i class="fa fa-trash"></i>
         </button>
         {# TODO uncomment folowwing lines when restore will work #}

--- a/templates/actions/admin-backups.twig
+++ b/templates/actions/admin-backups.twig
@@ -2,11 +2,12 @@
 {{ include_javascript('javascripts/actions/admin-backups.js', false, true) }}
 {{ include_css('styles/actions/admin-backups.css') }}
 
-<div class="admin-backups-container well">
+<div class="admin-backups-container">
   <h1>{{ _t('ADMIN_BACKUPS_TITLE') }}</h1>
   <h2>{{ _t('ADMIN_BACKUPS_CREATE') }}</h2>
   <div class="archive-buttons">
     <button 
+        v-if="currentArchiveUid.length == 0 || !archiving"
         @click="startArchive"
         class="btn btn-xs btn-primary"
         :disabled="updating || currentArchiveUid.length > 0 || archiving" 
@@ -14,14 +15,6 @@
         title="{{ _t('ADMIN_BACKUPS_CREATE') }}">
       {{ _t('ADMIN_BACKUPS_START') }}
     </button>
-    <span @click="showAdvancedParams = !showAdvancedParams">
-      <input 
-        type="checkbox" 
-        name="advanced-params" 
-        value="1" 
-        :checked="showAdvancedParams">
-      <span>{{ _t('ADMIN_BACKUPS_ADVANCED_PARAMS') }}</span>
-    </span>
     <button
         v-if="currentArchiveUid.length > 0 && archiving"
         @click="stopArchive"
@@ -31,6 +24,14 @@
         title="{{ _t('ADMIN_BACKUPS_STOP_BACKUP') }}">
       {{ _t('ADMIN_BACKUPS_STOP') }}
     </button>
+    <span @click="showAdvancedParams = !showAdvancedParams">
+      <input 
+        type="checkbox" 
+        name="advanced-params" 
+        value="1" 
+        :checked="showAdvancedParams">
+      <span>{{ _t('ADMIN_BACKUPS_ADVANCED_PARAMS') }}</span>
+    </span>
   </div>
   <div v-if="archiveMessage.length > 0" v-html="archiveMessage" :class="archiveMessageClass"></div>
   <div v-if="archiveMessage.length > 0 && askConfirmationToDelete"

--- a/templates/actions/admin-backups.twig
+++ b/templates/actions/admin-backups.twig
@@ -42,7 +42,7 @@
         <span></span>
       </div>
     </template>
-    <spinner-loader v-if="updating"></spinner-loader>
+    <spinner-loader v-if="updating" class="overlay"></spinner-loader>
   </div>
   <spinner-loader v-else height="300"></spinner-loader>
 </div>

--- a/templates/actions/admin-backups.twig
+++ b/templates/actions/admin-backups.twig
@@ -33,6 +33,15 @@
     </button>
   </div>
   <div v-if="archiveMessage.length > 0" v-html="archiveMessage" :class="archiveMessageClass"></div>
+  <div v-if="archiveMessage.length > 0 && askConfirmationToDelete"
+    @click="toggleconfimationToDeleteFiles()">
+    <input 
+      type="checkbox" 
+      name="confimationToDeleteFiles" 
+      value="1" 
+      :checked="canForceDelete">
+    <span>{{ _t('ADMIN_BACKUPS_CONFIRM_DELETE_FILES') }}</span>
+  </div>
   <div v-if="showAdvancedParams" class="well">
     <div class="input-group input-group-sm">
       <div class="input-group-prepend">

--- a/templates/actions/admin-backups.twig
+++ b/templates/actions/admin-backups.twig
@@ -4,19 +4,43 @@
 
 <div class="admin-backups-container well">
   <h1>{{ _t('ADMIN_BACKUPS_TITLE') }}</h1>
+  <div class="pull-right btn btn-xs btn-primary" @click="loadArchives" data-tooltip="toogle" title="{{ _t('RELOAD') }}"><i class="fas fa-redo-alt"></i></div>
   <h2>{{ _t('ADMIN_BACKUPS_ARCHIVES_LIST') }}</h2>
+  <div class="clearfix"></div>
   <div v-if="message.length > 0" v-html="message" :class="messageClass"></div>
   <div v-if="ready" class="backups-container">
     <div class="archive-item archive-item-title">{{ _t('ADMIN_BACKUPS_ARCHIVE_FILENAME') }}</div>
+    <div class="archive-item archive-item-title">{{ _t('ADMIN_BACKUPS_ARCHIVE_SIZE') }}</div>
     <div class="archive-item archive-item-title">{{ _t('ADMIN_BACKUPS_ARCHIVE_TYPE') }}</div>
     <div class="archive-item archive-item-title"></div>
+    <div class="archive-item archive-item-title">
+      <button class="btn btn-xs btn-warning btn-wrap" @click="deleteSelectedArchives" data-toggle="tooltip" title="{{ _t('DELETE_ALL_SELECTED_ITEMS')|e('html_attr') }}">
+        {{ _t('DELETE_SELECTION') }}
+      </button>
+    </div>
     <template v-for="archive in archives">
-      <div class="archive-item" v-html="archive.filename"></div>
+      <div class="archive-item archive-filename" v-html="archive.filename"></div>
+      <div class="archive-item" v-html="formatFileSize(archive.size)"></div>
       <div class="archive-item">
         <i v-if="archive.type == 'only_files'" class="fas fa-copy" data-toggle="tooltip" title="{{ _t('ONLY_FILES') }}"></i>
         <i v-if="archive.type == 'only_db'" class="fas fa-database" data-toggle="tooltip" title="{{ _t('ONLY_DB') }}"></i>
       </div>
-      <div class="archive-item"  @click="deleteArchive(archive)"><button>{{ _t('DELETE') }}</button></div>
+      <div class="archive-item">
+        <a :href="downloadUrl(archive)" class="btn btn-xs btn-primary" data-tooltip="toggle" title="{{ _t('DOWNLOAD') }}">
+          <i class="fas fa-download"></i>
+        </a>
+        <button class="btn btn-xs btn-danger" @click="deleteArchive(archive)" data-tooltip="toggle" title="{{ _t('DELETE') }}">
+          <i class="fa fa-trash"></i>
+        </button>
+      </div>
+      <div class="archive-item" @click="toggleSelectedArchive(archive.filename)">
+        <input 
+          type="checkbox" 
+          :name="archive.filename" 
+          value="1" 
+          :checked="selectedArchivesToDelete.includes(archive.filename)">
+        <span></span>
+      </div>
     </template>
     <spinner-loader v-if="updating"></spinner-loader>
   </div>

--- a/templates/preupdate-backup.twig
+++ b/templates/preupdate-backup.twig
@@ -2,14 +2,13 @@
 {{ include_javascript('javascripts/actions/admin-backups.js', false, true) }}
 {{ include_css('styles/actions/admin-backups.css') }}
 
-<div class="preupdate-backups-container well" data-upgrade="{{ upgrade }}">
+<div class="preupdate-backups-container" data-upgrade="{{ upgrade }}">
   <h2>{{ _t('ADMIN_BACKUPS_CREATING') }}</h2>
   <div class="archive-buttons">
     <button
-        v-if="currentArchiveUid.length > 0 && archiving"
         @click="stopArchive"
         class="btn btn-xs btn-danger"
-        :disabled="stoppingArchive" 
+        :disabled="stoppingArchive || currentArchiveUid.length == 0 || !archiving" 
         data-tooltip="toggle" 
         title="{{ _t('ADMIN_BACKUPS_STOP_BACKUP') }}">
       {{ _t('ADMIN_BACKUPS_STOP') }}

--- a/templates/preupdate-backup.twig
+++ b/templates/preupdate-backup.twig
@@ -1,0 +1,47 @@
+{{ include_javascript('javascripts/vendor/vue/vue.js') }}
+{{ include_javascript('javascripts/actions/admin-backups.js', false, true) }}
+{{ include_css('styles/actions/admin-backups.css') }}
+
+<div class="preupdate-backups-container well" data-upgrade="{{ upgrade }}">
+  <h2>{{ _t('ADMIN_BACKUPS_CREATING') }}</h2>
+  <div class="archive-buttons">
+    <button
+        v-if="currentArchiveUid.length > 0 && archiving"
+        @click="stopArchive"
+        class="btn btn-xs btn-danger"
+        :disabled="stoppingArchive" 
+        data-tooltip="toggle" 
+        title="{{ _t('ADMIN_BACKUPS_STOP_BACKUP') }}">
+      {{ _t('ADMIN_BACKUPS_STOP') }}
+    </button>
+    {% if config.archive.authorize_bypass_preupdate_backup %}
+        <button
+            @click="bypassArchive"
+            class="btn btn-sm btn-danger"
+            data-tooltip="toggle" 
+            title="{{ _t('ADMIN_BACKUPS_BY_PASS') }}">
+        {{ _t('ADMIN_BACKUPS_BY_PASS') }}
+        </button>
+    {% endif %}
+  </div>
+  <div v-if="archiveMessage.length > 0" v-html="archiveMessage" :class="archiveMessageClass"></div>
+  <div>
+    <a
+        v-if="!archiving && showReturn"
+        href="{{ url({params:{}}) }}"
+        class="btn btn-sm btn-info"
+        data-tooltip="toggle" 
+        title="{{ _t('GO_BACK') }}">
+      {{ _t('GO_BACK') }}
+    </a>
+    <button
+        v-if="canForceUpdate"
+        @click="forceUpdate"
+        class="btn btn-sm btn-danger"
+        data-tooltip="toggle" 
+        title="{{ _t('ADMIN_BACKUPS_FORCE_UPDATE') }}">
+      {{ _t('ADMIN_BACKUPS_FORCE_UPDATE') }}
+    </button>
+  </div>
+  <div class="clearfix"></div>
+</div>

--- a/tests/includes/services/ArchiveServiceTest.php
+++ b/tests/includes/services/ArchiveServiceTest.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace YesWiki\Test\Core\Commands;
+
+use YesWiki\Core\Service\ArchiveService;
+use YesWiki\Core\Service\ConfigurationService;
+use YesWiki\Test\Core\YesWikiTestCase;
+use YesWiki\Wiki;
+use ZipArchive;
+
+require_once 'tests/YesWikiTestCase.php';
+
+class ArchiveServiceTest extends YesWikiTestCase
+{
+    
+    /**
+     * @covers ArchiveService::__construct
+     * @return array ['wiki'=> $wiki,'archiveService' => $archiveService]
+     */
+    public function testArchiveServiceExisting(): array
+    {
+        $wiki = $this->getWiki();
+        $this->assertTrue($wiki->services->has(ArchiveService::class));
+        return ['wiki' => $wiki,'archiveService' => $wiki->services->get(ArchiveService::class)];
+    }
+
+    
+    /**
+     * @depends testArchiveServiceExisting
+     * @dataProvider archiveProvider
+     * @covers ArchiveService::archive
+     * @param bool $savefiles
+     * @param bool $savedatabase
+     * @param array $extrafiles
+     * @param array $excludedfiles
+     * @param string $locationSuffix
+     * @param null|int $nbFiles
+     * @param array $filesToFind
+     * @param null|array $wakkaContent
+     * @param array $services [$wiki,$archiveService]
+     */
+    public function testArchive(
+        bool $savefiles,
+        bool $savedatabase,
+        array $extrafiles,
+        array $excludedfiles,
+        string $locationSuffix,
+        ?int $nbFiles,
+        array $filesToFind,
+        ?array $wakkaContent,
+        array $services
+    ) {
+        $output = "";
+        $location = $services['archiveService']->archive(
+            $output,
+            $savefiles,
+            $savedatabase,
+            $extrafiles,
+            $excludedfiles,
+        );
+        $data = $this->getDataFromLocation($location,$services['wiki']);
+        $this->assertEmpty($data['error'] ?? "");
+        $this->assertArrayNotHasKey('error',$data);
+        $this->assertMatchesRegularExpression("/^.*".preg_quote(constant("\\YesWiki\\Core\\Service\\ArchiveService::{$locationSuffix}").".zip","/")."$/", $location);
+        if (!is_null($nbFiles) && $nbFiles > -1){
+            $this->assertArrayHasKey('files',$data);
+            $this->assertCount($nbFiles,$data['files']);
+            foreach ($filesToFind as $path) {
+                $this->assertContains($path,$data['files']);
+            }
+            if (!is_null($wakkaContent)){
+                $this->assertArrayHasKey('wakkaContent',$data);
+                $this->checkWakkaContent($wakkaContent,$data['wakkaContent']);
+            }
+        }
+    }
+    
+    public function archiveProvider()
+    {
+        return [
+            'archive only wakka.config.php' => [
+                'savefiles' => true,
+                'savedatabase' => false,
+                'extrafiles' => ['wakka.config.php'],
+                'excludedfiles' => ['*','.*','/var/tmp','../../*','c:\\'],
+                'locationSuffix' => "ARCHIVE_ONLY_FILES_SUFFIX",
+                'nbFiles' => 1,
+                'filesToFind' => ['wakka.config.php'],
+                'wakkaContent' => [
+                    'archive' => [
+                        'extrafiles' => ['wakka.config.php'],
+                        'excludedfiles' => ['*','.*'],
+                    ],
+                    'mysql_host' => '',
+                    'mysql_database' => '',
+                    'mysql_user' => '',
+                    'mysql_password' => '',
+                ]
+            ],
+            'archive only wakka.config.php with database' => [
+                'savefiles' => true,
+                'savedatabase' => true,
+                'extrafiles' => ['wakka.config.php'],
+                'excludedfiles' => ['*','.*'],
+                'locationSuffix' => "ARCHIVE_SUFFIX",
+                'nbFiles' => 1,
+                'filesToFind' => ['wakka.config.php'],
+                'wakkaContent' => [
+                    'archive' => [
+                        'extrafiles' => ['wakka.config.php'],
+                        'excludedfiles' => ['*','.*'],
+                    ],
+                    'mysql_host' => '',
+                    'mysql_database' => '',
+                    'mysql_user' => '',
+                    'mysql_password' => '',
+                ]
+            ],
+            'archive only database' => [
+                'savefiles' => false,
+                'savedatabase' => true,
+                'extrafiles' => ['wakka.config.php'],
+                'excludedfiles' => ['*','.*'],
+                'locationSuffix' => "ARCHIVE_ONLY_DATABASE_SUFFIX",
+                'nbFiles' => 1,
+                'filesToFind' => ['wakka.config.php'],
+                'wakkaContent' => [
+                    'archive' => [
+                        'extrafiles' => ['wakka.config.php'],
+                        'excludedfiles' => ['*','.*'],
+                    ],
+                    'mysql_host' => '',
+                    'mysql_database' => '',
+                    'mysql_user' => '',
+                    'mysql_password' => '',
+                ]
+            ],
+            'archive only wakka.config.php and tools/bazar/config.yaml' => [
+                'savefiles' => true,
+                'savedatabase' => false,
+                'extrafiles' => ['wakka.config.php','tools/bazar/config.yaml'],
+                'excludedfiles' => ['*','.*'],
+                'locationSuffix' => "ARCHIVE_ONLY_FILES_SUFFIX",
+                'nbFiles' => 4,
+                'filesToFind' => ['wakka.config.php','tools/bazar/config.yaml'],
+                'wakkaContent' => [
+                    'archive' => [
+                        'extrafiles' => ['wakka.config.php','tools/bazar/config.yaml'],
+                        'excludedfiles' => ['*','.*'],
+                    ],
+                    'mysql_host' => '',
+                    'mysql_database' => '',
+                    'mysql_user' => '',
+                    'mysql_password' => '',
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * retrieve data from location
+     * delete the zip file because only for tests
+     * @param string $location
+     * @param Wiki $wiki
+     * @return array $data
+     */
+    private function getDataFromLocation(string $location,Wiki $wiki): array
+    {
+        $data = [];
+        if (!empty($location) && file_exists($location)){
+            if (!preg_match("/^.*\.zip$/",$location)){
+                $data['error'] = "\"\$location\" (\"$location\") is not a zip file !";
+            } else {
+                $zip = new ZipArchive;
+                if ($zip->open($location) !== TRUE) {
+                    $data['error'] = "\"\$location\" (\"$location\") is not openable !";
+                } else {
+                    // create tmp folder in cache
+                    do {
+                        $tmpFolderName = "tmp_folder_to_delete_".md5(time());
+                    } while (file_exists("cache/$tmpFolderName"));
+                    if (!$zip->extractTo("cache/$tmpFolderName")){
+                        $data['error'] = "\"\$location\" (\"$location\") is not extractable !";
+                        $zip->close();
+                    } else {
+                        $zip->close();
+                        $files = [];
+                        foreach([
+                            "*",".?*",
+                            "*/*",".[\\.]*/*","*/.[\\.]*",".[\\.]*/.[\\.]*",
+                            "*/*/*",".[\\.]*/*/*","*/.[\\.]*/*",".[\\.]*/.[\\.]*/*",
+                            "*/*/*/*",".[\\.]*/*/*/*","*/.[\\.]*/*/*",".*/.[\\.]*/*/*",
+                        ] as $globCatch){
+                            foreach(glob("cache/$tmpFolderName/$globCatch") as $path){
+                                if (!in_array(basename($path),['.','..']) && !in_array($path,$files)){
+                                    $files[] = $path;
+                                }
+                            }
+                        }
+                        $files = array_map(function ($path) use ($tmpFolderName){
+                            return str_replace("\\","/",preg_replace("/^cache(?:\/|\\\\)".preg_quote($tmpFolderName,"/")."(?:\/|\\\\)/","",$path));
+                        },$files);
+                        $data['files'] = $files;
+
+                        // wakka content
+                        if (file_exists("cache/$tmpFolderName/wakka.config.php") && is_file("cache/$tmpFolderName/wakka.config.php")){
+                            $configurationService = $wiki->services->get(ConfigurationService::class);
+                            $config = $configurationService->getConfiguration("cache/$tmpFolderName/wakka.config.php");
+                            $config->load();
+                            $data['wakkaContent'] = $config->_parameters;
+                            unset($config);
+                        }
+                        $this->recursiveDelete("cache/$tmpFolderName");
+                    }
+                }
+            }
+            unlink($location);
+        } else {
+            $data['error'] = "\"\$location\" (\"$location\") is not a file !";
+        }
+        return $data;
+    }
+
+    private function recursiveDelete(string $path)
+    {
+        if (!in_array(basename($path),['.','..']) && !preg_match("/(?:^|\/|\\\\)\.{1,2}(?:^|\/|\\\\)/",$path)){
+            if (file_exists($path)){
+                if (is_dir($path)){
+                    $dh = opendir($path);
+                    while (false !== ($file = readdir($dh))) {
+                        $this->recursiveDelete("$path/$file");
+                    }
+                    closedir($dh);
+                    rmdir($path);
+                } elseif (is_file($path)){
+                    unlink($path);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param mixed $contentDefinition
+     * @param mixed $contentToCheck
+     */
+    private function checkWakkaContent($contentDefinition, $contentToCheck)
+    {
+        if (is_array($contentDefinition)){
+            $this->assertIsArray($contentToCheck);
+            foreach($contentDefinition as $key => $value){
+                $this->assertArrayHasKey($key,$contentToCheck);
+                $this->checkWakkaContent($contentDefinition[$key],$contentToCheck[$key]);
+            }
+        } elseif (is_scalar($contentDefinition)) {
+            $this->assertEquals($contentDefinition,$contentToCheck);
+        }
+    }
+}

--- a/tests/includes/services/ArchiveServiceTest.php
+++ b/tests/includes/services/ArchiveServiceTest.php
@@ -364,16 +364,17 @@ class ArchiveServiceTest extends YesWikiTestCase
             $this->unsetAnonymousParam($configService);
         }
 
+        $location = null;
         foreach ($results as $result) {
             if (isset($result['stdout'])) {
-                if (preg_match("/^Archive \\\"(.*)\\\" successfully created !\s*$/m", $result['stdout'], $matches)) {
+                if (preg_match("/^Archive \\\"(.*)\\\" successfully created !\s*END\s*$/m", $result['stdout'], $matches)) {
                     $location = $matches[1];
                 }
                 break;
             }
         }
         
-        $this->assertNotEmpty($location);
+        $this->assertNotEmpty($location, "Bad format of stdout");
         $this->assertTrue(is_file($location), "Extracted location is not a file !");
         $data = $this->getDataFromLocation($location, $services['wiki']);
         $error = $data['error'] ?? "";

--- a/tests/includes/services/ConsoleServiceTest.php
+++ b/tests/includes/services/ConsoleServiceTest.php
@@ -127,17 +127,18 @@ class ConsoleServiceTest extends YesWikiTestCase
      * @depends testConsoleServiceExisting
      * @param ConsoleService $consoleService
      */
-    public function testAsync(ConsoleService $consoleService) {
+    public function testAsync(ConsoleService $consoleService)
+    {
         $tmp_path = tempnam('cache', 'tmp_test_results_');
         $tmpfile = basename($tmp_path);
         $process = $consoleService->startConsoleAsync("core:testconsoleservice", [
             "-f",$tmpfile,
             "-t","ParentProcess",
             "-c","ChildProcess",
-            "-w",2,
+            "-w",1,
         ]);
         $process->wait();
-        sleep(3);
+        sleep(2);
 
         $content = file_get_contents($tmp_path);
         unlink($tmp_path);

--- a/tests/includes/services/ConsoleServiceTest.php
+++ b/tests/includes/services/ConsoleServiceTest.php
@@ -121,4 +121,26 @@ class ConsoleServiceTest extends YesWikiTestCase
             ],
         ];
     }
+
+    
+    /**
+     * @depends testConsoleServiceExisting
+     * @param ConsoleService $consoleService
+     */
+    public function testAsync(ConsoleService $consoleService) {
+        $tmp_path = tempnam('cache', 'tmp_test_results_');
+        $tmpfile = basename($tmp_path);
+        $process = $consoleService->startConsoleAsync("core:testconsoleservice", [
+            "-f",$tmpfile,
+            "-t","ParentProcess",
+            "-c","ChildProcess",
+            "-w",2,
+        ]);
+        $process->wait();
+        sleep(3);
+
+        $content = file_get_contents($tmp_path);
+        unlink($tmp_path);
+        $this->assertMatchesRegularExpression("/^ParentProcessChildProcess$/", $content);
+    }
 }

--- a/tests/includes/services/ConsoleServiceTest.php
+++ b/tests/includes/services/ConsoleServiceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace YesWiki\Test\Core\Commands;
+
+use YesWiki\Core\Service\ConsoleService;
+use YesWiki\Test\Core\YesWikiTestCase;
+
+require_once 'tests/YesWikiTestCase.php';
+
+class ConsoleServiceTest extends YesWikiTestCase
+{
+    
+    /**
+     * @return ConsoleService
+     */
+    public function testConsoleServiceExisting(): ConsoleService
+    {
+        $wiki = $this->getWiki();
+        $this->assertTrue($wiki->services->has(ConsoleService::class));
+        return $wiki->services->get(ConsoleService::class);
+    }
+
+    /**
+     * @depends testConsoleServiceExisting
+     * @dataProvider checkStartConsole
+     * @covers ConsoleService::startConsoleAsync
+     * @param string $command
+     * @param array $args
+     * @param bool $processIsNull
+     * @param null|string $stdout
+     * @param null|string $stderr
+     * @param ConsoleService $consoleService
+     */
+    public function testStartConsoleAsync(
+        string $command,
+        array $args,
+        bool $processIsNull,
+        ?string $stdout,
+        ?string $stderr,
+        ConsoleService $consoleService
+    ) {
+        $process = $consoleService->startConsoleAsync($command, $args);
+        if ($processIsNull) {
+            $this->assertNull($process);
+        } else {
+            $this->assertNotNull($process);
+            $process->wait();
+            $results = $consoleService->getProcessOut($process);
+            $this->assertNotNull($results);
+            $result = $results[array_key_first($results)];
+            if (!is_null($stdout)) {
+                $this->assertArrayHasKey('stdout', $result);
+                $this->assertMatchesRegularExpression($stdout, $result['stdout']);
+            }
+            if (!is_null($stderr)) {
+                $this->assertArrayHasKey('stderr', $result);
+                $this->assertMatchesRegularExpression($stderr, $result['stderr']);
+            }
+        }
+    }
+    
+    /**
+     * @depends testConsoleServiceExisting
+     * @dataProvider checkStartConsole
+     * @covers ConsoleService::startConsoleSync
+     * @param string $command
+     * @param array $args
+     * @param bool $processIsNull
+     * @param null|string $stdout
+     * @param null|string $stderr
+     * @param ConsoleService $consoleService
+     */
+    public function testStartConsoleSync(
+        string $command,
+        array $args,
+        bool $processIsNull,
+        ?string $stdout,
+        ?string $stderr,
+        ConsoleService $consoleService
+    ) {
+        $results = $consoleService->startConsoleSync($command, $args);
+        if ($processIsNull) {
+            $this->assertNull($results);
+        } else {
+            $this->assertNotNull($results);
+            $result = $results[array_key_first($results)];
+            if (!is_null($stdout)) {
+                $this->assertArrayHasKey('stdout', $result);
+                $this->assertMatchesRegularExpression($stdout, $result['stdout']);
+            }
+            if (!is_null($stderr)) {
+                $this->assertArrayHasKey('stderr', $result);
+                $this->assertMatchesRegularExpression($stderr, $result['stderr']);
+            }
+        }
+    }
+    
+    public function checkStartConsole()
+    {
+        return [
+            'hello command ok' => [
+                'command' => 'helloworld:hello',
+                'args' => [],
+                'processIsNull' => false,
+                'stdout' => "/^Hello !(?:\r|\n)+/",
+                'stderr' => null
+            ],
+            'hello command with args ok' => [
+                'command' => 'helloworld:hello',
+                'args' => ['John Smith'],
+                'processIsNull' => false,
+                'stdout' => "/^Hello John Smith !(?:\r|\n)+/",
+                'stderr' => null
+            ],
+            'not existing command' => [
+                'command' => 'nocommand:nocommand',
+                'args' => [''],
+                'processIsNull' => false,
+                'stdout' => null,
+                'stderr' => "/^\\s*There are no commands defined in the \"nocommand\" namespace\\.\\s+/"
+            ],
+        ];
+    }
+}

--- a/tools/autoupdate/app/AutoUpdate.php
+++ b/tools/autoupdate/app/AutoUpdate.php
@@ -1,6 +1,8 @@
 <?php
 namespace AutoUpdate;
 
+use YesWiki\Core\Service\ConfigurationService;
+
 class AutoUpdate
 {
     const DEFAULT_REPO = 'https://repository.yeswiki.net/';
@@ -9,9 +11,12 @@ class AutoUpdate
     private $wiki;
     public $repository = null;
 
+    protected $configurationService;
+
     public function __construct($wiki)
     {
         $this->wiki = $wiki;
+        $this->configurationService = $wiki->services->get(ConfigurationService::class);
     }
 
     /*	Parameter $requestedVersion contains the name of the YesWiki version
@@ -31,7 +36,7 @@ class AutoUpdate
 
     public function getWikiConfiguration()
     {
-        $configuration = new Configuration(
+        $configuration = $this->configurationService->getConfiguration(
             $this->getWikiDir() . '/wakka.config.php'
         );
         $configuration->load();

--- a/tools/autoupdate/app/Configuration.php
+++ b/tools/autoupdate/app/Configuration.php
@@ -1,68 +1,9 @@
 <?php
 namespace AutoUpdate;
+// TODO delete this file whan passing to ectoplasme
 
-class Configuration extends Collection
+use YesWiki\Core\Entity\ConfigurationFile;
+
+class Configuration extends ConfigurationFile
 {
-    private $file = null;
-
-    public function __construct($file)
-    {
-        $this->file = $file;
-    }
-
-    public function load()
-    {
-        include $this->file;
-        if (isset($wakkaConfig)) {
-            $this->list = $wakkaConfig;
-        }
-    }
-
-    public function write($file = null, $arrayName = "wakkaConfig")
-    {
-        if (is_null($file)) {
-            $file = $this->file;
-        }
-
-        // Bidouille pour eviter l'export de classe par var_export mais
-        // uniquement de la valeur
-        $release = $this->list['yeswiki_release'];
-        $this->list['yeswiki_release'] = (string)$this->list['yeswiki_release'];
-        $content = "<?php\n" . "\$$arrayName = ";
-        $content .= $this->customVarExport($this->list, true);
-        $content .= ";\n";
-
-        $this->list['yeswiki_release'] = $release;
-
-        if (file_put_contents($file, $content) === false) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * PHP var_export() with short array syntax (square brackets) indented 2 spaces.
-     * tips : https://www.php.net/manual/en/function.var-export.php#124194
-     * NOTE: The only issue is when a string value has `=>\n[`, it will get converted to `=> [`
-     * @param mixed $expression
-     * @param bool $return
-     * @return null|string
-     */
-    private function customVarExport($expression, $return=false): ?string
-    {
-        $export = var_export($expression, true);
-        $patterns = [
-            "/array \(/" => '[',
-            "/^([ ]*)\)(,?)$/m" => '$1]$2',
-            "/=>[ ]?\n[ ]+\[/" => '=> [',
-            "/([ ]*)(\'[^\']+\') => ([\[\'])/" => '$1$2 => $3',
-        ];
-        $export = preg_replace(array_keys($patterns), array_values($patterns), $export);
-        if ((bool)$return) {
-            return $export;
-        } else {
-            echo $export;
-            return null;
-        }
-    }
 }

--- a/tools/autoupdate/app/Controller.php
+++ b/tools/autoupdate/app/Controller.php
@@ -1,6 +1,7 @@
 <?php
 namespace AutoUpdate;
 
+use YesWiki\Core\Service\ArchiveService;
 use YesWiki\Security\Controller\SecurityController;
 
 /**
@@ -20,6 +21,7 @@ class Controller
         $this->autoUpdate = $autoUpdate;
         $this->messages = $messages;
         $this->wiki = $wiki;
+        $this->archiveService = $this->wiki->services->get(ArchiveService::class);
         $this->securityController = $this->wiki->services->get(SecurityController::class);
     }
 
@@ -44,6 +46,11 @@ class Controller
             $previousMessages = [];
             foreach ($this->messages as $message) {
                 $previousMessages[] = $message;
+            }
+            if (!$this->archiveService->hasValidatedBackup($get['forcedUpdateToken'] ?? "")) {
+                return $this->wiki->render("@core/preupdate-backup.twig", [
+                    'upgrade' => strval($get['upgrade'])
+                ]);
             }
             $this->upgrade($get['upgrade']);
             if ($get['upgrade'] == 'yeswiki') {

--- a/tools/autoupdate/app/PackageCore.php
+++ b/tools/autoupdate/app/PackageCore.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace AutoUpdate;
 
 class PackageCore extends Package
 {
-    const CORE_NAME = 'yeswiki';
+    public const CORE_NAME = 'yeswiki';
     public const IGNORED_FILES = [
         '.',
         '..',
@@ -13,9 +14,10 @@ class PackageCore extends Package
         'cache',
         'themes',
         'robots.txt',
-        'wakka.config.php'
+        'wakka.config.php',
+        'private'
     ];
-    
+
     public const FILES_TO_ADD_TO_IGNORED_FOLDERS = [
         'files/README.md',
         'files/LovelaceAda_lovelace.png',

--- a/tools/autoupdate/commands/PostUpdaterCommand.php
+++ b/tools/autoupdate/commands/PostUpdaterCommand.php
@@ -8,7 +8,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 // use Symfony\Component\Console\Question\ChoiceQuestion;
 // use YesWiki\Bazar\Service\EntryManager;
+use YesWiki\Core\Controller\AuthController;
+use YesWiki\Core\Controller\UserController;
 // use YesWiki\Core\Service\PageManager;
+use YesWiki\Core\Service\UserManager;
 use YesWiki\Wiki;
 
 class PostUpdaterCommand extends Command
@@ -39,18 +42,30 @@ class PostUpdaterCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         ob_start();
-        $this->wiki->Run($this->wiki->getPageTag(), 'update');
-        $bufferedOutput = ob_get_contents();
-        ob_end_clean();
+        // little hack (bad habit..): we use the first admin user to perform updates as an admin
+        $firstAdminName = $wiki->services->get(UserController::class)->getFirstAdmin();
+        if (!empty($firstAdminName)) {
+            $userManager = $wiki->services->get(UserManager::class);
+            $authController = $wiki->services->get(AuthController::class);
+            $firstAdmin = $userManager->getOneByName($firstAdminName);
+            if (!empty($firstAdmin)) {
+                $authController->login($firstAdmin);
 
-        $bufferedOutput = strip_tags($bufferedOutput, '<br><hr><em><strong>');
-        $bufferedOutput = preg_replace(
-            ['#<[bh]r ?/?>#Ui', '/<(em|strong)>/Ui', '#</ ?(em|strong)>#Ui'],
-            ["\n", "\e[1m", "\e[0m"],
-            $bufferedOutput
-        );
-        $output->write($bufferedOutput);
+                $this->wiki->Run($this->wiki->getPageTag(), 'update');
+                $bufferedOutput = ob_get_contents();
+                ob_end_clean();
 
-        return Command::SUCCESS;
+                $bufferedOutput = strip_tags($bufferedOutput, '<br><hr><em><strong>');
+                $bufferedOutput = preg_replace(
+                    ['#<[bh]r ?/?>#Ui', '/<(em|strong)>/Ui', '#</ ?(em|strong)>#Ui'],
+                    ["\n", "\e[1m", "\e[0m"],
+                    $bufferedOutput
+                );
+                $output->write($bufferedOutput);
+
+                return Command::SUCCESS;
+            }
+        }
+        return Command::FAILURE;
     }
 }

--- a/tools/autoupdate/commands/PostUpdaterCommand.php
+++ b/tools/autoupdate/commands/PostUpdaterCommand.php
@@ -7,10 +7,8 @@ use Symfony\Component\Console\Input\InputInterface;
 // use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 // use Symfony\Component\Console\Question\ChoiceQuestion;
-// use YesWiki\Bazar\Service\EntryManager;
 use YesWiki\Core\Controller\AuthController;
 use YesWiki\Core\Controller\UserController;
-// use YesWiki\Core\Service\PageManager;
 use YesWiki\Core\Service\UserManager;
 use YesWiki\Wiki;
 

--- a/tools/autoupdate/commands/UpdaterCommand.php
+++ b/tools/autoupdate/commands/UpdaterCommand.php
@@ -8,8 +8,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 // use Symfony\Component\Console\Question\ChoiceQuestion;
 use YesWiki\Core\Controller\AuthController;
-use YesWiki\Core\Controller\UserController;
-use YesWiki\Core\Service\UserManager;
 use YesWiki\Wiki;
 
 class UpdaterCommand extends Command
@@ -40,28 +38,10 @@ class UpdaterCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         // little hack (bad habit..): we use the first admin user to perform updates as an admin
-        $firstAdminName = $wiki->services->get(UserController::class)->getFirstAdmin();
-        if (!empty($firstAdminName)) {
-            $userManager = $wiki->services->get(UserManager::class);
-            $authController = $wiki->services->get(AuthController::class);
-            $firstAdmin = $userManager->getOneByName($firstAdminName);
-            if (!empty($firstAdmin)) {
-                $authController->login($firstAdmin);
-
-
-                $output->writeln('TODO ;)');
-
-                $bufferedOutput = ob_get_contents();
-                ob_end_clean();
-
-                $bufferedOutput = strip_tags($bufferedOutput, '<br><hr><em><strong>');
-                $bufferedOutput = preg_replace(
-                    ['#<[bh]r ?/?>#Ui', '/<(em|strong)>/Ui', '#</ ?(em|strong)>#Ui'],
-                    ["\n", "\e[1m", "\e[0m"],
-                    $bufferedOutput
-                );
-                $output->write($bufferedOutput);
-            }
+        $firstAdmin = $wiki->services->get(AuthController::class)->connectFirstAdmin();
+        if (!empty($firstAdmin)) {
+            $output->writeln('TODO ;)');
+            $wiki->services->get(AuthController::class)->logout();
         }
         return Command::SUCCESS;
     }

--- a/tools/autoupdate/commands/UpdaterCommand.php
+++ b/tools/autoupdate/commands/UpdaterCommand.php
@@ -8,7 +8,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 // use Symfony\Component\Console\Question\ChoiceQuestion;
 // use YesWiki\Bazar\Service\EntryManager;
+use YesWiki\Core\Controller\AuthController;
+use YesWiki\Core\Controller\UserController;
 // use YesWiki\Core\Service\PageManager;
+use YesWiki\Core\Service\UserManager;
 use YesWiki\Wiki;
 
 class UpdaterCommand extends Command
@@ -38,7 +41,30 @@ class UpdaterCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->writeln('TODO ;)');
+        // little hack (bad habit..): we use the first admin user to perform updates as an admin
+        $firstAdminName = $wiki->services->get(UserController::class)->getFirstAdmin();
+        if (!empty($firstAdminName)) {
+            $userManager = $wiki->services->get(UserManager::class);
+            $authController = $wiki->services->get(AuthController::class);
+            $firstAdmin = $userManager->getOneByName($firstAdminName);
+            if (!empty($firstAdmin)) {
+                $authController->login($firstAdmin);
+
+
+                $output->writeln('TODO ;)');
+
+                $bufferedOutput = ob_get_contents();
+                ob_end_clean();
+
+                $bufferedOutput = strip_tags($bufferedOutput, '<br><hr><em><strong>');
+                $bufferedOutput = preg_replace(
+                    ['#<[bh]r ?/?>#Ui', '/<(em|strong)>/Ui', '#</ ?(em|strong)>#Ui'],
+                    ["\n", "\e[1m", "\e[0m"],
+                    $bufferedOutput
+                );
+                $output->write($bufferedOutput);
+            }
+        }
         return Command::SUCCESS;
     }
 }

--- a/tools/autoupdate/commands/UpdaterCommand.php
+++ b/tools/autoupdate/commands/UpdaterCommand.php
@@ -7,10 +7,8 @@ use Symfony\Component\Console\Input\InputInterface;
 // use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 // use Symfony\Component\Console\Question\ChoiceQuestion;
-// use YesWiki\Bazar\Service\EntryManager;
 use YesWiki\Core\Controller\AuthController;
 use YesWiki\Core\Controller\UserController;
-// use YesWiki\Core\Service\PageManager;
 use YesWiki\Core\Service\UserManager;
 use YesWiki\Wiki;
 

--- a/tools/autoupdate/commands/console
+++ b/tools/autoupdate/commands/console
@@ -4,55 +4,10 @@
 
 namespace YesWiki\AutoUpdate\Commands;
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
-use Symfony\Component\Console\Application;
-use YesWiki\AutoUpdate\Commands\UpdaterCommand;
-use YesWiki\AutoUpdate\Commands\PostUpdaterCommand;
-use YesWiki\Core\Controller\AuthController;
-use YesWiki\Core\Controller\UserController;
-use YesWiki\Core\Service\UserManager;
-
 if (!file_exists('wakka.config.php')) {
     exit("\e[31mThe command should be launched from your YesWiki root directory\e[0m");
 } else {
-    include_once('wakka.config.php');
-    // fake $_SERVER vars
-    $_SERVER['REQUEST_URI'] = $wakkaConfig['base_url'].$wakkaConfig['root_page'];
-    $_SERVER['HTTP_HOST'] = parse_url($wakkaConfig['base_url'], PHP_URL_HOST);
-    $_SERVER['REQUEST_METHOD'] = 'GET';
-    // fake wiki page
-    $_REQUEST['wiki'] = $wakkaConfig['root_page'];
-}
-
-
-require_once 'includes/autoload.inc.php';
-$loader = require_once 'vendor/autoload.php';
-AnnotationRegistry::registerLoader([$loader, 'loadClass']);
-require_once __DIR__.'/../vendor/autoload.php';
-
-
-$application = new Application();
-
-require_once 'includes/YesWiki.php';
-$wiki = new \YesWiki\Wiki();
-
-// second little hack (bad habit..): we use the first admin user to perform updates as an admin
-$firstAdminName = $wiki->services->get(UserController::class)->getFirstAdmin();
-if (!empty($firstAdminName)) {
-    $userManager = $wiki->services->get(UserManager::class);
-    $authController = $wiki->services->get(AuthController::class);
-    $firstAdmin = $userManager->getOneByName($firstAdminName);
-    if (!empty($firstAdmin)) {
-        $authController->login($firstAdmin);
-        
-        // ... register commands
-
-        $application->add(new UpdaterCommand($wiki));
-
-        $application->add(new PostUpdaterCommand($wiki));
-
-        $application->run();
-
-        $authController->logout();
-    }
+    // backward compatibility for extension ferme
+    // TODO delete this file
+    include 'includes/commands/console';
 }

--- a/tools/autoupdate/config.yaml
+++ b/tools/autoupdate/config.yaml
@@ -12,3 +12,4 @@ parameters:
     - GererMotsClef
     - TableauDeBord
     - LookWiki
+    - GererSauvegardes

--- a/tools/autoupdate/lang/autoupdate_fr.inc.php
+++ b/tools/autoupdate/lang/autoupdate_fr.inc.php
@@ -59,4 +59,7 @@ return [
     'AU_SEVERAL_TOOLS_UPDATE' => 'Vous avez {nbMaj} extensions à mettre à jour',
     'AU_ONE_TOOL_UPDATE' => 'Vous avez 1 extension à mettre à jour',
 
+    // tools/templates/autoupdate/core.twig
+    'AU_MANAGE_BACKUPS' => 'Gérer les sauvegardes',
+
 ];

--- a/tools/autoupdate/lang/autoupdate_fr.inc.php
+++ b/tools/autoupdate/lang/autoupdate_fr.inc.php
@@ -59,7 +59,4 @@ return [
     'AU_SEVERAL_TOOLS_UPDATE' => 'Vous avez {nbMaj} extensions à mettre à jour',
     'AU_ONE_TOOL_UPDATE' => 'Vous avez 1 extension à mettre à jour',
 
-    // tools/templates/autoupdate/core.twig
-    'AU_MANAGE_BACKUPS' => 'Gérer les sauvegardes',
-
 ];

--- a/tools/autoupdate/lang/autoupdate_pt.inc.php
+++ b/tools/autoupdate/lang/autoupdate_pt.inc.php
@@ -60,4 +60,6 @@ return [
     // 'AU_SEVERAL_TOOLS_UPDATE' => 'Vous avez {nbMaj} extensions à mettre à jour',
     // 'AU_ONE_TOOL_UPDATE' => 'Vous avez 1 extension à mettre à jour',
 
+    // tools/templates/autoupdate/core.twig
+    // 'AU_MANAGE_BACKUPS' => 'Gérer les sauvegardes',
 ];

--- a/tools/autoupdate/lang/autoupdate_pt.inc.php
+++ b/tools/autoupdate/lang/autoupdate_pt.inc.php
@@ -59,7 +59,4 @@ return [
     // 'AU_ONE_THEME_UPDATE' => 'Vous avez 1 thème à mettre à jour',
     // 'AU_SEVERAL_TOOLS_UPDATE' => 'Vous avez {nbMaj} extensions à mettre à jour',
     // 'AU_ONE_TOOL_UPDATE' => 'Vous avez 1 extension à mettre à jour',
-
-    // tools/templates/autoupdate/core.twig
-    // 'AU_MANAGE_BACKUPS' => 'Gérer les sauvegardes',
 ];

--- a/tools/autoupdate/templates/core.twig
+++ b/tools/autoupdate/templates/core.twig
@@ -84,5 +84,8 @@
             title="{{ _t('AU_CHANGELOG_HINT')|raw('html') }}">
             {{ _t('AU_CHANGELOG') }}
         </a>
-    </i>
+    </i> / <a class="btn btn-secondary-1 btn-xs" href="{{ url({tag:'GererSauvegardes'}) }}"
+        title="{{ _t('AU_MANAGE_BACKUPS') }}">
+        {{ _t('AU_MANAGE_BACKUPS') }}
+    </a>
 </div>

--- a/tools/autoupdate/templates/core.twig
+++ b/tools/autoupdate/templates/core.twig
@@ -84,8 +84,5 @@
             title="{{ _t('AU_CHANGELOG_HINT')|raw('html') }}">
             {{ _t('AU_CHANGELOG') }}
         </a>
-    </i> / <a class="btn btn-secondary-1 btn-xs" href="{{ url({tag:'GererSauvegardes'}) }}"
-        title="{{ _t('AU_MANAGE_BACKUPS') }}">
-        {{ _t('AU_MANAGE_BACKUPS') }}
-    </a>
+    </i>
 </div>

--- a/tools/helloworld/commands/HelloCommand.php
+++ b/tools/helloworld/commands/HelloCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace YesWiki\Helloworld\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use YesWiki\Wiki;
+
+class HelloCommand extends Command
+{
+    // the name of the command (the part after "bin/console")
+    protected static $defaultName = 'helloworld:hello';
+
+    protected $wiki;
+
+    public function __construct(Wiki &$wiki)
+    {
+        parent::__construct();
+        $this->wiki = $wiki;
+    }
+
+    protected function configure()
+    {
+        $this
+            // the short description shown while running "php bin/console list"
+            ->setDescription('Display message "Hello !".')
+
+            // the full command description shown when running the command with
+            // the "--help" option
+            ->setHelp("This command display the message \"Hello !\" with options for uppercase of add a username.\n".
+                "The argument \"username\" can be used to add a username. Example : \n".
+                "Command line'php includes/commands/console helloworld:hello \"John Smith\"' gives \"Hello John Smith !\"")
+
+            // add argument for username
+            // second parameter could be InputArgument::OPTIONAL <=> null, InputArgument::REQUIRED, InputArgument::IS_ARRAY
+            // third parameter is the description
+            // forth parameter is default value
+            ->addArgument('username', InputArgument::OPTIONAL, 'Username')
+
+            // add option to display output as UPPERCASE
+            // second parameter null|string is shortcut
+            // third parameter null|int could be InputOption::VALUE_NONE <=> null, InputOption::VALUE_REQUIRED
+            //          , InputOption::VALUE_OPTIONAL, InputOption::VALUE_IS_ARRAY, InputOption::VALUE_NEGATABLE
+            // forth parameter is the description
+            ->addOption('uppercase', 'u', InputOption::VALUE_NONE, 'Display output in UPPERCASE')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $username = $input->getArgument('username');
+        $username = empty($username) ? "" : "$username ";
+        $outputString = "Hello $username!";
+        if ($input->getOption('uppercase')) {
+            $outputString = strtoupper($outputString);
+        }
+        $output->writeln($outputString);
+        return Command::SUCCESS;
+    }
+}

--- a/tools/helloworld/tests/commands/HelloCommandTest.php
+++ b/tools/helloworld/tests/commands/HelloCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace YesWiki\Test\Helloworld\Commands;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use YesWiki\Helloworld\Commands\HelloCommand;
+use YesWiki\Test\Core\YesWikiTestCase;
+
+require_once 'tests/YesWikiTestCase.php';
+
+class HelloCommandTest extends YesWikiTestCase
+{
+    /**
+     * @covers HelloCommand::execute
+     * @dataProvider providerTestExecute
+     * @param null|string $username
+     * @param bool $uppercase
+     * @param int $statusCode
+     * @param string $waitedOutput
+     */
+    public function testExecute(?string $username, bool $uppercase, int $statusCode, string $waitedOutput)
+    {
+        $wiki = $this->getWiki();
+        // create Application
+        $application = new Application();
+        $application->add(new HelloCommand($wiki));
+
+        $command = $application->find('helloworld:hello');
+        $commandTester = new CommandTester($command);
+        $params = [];
+        if (!empty($username)) {
+            $params['username'] = $username;
+        }
+        if ($uppercase) {
+            $params['--uppercase'] = '1';
+        }
+        // pass arguments to the helper
+        // [
+        //'username' => 'Wouter',
+
+        // prefix the key with two dashes when passing options,
+        // e.g: '--some-option' => 'option_value',
+        //]
+        $commandTester->execute($params);
+        // $commandTester->assertCommandIsSuccessful();
+        $this->assertEquals($statusCode, $commandTester->getStatusCode());
+        // the output of the command in the console
+        $this->assertMatchesRegularExpression($waitedOutput, $commandTester->getDisplay());
+    }
+
+    public function providerTestExecute()
+    {
+        return [
+            'no arg, no option' => [
+                'username' => null,
+                'uppercase' => false,
+                'statusCode' => Command::SUCCESS,
+                'output' => "/^Hello !(?:\r|\n)+$/"
+            ],
+            'with username' => [
+                'username' => "John Smith",
+                'uppercase' => false,
+                'statusCode' => Command::SUCCESS,
+                'output' => "/^Hello John Smith !(?:\r|\n)+$/"
+            ],
+            'with username uppercase' => [
+                'username' => "John Smith",
+                'uppercase' => true,
+                'statusCode' => Command::SUCCESS,
+                'output' => "/^HELLO JOHN SMITH !(?:\r|\n)+$/"
+            ],
+            'uppercase no username ' => [
+                'username' => null,
+                'uppercase' => true,
+                'statusCode' => Command::SUCCESS,
+                'output' => "/^HELLO !(?:\r|\n)+$/"
+            ],
+        ];
+    }
+}

--- a/tools/security/config.yaml
+++ b/tools/security/config.yaml
@@ -11,6 +11,7 @@ parameters:
     - 'wiki_status'
     - archive:
       - privatePath
+      - call_archive_async
     
 services:
   _defaults:

--- a/tools/security/config.yaml
+++ b/tools/security/config.yaml
@@ -13,6 +13,7 @@ parameters:
       - privatePath
       - call_archive_async
       - max_nb_files
+      - preupdate_backup_activated
     
 services:
   _defaults:

--- a/tools/security/config.yaml
+++ b/tools/security/config.yaml
@@ -12,6 +12,7 @@ parameters:
     - archive:
       - privatePath
       - call_archive_async
+      - max_nb_files
     
 services:
   _defaults:

--- a/tools/security/config.yaml
+++ b/tools/security/config.yaml
@@ -9,6 +9,8 @@ parameters:
     - 'use_captcha'
     - 'use_hashcash'
     - 'wiki_status'
+    - archive:
+      - privatePath
     
 services:
   _defaults:

--- a/tools/security/controllers/SecurityController.php
+++ b/tools/security/controllers/SecurityController.php
@@ -31,7 +31,7 @@ class SecurityController extends YesWikiController
      */
     public function isWikiHibernated(): bool
     {
-        return (in_array($this->params->get('wiki_status'), ['hibernate']));
+        return (in_array($this->params->get('wiki_status'), ['hibernate','archiving','updating']));
     }
 
     /**

--- a/tools/security/lang/security_ca.inc.php
+++ b/tools/security/lang/security_ca.inc.php
@@ -34,6 +34,7 @@ return [
     // 'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_ca.inc.php
+++ b/tools/security/lang/security_ca.inc.php
@@ -35,6 +35,7 @@ return [
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
     // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_ca.inc.php
+++ b/tools/security/lang/security_ca.inc.php
@@ -34,7 +34,7 @@ return [
     // 'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
-    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
 
     // security controller

--- a/tools/security/lang/security_ca.inc.php
+++ b/tools/security/lang/security_ca.inc.php
@@ -36,6 +36,7 @@ return [
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
     // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[MAX_NB_FILES]' => 'Nombre maximum de fichiers de sauvegarde à conserver (min. 3)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_ca.inc.php
+++ b/tools/security/lang/security_ca.inc.php
@@ -37,6 +37,7 @@ return [
     // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[MAX_NB_FILES]' => 'Nombre maximum de fichiers de sauvegarde à conserver (min. 3)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[PREUPDATE_BACKUP_ACTIVATED]' => 'Faire une sauvegarde avant chaque mise à jour (true ou false)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_en.inc.php
+++ b/tools/security/lang/security_en.inc.php
@@ -34,6 +34,7 @@ return [
     // 'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_en.inc.php
+++ b/tools/security/lang/security_en.inc.php
@@ -34,7 +34,8 @@ return [
     // 'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
-    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
+    'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'LBackups\'folder path (empty = tmp folder if possible)',
+    'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Start backups in backgound (true/false)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_en.inc.php
+++ b/tools/security/lang/security_en.inc.php
@@ -34,7 +34,7 @@ return [
     // 'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
-    'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'LBackups\'folder path (empty = tmp folder if possible)',
+    'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Backups\'folder path (\'%TMP\' = system temporary folder)',
     'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Start backups in backgound (true/false)',
 
     // security controller

--- a/tools/security/lang/security_en.inc.php
+++ b/tools/security/lang/security_en.inc.php
@@ -36,6 +36,7 @@ return [
     'EDIT_CONFIG_GROUP_SECURITY' => 'Security',
     'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Backups\'folder path (\'%TMP\' = system temporary folder)',
     'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Maximum number of backup\'s files to keep (min. 3)',
+    'EDIT_CONFIG_HINT_ARCHIVE[PREUPDATE_BACKUP_ACTIVATED]' => 'Make a backup before each update (true or false)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_en.inc.php
+++ b/tools/security/lang/security_en.inc.php
@@ -29,13 +29,13 @@ return [
     // 'DESPAM_ONLY_FOR_ADMINS' => 'Action {{despam}} réservée aux administrateurs.',
 
     // for edit config
-    // 'EDIT_CONFIG_HINT_USE_CAPTCHA' => 'Activer l\'utilisation d\'un captcha avant la sauvegarde (true ou false)',
-    // 'EDIT_CONFIG_HINT_USE_HASHCASH' => 'Activer l\'antispam hashcash du wiki (activé par défaut)',
-    // 'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
-    // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
-    // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
+    'EDIT_CONFIG_HINT_USE_CAPTCHA' => 'Activate usage of captcha before save (true or false)',
+    'EDIT_CONFIG_HINT_USE_HASHCASH' => 'Activate wiki antispam hashcash (activated by default)',
+    'EDIT_CONFIG_HINT_USE_ALERTE' => 'Warn before leaving a page without saving (true or false)',
+    'EDIT_CONFIG_HINT_WIKI_STATUS' => 'Wiki status (running or empty = standard, hibernate = read only)',
+    'EDIT_CONFIG_GROUP_SECURITY' => 'Security',
     'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Backups\'folder path (\'%TMP\' = system temporary folder)',
-    'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Start backups in backgound (true/false)',
+    'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Maximum number of backup\'s files to keep (min. 3)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_es.inc.php
+++ b/tools/security/lang/security_es.inc.php
@@ -34,6 +34,7 @@ return [
     // 'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_es.inc.php
+++ b/tools/security/lang/security_es.inc.php
@@ -35,6 +35,7 @@ return [
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
     // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_es.inc.php
+++ b/tools/security/lang/security_es.inc.php
@@ -34,7 +34,7 @@ return [
     // 'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
-    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
 
     // security controller

--- a/tools/security/lang/security_es.inc.php
+++ b/tools/security/lang/security_es.inc.php
@@ -36,6 +36,7 @@ return [
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
     // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[MAX_NB_FILES]' => 'Nombre maximum de fichiers de sauvegarde à conserver (min. 3)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_es.inc.php
+++ b/tools/security/lang/security_es.inc.php
@@ -37,6 +37,7 @@ return [
     // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[MAX_NB_FILES]' => 'Nombre maximum de fichiers de sauvegarde à conserver (min. 3)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[PREUPDATE_BACKUP_ACTIVATED]' => 'Faire une sauvegarde avant chaque mise à jour (true ou false)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_fr.inc.php
+++ b/tools/security/lang/security_fr.inc.php
@@ -37,6 +37,7 @@ return [
     'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
     'EDIT_CONFIG_HINT_ARCHIVE[MAX_NB_FILES]' => 'Nombre maximum de fichiers de sauvegarde à conserver (min. 3)',
+    'EDIT_CONFIG_HINT_ARCHIVE[PREUPDATE_BACKUP_ACTIVATED]' => 'Faire une sauvegarde avant chaque mise à jour (true ou false)',
 
     // security controller
     'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_fr.inc.php
+++ b/tools/security/lang/security_fr.inc.php
@@ -36,6 +36,7 @@ return [
     'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
     'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
+    'EDIT_CONFIG_HINT_ARCHIVE[MAX_NB_FILES]' => 'Nombre maximum de fichiers de sauvegarde à conserver (min. 3)',
 
     // security controller
     'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_fr.inc.php
+++ b/tools/security/lang/security_fr.inc.php
@@ -34,7 +34,7 @@ return [
     'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
     'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
-    'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
+    'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
 
     // security controller

--- a/tools/security/lang/security_fr.inc.php
+++ b/tools/security/lang/security_fr.inc.php
@@ -34,6 +34,7 @@ return [
     'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
     'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
+    'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
 
     // security controller
     'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_fr.inc.php
+++ b/tools/security/lang/security_fr.inc.php
@@ -35,6 +35,7 @@ return [
     'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
     'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
+    'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
 
     // security controller
     'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_nl.inc.php
+++ b/tools/security/lang/security_nl.inc.php
@@ -34,6 +34,7 @@ return [
     // 'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_nl.inc.php
+++ b/tools/security/lang/security_nl.inc.php
@@ -35,6 +35,7 @@ return [
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
     // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_nl.inc.php
+++ b/tools/security/lang/security_nl.inc.php
@@ -34,7 +34,7 @@ return [
     // 'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
-    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
 
     // security controller

--- a/tools/security/lang/security_nl.inc.php
+++ b/tools/security/lang/security_nl.inc.php
@@ -36,6 +36,7 @@ return [
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
     // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[MAX_NB_FILES]' => 'Nombre maximum de fichiers de sauvegarde à conserver (min. 3)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_nl.inc.php
+++ b/tools/security/lang/security_nl.inc.php
@@ -37,6 +37,7 @@ return [
     // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[MAX_NB_FILES]' => 'Nombre maximum de fichiers de sauvegarde à conserver (min. 3)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[PREUPDATE_BACKUP_ACTIVATED]' => 'Faire une sauvegarde avant chaque mise à jour (true ou false)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_pt.inc.php
+++ b/tools/security/lang/security_pt.inc.php
@@ -34,6 +34,7 @@ return [
     // 'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_pt.inc.php
+++ b/tools/security/lang/security_pt.inc.php
@@ -35,6 +35,7 @@ return [
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
     // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_pt.inc.php
+++ b/tools/security/lang/security_pt.inc.php
@@ -34,7 +34,7 @@ return [
     // 'EDIT_CONFIG_HINT_USE_ALERTE' => 'Prévenir si l\'on quitte la page sans sauvegarder (true ou false)',
     // 'EDIT_CONFIG_HINT_WIKI_STATUS' => 'État du wiki (running ou vide = standard, hibernate = lecture seule)',
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
-    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (vide = dossier temporaire si possible)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
 
     // security controller

--- a/tools/security/lang/security_pt.inc.php
+++ b/tools/security/lang/security_pt.inc.php
@@ -36,6 +36,7 @@ return [
     // 'EDIT_CONFIG_GROUP_SECURITY' => 'Sécurité',
     // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[MAX_NB_FILES]' => 'Nombre maximum de fichiers de sauvegarde à conserver (min. 3)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/security/lang/security_pt.inc.php
+++ b/tools/security/lang/security_pt.inc.php
@@ -37,6 +37,7 @@ return [
     // 'EDIT_CONFIG_HINT_ARCHIVE[PRIVATEPATH]' => 'Localisation des sauvegardes (\'%TMP\' = dossier des fichiers temporaires du système)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[CALL_ARCHIVE_ASYNC]' => 'Lancer les opérations de sauvegardes en arrière-plan (true/false)',
     // 'EDIT_CONFIG_HINT_ARCHIVE[MAX_NB_FILES]' => 'Nombre maximum de fichiers de sauvegarde à conserver (min. 3)',
+    // 'EDIT_CONFIG_HINT_ARCHIVE[PREUPDATE_BACKUP_ACTIVATED]' => 'Faire une sauvegarde avant chaque mise à jour (true ou false)',
 
     // security controller
     // 'WIKI_IN_HIBERNATION' => 'Action désactivée car ce wiki est en lecture seule. Veuillez contacter l\'administrateur pour le réactiver.',

--- a/tools/templates/actions/setwikidefaulttheme.php
+++ b/tools/templates/actions/setwikidefaulttheme.php
@@ -1,5 +1,6 @@
 <?php
 use YesWiki\Security\Controller\SecurityController;
+use YesWiki\Core\Service\ConfigurationService;
 
 if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
@@ -14,8 +15,7 @@ if (!is_writable('wakka.config.php')) {
 } else {
     if ($this->UserIsAdmin()) {
         $themes = getTemplatesList();
-        include_once 'tools/templates/libs/Configuration.php';
-        $config = new Configuration('wakka.config.php');
+        $config = $this->services->get(ConfigurationService::class)->getConfiguration('wakka.config.php');
         $config->load();
 
         if (isset($_POST['action']) and $_POST['action'] === 'setTemplate') {

--- a/tools/templates/libs/Configuration.php
+++ b/tools/templates/libs/Configuration.php
@@ -1,91 +1,9 @@
 <?php
 
-class Configuration
+// TODO delete this file whan passing to ectoplasme
+
+use YesWiki\Core\Entity\ConfigurationFile;
+
+class Configuration extends ConfigurationFile
 {
-    private $_parameters = array();
-    private $_file = "";
-
-    /**
-     * [__construct description]
-     * @param [type] $file [description]
-     */
-    public function __construct($file)
-    {
-        $this->_file = $file;
-    }
-
-    public function __get($name)
-    {
-        if (isset($this->_parameters[$name])) {
-            return $this->_parameters[$name];
-        }
-        throw new \Exception("Paramètre inconnu Configuration::$name", 1);
-    }
-
-    public function __isset($name)
-    {
-        return isset($this->_parameters[$name]);
-    }
-
-    public function __set($name, $value)
-    {
-        $this->_parameters[$name] = $value;
-    }
-
-    public function __unset($name)
-    {
-        unset($this->_parameters[$name]);
-    }
-
-    public function load()
-    {
-        if (!is_file($this->_file)) {
-            return;
-        }
-
-        require $this->_file;
-
-        if (isset($wakkaConfig)) {
-            $this->_parameters = $wakkaConfig;
-        }
-    }
-
-    /**
-     * écris le fichier de configuration
-     * @return [type] [description]
-     */
-    public function write()
-    {
-        $content = "<?php\n\$wakkaConfig = ";
-
-        $content .= $this->customVarExport($this->_parameters, true);
-        $content .= ";\n";
-        file_put_contents($this->_file, $content);
-    }
-
-    /**
-     * PHP var_export() with short array syntax (square brackets) indented 2 spaces.
-     * tips : https://www.php.net/manual/en/function.var-export.php#124194
-     * NOTE: The only issue is when a string value has `=>\n[`, it will get converted to `=> [`
-     * @param mixed $expression
-     * @param bool $return
-     * @return null|string
-     */
-    private function customVarExport($expression, $return=false): ?string
-    {
-        $export = var_export($expression, true);
-        $patterns = [
-            "/array \(/" => '[',
-            "/^([ ]*)\)(,?)$/m" => '$1]$2',
-            "/=>[ ]?\n[ ]+\[/" => '=> [',
-            "/([ ]*)(\'[^\']+\') => ([\[\'])/" => '$1$2 => $3',
-        ];
-        $export = preg_replace(array_keys($patterns), array_values($patterns), $export);
-        if ((bool)$return) {
-            return $export;
-        } else {
-            echo $export;
-            return null;
-        }
-    }
 }


### PR DESCRIPTION
Cette PR permet d'introduire une fonctionnalité d'archivage asynchrone du wiki.
**Spécifications pour cette PR** : ci-dessous

**Pour tester**:
 - faire `/update` une fois sur la branche `feat/archive`
 - penser à faire un `composer install` juste au cas où
 - se rendre sur la page `GererMisesAJour` :
   - il y a alors un bouton "Gérer les sauvegardes"
   - une sauvegarde est lancée avant chaque mise à jour

**Matrice de couverture de la spécification**:
|Numéro|Nom|Implémenté|Testé|Commentaire|
|:-|:-|:-|:-|:-|
|[R01]|console + command spécifique|[x]|[x]||
|[R02]|command avec params|[x]|[x]||
|[R02.1]|params pour choix sql, fichiers ou tout|[x]|[x]||
|[R02.2]|par défaut tout|[x]|[x]|test par lecture du code|
|[R02.3]|nom des fichiers|[x]|N.A.|voir constantes dans `ArchiveService`|
|[R02.4]|params `extrafiles`|[x]|[x]|test manuel|
|[R02.4.1]|params `extrafiles` chemins relatifs|[x]|[x]|test phpunit|
|[R02.4.2]|params `extrafiles` OK pour dossiers|[x]|[x]|test manuel|
|[R02.4.3]|params `extrafiles` OK pour sous-dossiers|[x]|[x]|test manuel|
|[R02.4.4]|params `extrafiles` compatible `glob`|[x]|[x]|test manuel|
|[R02.4.5]|params `extrafiles` save dans `wakka.config.php` du zip|[x]|[x]|test phpunit|
|[R02.4.6]|params `extrafiles` configurable via frontend|[x]|[x]|tests manuels|
|[R02.4.8]|params `extrafiles` save dans `wakka.config.php` du zip sous forme de tableau|[x]|[x]|test phpunit|
|[R02.4.9]|params `extrafiles` ne doit tenir compte que des chemins inclus dans le dossier de tête|[x]|[x]|test phpunit|
|[R02.5]|params `excludedfiles`|[x]|[x]|test hors phpunit|
|[R02.5.1]|params `excludedfiles` chemins relatifs|[x]|[x]|test phpunit|
|[R02.5.2]|params `excludedfiles` OK pour dossiers|[x]|[x]|test phpunit|
|[R02.5.3]|params `excludedfiles` compatible `glob`|[x]|[x]|test hors phpunit|
|[R02.5.4]|params `excludedfiles` save dans `wakka.config.php` du zip|[x]|[x]|test phpunit|
|[R02.5.5]|params `excludedfiles` configurable via frontend|[x]|[x]|tests manuels|
|[R02.5.6]|params `excludedfiles` save dans `wakka.config.php` du zip sous forme de tableau|[x]|[x]|test phpunit|
|[R03]|permettre l'anonymisation de `wakka.config.php`|[x]|[x]|test phpunit|
|[R03.1]|anonymisation de `wakka.config.php` réglable par un paramètre|[x]|[x]|test phpunit|
|[R03.2]|anonymisation de `wakka.config.php` valeurs par défaut|[x]|[x]|test phpunit|
|[R03.3]|anonymisation de `wakka.config.php` save dans `wakka.config.php`|[x]|[x]||
|[R03.4]|anonymisation `wakka.config.php` avec tableaux aussi|[x]|[x]|test phpunit|
|[R03.5]|anonymisation `wakka.config.php` avec tableaux : format|[x]|[x]|test phpunit|
|[R04]|un controlleur pour appeler la CLI|[x]|[x]|test phpunit|
|[R04.1]|un controlleur dans `includes`|[x]|[x]|test par lecture du code; c'est un service|
|[R04.2]|le controlleur fournit les paramètres d'anonymisation|[x]|[x]|test phpunit|
|[R04.3]|les paramètres d'anonymisation ne peuvent être réglés par le frontend|[x]|N.A.|vérifiaction en lisant le code|
|[R05]|la CLI vérifie le dossier n'est pas sur le web|[x]|[x]|tests manuel en suppriment `.htaccess`|
|[R05.1]|chemin de sauvegarde dans `wakka.config.php`|[x]|[x]|test manuel|
|[R05.2]|chemin de sauvegarde configurable via `{{editconfig}}`|[x]|[x]|test manuel|
|[R06]|mode hibernate pendant la sauvegarde|[x]|[x]|proposition de créer un mode `archiving`|
|[R07]|archivage sur PID différent|[x]|[x]|test phpunit + test manuels|
|[R07.1]|utilisation possible de `symfony/process`|[x]|[x]||
|[R07.2]|pouvoir arrêter la CLI|[x]|[x]|test manuel|
|[R07.3]|fournit un état instantané de la CLI|[x]|[x]|test manuel|
|[R07.4]|communication avec la CLI via un fichier|[x]|[x]|test manuel|
|[R08]|zip avec arborescence similaire au yeswiki|[x]|[x]|test phpunit|
|[R08.1]|sauvegarde sql dans zip|[x]|[x]|test phpunit|
|[R08.4]|sauvegarde sql dans zip private/backups|[x]|[x]|test phpunit|
|[R08.5]|private/backups avec .htaccess et README|[x]|[x]|test phpunit|
|[R08.6]|pas d'assurance de la sécurité des données|[x]|N.A.||
|[R09]|téléchargement du fichier sans lien direct|[x]|[x]|test manuel|
|[R10]|pas de sauvegarde pendant une autre sauvegarde|[x]|[x]|test phpunit|
|[R11]|vérification de l'espace disque avant de lancer une sauvegarde|[x]|[x]|test manuel|
|[R11.1]|règle pour la marge d'espace disque|[x]|[x]|choix taille files + custom + 300 Mo|
|[R12]|limiter le nombre de sauvegardes à 10|[x]|[x]|test manuel|
|[R12.1]|toujours supprimer la plus ancienne|[x]|[x]|test manuel ! conserve toujours au moins une archive qui a deux jours|
|[R12.2]|demander une confirmation du frontend avant suppression|[x]|[x]|test manuel|
|[R21]|frontend via `{{adminbackups}}`|[x]|[x]|test manuel|
|[R21.1]|pas d'impact dans  `{{update}}`|[x]|N.A.||
|[R22]|`{{adminbackups}}` gestion des sauvegardes précédentes|[x]|[x]|test manuel|
|[R22.1]|`{{adminbackups}}` actions : liste/télécharger/supprimer|[x]|[x]|test manuel|
|[R22.2]|`{{adminbackups}}` actions : laisser la possibilité pour "restaurer"|[x]|N.A.|le code frontend contient déja des bouts de codes en commentaires|
|[R23]|`{{update}}` lancer une sauvegarde automatique avant update|[x]|[x]|tests manuels|
|[R23.1]|`{{update}}` sauvegarde auto contournable|[x]|[x]|tests manuels|
|[R23.2]|`{{update}}` sauvegarde auto contourné = confirmation requise|[x]|[x]|tests manuels|
|[R23.3]|`{{adminbackups}}` permet une sauvegarde manuelle|[x]|[x]|tests manuels|
|[R23.4]|`{{adminbackups}}` permet la configuration de la sauvegarde|[x]|[x]|tests manuels|
|[R23.5]|`{{update}}` sauvegarde auto contournable uniquement si param dans wakka.config|[x]|[x]|tests manuels|
|[R24]|`{{adminbackups}}` VueJS possible|[x]|[x]|usage de VueJs avec syntaxe compatible vuejs 2 et 3|
|[R25]|`{{adminbackups}}` appel routes API|[x]|[x]||
|[R25.1]|`{{adminbackups}}` appel routes API en ajax|[x]|[x]||
|[R25.2]|`{{adminbackups}}` suivi CLI en dynamique|[x]|[x]|test manuel|
|[R25.3]|`{{adminbackups}}` permettre arrêter la CLI|[x]|[x]|test manuel|
|[R25.4]|`{{adminbackups}}` rafraichissement mini 5 sec|[x]|[x]|test manuel|
|[R26]|route API pour lancer la sauvegarde|[x]|[x]|test manuel|
|[R26.1]|route API pour lancer la sauvegarde sauf si pas assez d'espace|[x]|[x]|test manuel|
|[R26.2]|route API pour lancer la sauvegarde suppression auto de la plus ancienne si > 10|[x]|[x]|test manuel|
|[R26.3]|route API pour lancer la sauvegarde limite 2 par jours maxi|N.A.|N.A.|non réalisable car c'est la même route api|

_N.A._ : non applicable

----

## Spécifications de "haut" niveau pour la fonctionnalité d'archivage/restitution d'un YesWiki

**Auteurs** :
 - [JD] = [Jérémy][JD]
 - mrflos

[JD]: https://yeswiki.net/?JeremyDufraisse

_Ces spécifications sont couvertes par deux devis donc la présentation est faite en deux parties_.

## Archivage automatisé d'un YesWiki

### Backend

 - mettre en place une **interface CLI** pour sauvegarder le wiki
 - [R01] cette interface CLI **DOIT** être découpée en une commande standard disponible dans le coeur et une partie plus spécifique à la commande en question. L'objectif est de permettre la réutilisation de cette CLI pour d'autres services
 - [R02] l'interface CLI **DOIT** recevoir des paramètres pour sélectionner ce qui doit être exporté. 
   - [R02.1] les choix possibles pour la sauvegarde **DEVRAIENT** être:
     - Base de données seule
     - Fichiers uniquement (tous les fichiers depuis la racine sauf `cache/`) 
     - Base de données et fichiers (tous les fichiers depuis la racine sauf `cache/`)
> mrflos : (**apres réflexion je me demande meme s'il ne faut pas tout sauver db+fichiers et ne pas permettre de choix**)
>> [JD] : j'ai une préférence pour permettre l'export SQL seul car parfois je sais que je ne vais pas faire une mise à jour mais que je vais modifier les formulaires et j'aimerais bien avoir juste la base de données avant les modifications
>>> mrflos : ok
   - [R02.2] le choix par défaut **DOIT** être "Base de données et fichiers"
   - [R02.3] les noms de fichier d'archive **DOIVENT** être:
     - Base de données seule : `<date>T<heure>_archive_only_db.zip` au format exemple `2022-01-01T12-45-01_archive_only_db.zip`
     - Fichiers uniquement : `<date>T<heure>_archive_only_files.zip` au format exemple `2022-01-01T12-45-01_archive_only_files.zip`
     - Base de données et fichiers : `<date>T<heure>_archive.zip` au format exemple `2022-01-01T12-45-01_archive.zip`
   - [R02.4] le paramètre `extrafiles` **DOIT** être accepté pour forcer des fichiers supplémentaires
     - [R02.4.1] le format du paramètre `extrafiles` fournit à la CLI **DOIT** être : chemins relatifs à partir du dossier de base séparés par des virgules
     - [R02.4.2] `extrafiles` **DEVRAIT** accepter les chemins de dossier
     - [R02.4.3] pour les dossiers, `extrafiles` **DEVRAIT** faire aussi référence à tous ses fichiers et sous-dossiers
     - [R02.4.4] `extrafiles` **DOIT** accepter le caractère `*` dans un format compatible de la fonction php `glob()`
     - [R02.4.5] `extrafiles` **DOIT** être sauvegardé dans `wakka.config.php`
     - [R02.4.6] `extrafiles` **PEUT** être configurable par l'interface `frontend`
     - ~~[R02.4.7]~~
     - [R02.4.8] le paramètre `extrafiles` stocké dans `wakka.config.php` **DOIT** être un tableau
     - [R02.4.9] le paramètre `extrafiles` **NE DOIT PAS** tenir compte des chemins de fichiers qui ne sont pas inclus dans le dossier de base
     > mrflos : chemin relatif vers des dossiers ou fichiers (un dossier contenant tous les fichiers et sous dossiers a l'interieur), dans ce cas pas la peine de faire reference a tous les fichiers des dossiers, si le glob est utilise, il faut s'assurer que l'on ne sauve que des dossiers present depuis le dossier du wiki (pas de ../ possible)
     >>[JD] pris en compte
   - [R02.5] le paramètre `excludedfiles` **DOIT** être accepté pour retirer des fichiers de la sauvegarde
   - [R02.5.1] le format du paramètre `excludedfiles` fournit à la CLI **DOIT** être : chemins relatifs à partir du dossier de base séparés par des virgules
     - [R02.5.2] `excludedfiles` **DEVRAIT** accepter les chemins de dossier
     - [R02.5.3] `excludedfiles` **DOIT** accepter le caractère `*` dans un format compatible de la fonction php `glob()`
     - [R02.5.4] `excludedfiles` **DOIT** être sauvegardé dans `wakka.config.php`
     - [R02.5.5] `excludedfiles` **PEUT** être configurable par l'interface `frontend`
     - [R02.5.6] le paramètre `excludedfiles` stocké dans `wakka.config.php` **DOIT** être un tableau

 - [R03] l'interface CLI **DOIT** permettre d'anonymiser des données dans wakka.config.php
   - [R03.1] la liste des paramètres à anonymiser **DOIT** être un paramètre de la CLI
   - [R03.2] cette liste **PEUT** être initialisée par défaut à
   ```
   [
     'mysql_host'=>'',
     'mysql_database'=>'',
     'mysql_user',=>'',
     'mysql_password',=>'',
     'table_prefix',=>'',
     'contact_smtp_host',=>'',
     'contact_smtp_user',=>'',
     'contact_smtp_pass',=>'',
     'api_allowed_keys'=>[],
   ]
   ```
   - [R03.3] cette liste par défaut **PEUT** être sauvegardée dans `wakka.config.php`
   >mrflos : comment gérer le fait que certaines entrées soient des tableaux?
   >> [JD] cf [R03.4]
   - [R03.4] la liste des paramètres à anonymiser **PEUT** faire référence à des clés spécifiques d'un tableau.
   - [R03.5] pour faire référence à des tableaux, la liste **DOIT** contenir un tableau ayant la même arboresence que wakka.config.php. Exemple 
   ```
   [
     'mysql_host' => '',
     'lms' => [
       'custom_params' => [
         'api_keys' => []
       ]
     ],
     'mysql_user' => ''
   ]
   ```
 - [R04] un contrôleur YesWiki **DEVRAIT** appeler la CLI de façon asynchrone
   - [R04.1] ce contrôleur **DEVRAIT** faire partie du cœur`includes`
   >mrflos : plutot dans le coeur non? un service de backup, et une action {{adminbackup}} qui ferait controlleur, et le controlleur de l'api
   >> [JD] pris en compte
   - [R04.2] ce contrôleur **DEVRAIT** fournir la liste des paramètres à anonymiser depuis `wakka.config.php`
   - [R04.3] ce contrôleur **NE DOIT PAS** fournir une liste différente à partir des informations du frontend (seul `wakka.config.php` est utilisable)
  - [R05] la commande CLI (ou service associé) **DOIT** vérifier que le dossier de sauvegarde n'est pas accessible depuis internet
    - [R05.1] le chemin du dossier de sauvegarde **DEVRAIT** être configurable dans `wakka.config.php`
    - [R05.2] le chemin du dossier de sauvegarde **PEUT** être configurable via `{{editconfig}}`
 - [R06] la CLI **DEVRAIT** mettre le wiki en mode `hibernate` le temps de la sauvegarde (_paramètre de `wakka.config.php`_)
 - [R07] : la sauvegarde **DEVRAIT** se faire en asynchrone dans un PID différent de Apache/Nginx
   - [R07.1] le controlleur **PEUT** utiliser la librairie [`symfony/process`](https://symfony.com/doc/current/components/process.html) pour lancer la CLI en asynchrone
   - [R07.2] le contrôleur **DOIT** permettre d'arrêter la CLI à la demande
   - [R07.3] le contrôleur **DOIT** fournir un état instannée de la CLI
   - [R07.4] le moyen de communication entre la CLI et le controleur **PEUT** être via un fichier dans le dossier de sauvegarde
 - [R08] le format de sauvegarde **DOIT** être un `.zip` avec un arborescence interne similaire à la structure du serveur
   - [R08.1] la base de données **DOIT** être sauvegardée dans un chemin interne en respectant l'arborescence définie par l'extension ferme
   - ~~[R08.2]~~
   - ~~[R08.3]~~ 
   - [R08.4] le chemin de sauvegarde dans le `.zip` **DOIT** être à partir de la racine `private/backups`
   - [R08.5] le service d'archive **DEVRAIT** ajouter un fichier `.htaccess` dans le dossier `private` (dans le zip) pour restreindre sont accès depuis l'extérieur
   - [R08.6] le service d'archive **NE DEVRAIT PAS** être responsable de la sécurisation du dossier `private` en cas de restauration (cet aspect restant du ressort de l'étape de restauration)
 - [R09] : le contrôlleur **DOIT** permettre le téléchargement de la sauvegarde en sécurité sans recopier le fichier dans un dossier accessible depuis internet
 - [R10] : le contrôleur/la CLI **NE DOIVENT PAS** lancer une sauvegarde si une sauvegarde est déjà en cours
 - [R11] : le service d'archive **DOIT** vérifier que l'espace disque disponible est suffisant avant de lancer une sauvegarde
   - [R11.1] : l'estimation d'espace nécessaire **PEUT** être faite à partir de la taille du dossier racine sans le cache avec une marge de 200 Mo. 
 - [R12] : le service d'archive **DOIT** limiter le nombre de sauvegardes stockées à 10
   - [R12.1]: le service d'archive **DEVRAIT** supprimer la sauvegarde la plus ancienne en lançant la nouvelle
   - [R12.2]: le service d'arichage **DOIT** attendre une confirmation du `frontend` avant de supprimer la sauvegarde la plus ancienne
>mrflos a discuter : mettre un parametre pour limiter le nombre de sauvegardes : si plus de 10 : effacer la derniere avant de lancer la nouvelle
>> [JD]: pris en compte

### Frontend

 - [R21] l'interface de sauvegarde **DOIT** être accessible via l'action `{{adminbackups}}`
   - [R21.1] le fichier `actions/update.php` **NE DOIT PAS** contenir le code associé à la sauvegarde. Un service spécifique **DOIT** être créé pour celà et appelé depuis `{{update}}` (par exemple en appelant `{{adminbackups}}` ou autre service)
 - [R22] l'interface **DEVRAIT** être une interface de gestion des dernières sauvegardes
   - [R22.1] la gestion **DEVRAIT** autoriser les actions suivantes :
     - liste des sauvegardes
     - télécharger la sauvegarde
     - effacer la sauvegarde
   - [R22.2] la gestion **DEVRAIT** permettre l'ajout ultérieur de l'action "restaurer la sauvegarde"
 - [R23] une sauvegarde **POURRAIT** être lancée automatiquement avant chaque mise à jour
   - [R23.1] une case à cocher **PEUT** autoriser le contournement de la sauvegarde automatique avant mise à jour
>mrflos : je suis partisan de le faire automatiquement (a la limite permettre de passer outre si pas assez d'espace disque disponible) et de proposer de supprimer le backup à la fin si tout va bien
>> [JD] : dans le cadre d'une mise à jour d'une extension ou d'un thème ou d'une version spécifique par un admin, il est parfois pas nécessaire de lancer une sauvegarde avant (en particuliers à des fins de tests). Pour moi, le mécanisme de contournement est nécessaire. Toutefois, nous pouvons penser l'interface pour que l'option ne soit visible que si l'admin a configuré un paramètre dans `wakka.config.php` cf [R23.5]
   - [R23.2] le décochage de cette case **DOIT** afficher un message d'avertissement avec validation requise
>mrflos : du coup pas besoin dans l'autre sens
   - [R23.3] l'interface **DOIT** permettre le lancement manuel d'une sauvegarde
   - [R23.4] l'interface **DOIT** permettre de configurer le contenu de la sauvegarde
   - [R23.5] le système de contournement de sauvegarde avant mise à jour **DOIT** être activé que si l'option `allow-no-save-before-update` vaut `true` dans `wakka.config.php`
 - [R24] l'interface **PEUT** être en VueJs
 - [R25] l'interface **DOIT** se connecter via une route API au contrôleur de la CLI pour interroger l'état de la CLI pendant la sauvegarde
   - [R25.1] ce suivi **DOIT** être en ajax
   - [R25.2] l'interface **DOIT** se mettre à jour régulièrement en fonction de l'état de la sauvegarde
   - [R25.3] Il **DEVRAIT** être possible d'arrêter la CLI depuis l'interface (via l'API)
   - [R25.4] le taux de rafraichissement de l'interface **PEUT** être d'une fois par seconde mais **DOIT** être plus d'une fois toutes les 5 secondes
 - [R26] une route api restreinte aux admins **DOIT** permettre de lancer une sauvegarde
   - [R26.1] en cas de lancement via l'api, la sauvegarde **NE DOIT PAS** être faite si l'espace disque est insuffisant
   - [R26.3] en cas de lancement via l'api, si le quota de sauvegarde est atteint, la sauvegarde la plus ancienne **DEVRAIT** être supprimée sans message d'avertissement ni confirmation
   - [R26.3] en cas de lancement via l'api, un mécanisme **DOIT** empêcher les sauvegardes trop régulières (genre pas plus de deux par jours), pour éviter les surcharges du serveur et éviter un piratage qui effacerait trop vite les 10 dernières sauvegardes
>mrflos : idéalement, il faudrait aussi un token qui permettrait de déclencher une sauvegarde à distance (une clé passée dans les entetes http pour lancer une sauvegarde à distance par cron par exemple)
>> [JD] pris en compte, car depuis cron et avec curl il est possilbe de passer le bearer pour atteindre l'api en temps qu'admin


## Restitution d'un YesWiki par l'interface web

### Frontend

 - [R41] l'accès à la partie de restitution **DOIT** se faire par l'action `{{adminbackups}}`
   - [R41.1] le code de restitution **DOIT** être dans un service/controleur spécifique appelé par l'action `{{adminbackups}}`
   - [R41.2] le code de restitution **PEUT** être dans le même contrôleur que l'archivage ou pas
 - [R42] l'interface **DEVRAIT** permettre la restauration d'une archive sélectionnée
 - [R43] si le site est à redémarrer, YesWiki **DEVRAIT** détecter que c'est une sauvegarde complète
   - [R43.1] lors de la connexion au serveur avec l'archive décompressée, YesWiki **DEVRAIT** afficher une interface de restauration demandant les inforamtions manquantes (BDD, SMTP, etc)
 - [R44] : l'interface de restaration **DEVRAIT** afficher dynamiquement l'état de la restauration via l'API
   - [R44.1] : l'interface **PEUT** utiliser la librairie VueJs

### Backend

 - [R61] : la restauration **DEVRAIT** être faite via CLI en asynchrone
   - [R61.1] : l'état de la restauration **DEVRAIT** être accessible via un controleur (comme pour l'archivage)
   - [R61.2] : une nouvelle restauration **NE DOIT PAS** être lancée si une restauration ou un archivage est déjà en cours

## Suivi des modifications

 - 2022 07 15 : [JD]
   - [R03.2]: liste à anonymiser par défaut : ajout des valeurs par défaut
   - [R03.5] : changement syntaxe anonymous pour les tableaux
 - 2022 07 01 : [JD]
   - [R02.4.6] NE DEVRAIT PAS => PEUT
   - [R02.4.7] suppression ~~le service d'archivage **DEVRAIT** fournir un fichier `.json` dans le fichier `.zip` pour indiquer les chemains relatifs nécessaires pour la restauration des `extrafiles` dans le cas où ces fichiers/dossiers ne sont pas inclus dans le dossier racine du YesWiki~~
   - [R02.4.9] ajout paramètre `extrafiles` uniquement dossier de base
   - [R02.5.5] NE DEVRAIT PAS => PEUT
   - [R03.4], [R03.5] ajout : format pour identifier certaines clés spécifiques d'un tableau dans la liste à anonymiser
   - [R04.1] `tools/autoupdate` => `includes` (cœur)
 - 2022 06 24 : [JD]
   - [R02] suite à commentaire de mrflos : changement de la méthode de choix
   - [R02.1] ajout des options
   - [R02.2] ajout option par défaut
   - [R02.3] ajout noms des fichiers
   - [R02.4], [R02.4.1], [R02.4.2], [R02.4.3], [R02.4.4], [R02.4.5], [R02.4.6], [R02.4.7], [R02.4.8] ajout pour `extrafiles`
   - [R02.5], [R02.5.1], [R02.5.2], [R02.5.3], [R02.5.4], [R02.5.5], [R02.5.6] ajout pour `excludedfiles`
   - [R04.3] PEUT => NE DOIT PAS
   - [R05.2] NE DOIT PAS => PEUT
   - [R08.1] découpage en plusieurs spec. => [R08.4],[R08.5],[R08.7] ajoutées dans ce sens (sauvegarde sql)
   - [R08.2] suppression ~~le nommage du fichier **DOIT** clairement indiquer si le fichier `.sql` est un dump brut ou un fichier pour réinstallation sur un autre serveur (via `install.php`)~~
   - [R08.3] suppression ~~la sauvegarde de la base de données **PEUT** être faite à chaque fois dans les deux formats (brut vs "pour installation")~~
   - [R11], [R11.1] ajout vérfication de l'espace disque
   - [R12], [R12.1], [R12.2] ajout pour limiter le nombre de sauvegardes
   - [R21] DEVRAIT => DOIT et `{{update}}` => `{{adminbackups}}`
   - [R23.5] ajout pour activer le système de contournement qu'en présence d'un paramètre dans `wakka.config.php`
   - [R26], [R26.1], [R26.2], [R26.3] ajout route api pour sauvegarde
   - [R41] PEUT => DOIT et `{{update}}` => `{{adminbackups}}`
   - [R41.1] `{{update}}` => `{{adminbackups}}`
 - 2022 06 23 : [JD] création