### PR TITLE
Feat/auth cookies

### DIFF
--- a/includes/controllers/AuthController.php
+++ b/includes/controllers/AuthController.php
@@ -192,9 +192,10 @@ class AuthController extends YesWikiController
         );
         if (!$this->wiki->isCli()) {
             // prevent setting cookies in CLI (could be errors)
-            $this->wiki->SetPersistentCookie('name', $user['name'], $remember);
-            $this->wiki->SetPersistentCookie('password', $user['password'], $remember);
-            $this->wiki->SetPersistentCookie('remember', $remember, $remember);
+            // clean old cookies TODO for ectoplasme, remove this part
+            $this->wiki->DeleteCookie('name');
+            $this->wiki->DeleteCookie('password');
+            $this->wiki->DeleteCookie('remember');
         }
     }
 
@@ -203,6 +204,7 @@ class AuthController extends YesWikiController
         $_SESSION['user'] = '';
         if (!$this->wiki->isCli()) {
             // prevent setting cookies in CLI (could be errors)
+            // clean old cookies TODO for ectoplasme, remove this part
             $this->wiki->DeleteCookie('name');
             $this->wiki->DeleteCookie('password');
             $this->wiki->DeleteCookie('remember');

--- a/includes/controllers/AuthController.php
+++ b/includes/controllers/AuthController.php
@@ -149,18 +149,6 @@ class AuthController extends YesWikiController
                 }
             }
         }
-        if (empty($user) && !empty($_COOKIE['name']) && is_string($_COOKIE['name'])) {
-            $user = $this->userManager->getOneByName($_COOKIE['name']);
-            $remember = $_COOKIE['remember'] ?? 0;
-            if (!empty($user) && (
-                empty($_COOKIE['password']) ||
-                    !is_string($_COOKIE['password']) ||
-                    $_COOKIE['password'] != $user['password'] // this is the key point where comparisn is done with password
-            )) {
-                // not right connected user
-                $user = null;
-            }
-        }
         if (empty($user)) {
             $this->logout();
         } else {


### PR DESCRIPTION
Cette PR est surtout pour vérifier avec toi @mrflos si c'est OK pour ne plus utiliser les cookies `name` et `password` pour l'auto-authentification mais plutôt utiliser le cookie de session qu'on rend alors persistant.

La technique proposée n'est pas idéale (voir https://www.php.net/manual/fr/features.session.security.management.php#features.session.security.management.session-and-autologin) mais je la trouve déjà plus sûre que les cookies `name` `password` et elle reste simple à mettre en œuvre de suite (le temps de trouver une solution plus fiable mais plus complexe)

Je suis partisan de l'intégrer pour `doryphore 4.3`

resolve #962 