### PR TITLE
feat/enum2level

### DIFF
--- a/tools/bazar/fields/EnumLevel2Field.php
+++ b/tools/bazar/fields/EnumLevel2Field.php
@@ -1,0 +1,322 @@
+<?php
+
+namespace YesWiki\Bazar\Field;
+
+use Psr\Container\ContainerInterface;
+use YesWiki\Bazar\Field\CheckboxEntryField;
+use YesWiki\Bazar\Field\CheckboxListField;
+use YesWiki\Bazar\Field\RadioEntryField;
+use YesWiki\Bazar\Field\RadioListField;
+use YesWiki\Bazar\Field\SelectEntryField;
+use YesWiki\Bazar\Field\SelectListField;
+use YesWiki\Bazar\Field\EnumField;
+
+/**
+ * @Field({"enumlevel2"})
+ */
+class EnumLevel2Field extends EnumField
+{
+    protected $displayMethod ; 
+    protected const FIELD_DISPLAY_METHOD = 7;
+
+    private $internalField;
+
+    public function __construct(array $values, ContainerInterface $services)
+    {
+        parent::__construct($values, $services);
+        $this->displayMethod = $values[self::FIELD_DISPLAY_METHOD];
+        $internalValues = $values;
+        switch ($this->displayMethod) {
+            case 'checkbox':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "";
+                $this->internalField = new CheckboxListField($internalValues,$services);
+                break;
+            case 'checkboxtags':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "tags";
+                $this->internalField = new CheckboxListField($internalValues,$services);
+                break;
+            case 'checkboxdragndrop':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "dragndrop";
+                $this->internalField = new CheckboxListField($internalValues,$services);
+                break;
+            case 'checkboxfiche':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "";
+                $this->internalField = new CheckboxEntryField($internalValues,$services);
+                break;
+            case 'checkboxfichetags':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "tags";
+                $this->internalField = new CheckboxEntryField($internalValues,$services);
+                break;
+            case 'checkboxfichedragndrop':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "dragndrop";
+                $this->internalField = new CheckboxEntryField($internalValues,$services);
+                break;
+            case 'radio':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "";
+                $this->internalField = new RadioListField($internalValues,$services);
+                break;
+            case 'radiotags':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "tags";
+                $this->internalField = new RadioListField($internalValues,$services);
+                break;
+            case 'radiodragndrop':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "dragndrop";
+                $this->internalField = new RadioListField($internalValues,$services);
+                break;
+            case 'radiofiche':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "";
+                $this->internalField = new RadioEntryField($internalValues,$services);
+                break;
+            case 'radiofichetags':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "tags";
+                $this->internalField = new RadioEntryField($internalValues,$services);
+                break;
+            case 'radiofichedragndrop':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "dragndrop";
+                $this->internalField = new RadioEntryField($internalValues,$services);
+                break;
+            case 'liste':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "";
+                $this->internalField = new SelectListField($internalValues,$services);
+                break;
+            case 'listefiche':
+                $internalValues[self::FIELD_DISPLAY_METHOD] = "";
+                $this->internalField = new SelectEntryField($internalValues,$services);
+                break;
+            
+            default:
+                $this->internalField = null;
+                break;
+        }
+    }
+
+    /**
+     * Render the edit view of the field. Check ACLS first
+     * @param array|null $entry
+     * @param string|null $userNameForRendering username to render the field, if empty uses connected user
+     * @return string|null $html
+     */
+    public function renderStaticIfPermitted($entry, ?string $userNameForRendering = null)
+    {
+        if (!$this->internalField) {
+            return '';
+        }
+        return $this->internalField->renderStaticIfPermitted($entry,$userNameForRendering);
+    }
+
+    // Render the edit view of the field. Check ACLS first
+    public function renderInputIfPermitted($entry)
+    {
+        if (!$this->internalField) {
+            // TODO add warning
+            return '';
+        }
+        // TODO find first level field and associated form to use it for input render
+        return $this->internalField->renderInputIfPermitted($entry);
+    }
+
+    public function formatValuesBeforeSaveIfEditable($entry, bool $isCreation = false)
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        // TODO filter on authorized values according to level 1
+        return $this->internalField->formatValuesBeforeSaveIfEditable($entry,$isCreation);
+    }
+
+    // Format input values before save
+    public function formatValuesBeforeSave($entry)
+    {
+        return $this->internalField->formatValuesBeforeSaveIfEditable($entry);
+    }
+
+    // HELPERS
+    /**
+     * Return true if we are if reading is allowed for the field
+     * @param array|null $entry
+     * @param string|null $userNameForRendering username to render the field, if empty uses connected user
+     * @return bool
+     */
+    public function canRead($entry, ?string $userNameForRendering = null)
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->canRead($entry, $userNameForRendering);
+    }
+
+    /* Return true if we are if editing is allowed for the field */
+    public function canEdit($entry, bool $isCreation = false)
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->canEdit($entry, $isCreation);
+    }
+
+    // EnumField proxy
+
+    public function loadOptionsFromList()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->loadOptionsFromList();
+    }
+
+    public function loadOptionsFromJson()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->loadOptionsFromJson();
+    }
+
+    public function loadOptionsFromEntries()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->loadOptionsFromEntries();
+    }
+
+    public function getLinkedObjectName()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->getLinkedObjectName();
+    }
+
+    // GETTERS
+
+    public function getPropertyName()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->getPropertyName();
+    }
+
+    public function getName()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->getName();
+    }
+
+    public function getLabel()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->getLabel();
+    }
+
+    public function getSize()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->getSize();
+    }
+
+    public function getMaxChars()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->getMaxChars();
+    }
+
+    public function getDefault()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->getDefault();
+    }
+
+    public function isRequired(): bool
+    {
+        if (!$this->internalField) {
+            return false;
+        }
+        return $this->internalField->isRequired();
+    }
+
+    public function getSearchable()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->getSearchable();
+    }
+
+    public function getHint()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->getHint();
+    }
+
+    public function getReadAccess()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->getReadAccess();
+    }
+
+    public function getWriteAccess()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->getWriteAccess();
+    }
+
+    public function getSemanticPredicate()
+    {
+        if (!$this->internalField) {
+            return null;
+        }
+        return $this->internalField->getSemanticPredicate();
+    }
+
+    // not proxy
+
+    public function getdisplayMethod()
+    {
+        return $this->displayMethod;
+    }
+    // ====
+
+    public function jsonSerialize()
+    {
+        if (!$this->internalField) {
+            return [
+                'id' => parent::getPropertyName(),
+                'propertyname' => parent::getPropertyName(),
+                'label' => parent::getLabel(),
+                'name' => parent::getName(),
+                'type' => parent::getType(),
+                'default' => parent::getDefault(),
+                'searchable' => parent::getSearchable(),
+                'required' => parent::isRequired(),
+                'helper' => parent::getHint(),
+                'read_acl' => parent::getReadAccess(),
+                'write_acl' => parent::getWriteAccess(),
+                'sem_type' => parent::getSemanticPredicate(),
+                'displayMethod' => $this->getdisplayMethod()
+                ];
+        } else {
+            $internalFieldData = $this->internalField->jsonSerialize();
+            $internalFieldData['type'] = $this->type;
+            $internalFieldData['displayMethod'] = $this->getdisplayMethod();
+            return $internalFieldData;
+        }
+    }
+}


### PR DESCRIPTION
Cette pull-request a pour objectif de créer un système de listes à plusieurs niveaux sans tout refaire dans YesWiki

_Ceci est d'abord une pull-request draft, qui propose les améliorations en se basant sur des développements custom.
**Ne pas prendre le code proposé comme valide pour fusion tant que les spécifications ne sont pas validées.**
le code est d'abord proposé comme base de travail des spécifications qui peuvent invalider tout ou partie des modifications courantes_.

**Proposition de spécifications**:
# Spécifications pour les listes à deux niveaux

Auteurs:

[JD]: Jérémy Dufraisse

[JD]: https://yeswiki.net/?JeremyDufraisse

 - [R01] : le niveau 1 DOIT être de type `checkboxfiche`, `listefiche` ou `radiofiche` qui pointe vers un formulaire qui contient les fiches de niveaux 1
 - [R01.1] : le formulaire associé DEVRAIT contenir un champ `EnumField` qui pointe vers une liste ou un autre formulaire qui représente le niveau 2
 - [R01.2] : la saisie des associations entre niveau 1 et 2 DOIT être faite par ce forumaire dédiée 
 - [R02] : un nouveau champ bazar DEVRAIT être créé pour permettre la définition des listes à deux niveaux
 - [R02.1] : son nom dans les formulaires DEVRAIT être `enumlevel2`
 - [R02.2] : la classe `EnumLevel2Field` DOIT étendre `EnumField`
 - [R02.3] : la classe `EnumLevel2Field` DEVRAIT être un proxy vers le bon type parmi `CheckboxEntryField` `CheckboxListField` `RadioEntryField` `RadioListField` `SelectEntryField` `SelectListField`
 - [R02.4] : un paramètre de type `subtype` DEVRAIT permettre de choisir le type de saisie dans le `formbuilder` afin de choisir à quel `Field` le champ `EnumLevel2Field` doit relier son proxy
 - [R02.5] : le type `enumlevel2` et son sous-type DEVRAIENT être correctement gérés par les facettes
 - [R02.6] : le nom de la liste ou du formulaire associé DOIT être identique au nom de la liste ou du formulaire associé utilisé pour les listes de niveau 1
 - [R03] : la liste de niveau 1 DEVRAIT être un champ standard de type `CheckboxEntryField` `CheckboxListField` `RadioEntryField` `RadioListField` `SelectEntryField` `SelectListField`
 - [R03.1] : le champ `enumlevel2` DOIT avoir un paramètre permettant de choisir le nom du champ associé dans le même formulaire pour le niveau 1
 - [R03.2] : si le champ `enumlevel2` n'a pas une valeur correcte pour le paramètre défini en [R03.1], il DOIT afficher un message d'erreur pendant la saisie des fiches
 - [R03.3] : un autre paramètre de `enumlevel2` DEVRAIT permettre de déterminer le nom du champ à utiliser dans le formulaire associé au niveau 1 (pratique pour différencier les champs multiples)
 - [R03.4] : en l'absence de valeur pour le paramètre de [R03.3], ce DEVRAIT être le premier champ qui correspond qui est retenu
 - [R04] : le niveau 1 DOIT être stocké normalement dans la fiche par le champ concerné
 - [R04.1] : le niveau 2 DOIT être stocké normalement dans la fiche par le champ concerné (comme si c'était un `EnumField` standard)
> [JD] : l'intérêt est qu'il n'y a rien à changer pour ce qui conerne l'affichage et le filtrage des données des fiches
 - [R05] : lors de la saisie des fiches, un script javascript dynamique DOIT automatiquement mettre à jour la liste des valeurs possibles pour le second niveau
 - [R05.1] : le script évoqué en [R05.1] peut être en `VueJS` (compatible versions 2 et 3)
 - [R05.2] : le mode de saisie du niveau 2 DOIT être le même que les champs standards associés (`checkbox`,`radio`,`list`, par tags, drags and drop, cases à cocher, données externes, ...)
 - [R05.3] : lors de l'enregistrement, les données DOIVENT être nettoyées pour s'assurer que le contenu du niveau 2 est bien associé au niveau 1 sinon, suppression de la valeur en trop
 - [R06] : au niveau des filtres (facettes), une intéractivité DEVRAIT être mise en place (ou réactivée) pour ajuster en temps réel le nombre de fiches restantes pour les autres filtres
 - [R06.1] : un nouveau paramètre de `bazarliste` DEVRAIT être créé pour choisir la règle entre les entrées d'un même filtre
 - [R06.2] : le paramètre de [R06.1] PEUT s'appeler `intrafilterrule`
 - [R06.3] : la valeur par défaut de `intrafilterrule` DEVRAIT être `or`
 - [R06.4] : les valeurs possibles pour `intrafilterrule` DEVRAIENT être `or` ou `and` (et leur syntaxe en majuscule ou équilavent)
 - [R06.5] comportement de la réactivité dans les filtres DEVRAIT être
   - `intrafilterrule == or`, pas de réactivité, comportement standard
   - `intrafilterrule == et`, activation de la réactivité
   - pour `enumlevel2`, activation de la mie à jour automatique du nombre de fiches pour le niveau 2, en fonction du niveau 1 dans tous les cas mais
     - si `intrafilterrule == or`, le nombre affiché correspond à toutes les fiches possibles en fonction du niveau 1
     - `intrafilterrule == et`, le nombre affiché correspond uniquement aux fiches possibles en fonction du niveau 1 et du niveau 2 déjà coché
> [JD]: le reste du filtrage est déjà assuré par YesWiki pour les fonctions standards pour tous les templates
 - [R07]: le niveau 1 PEUT être de type `enumlevel2`, ce qui permet de faire des listes à 3 niveaux avec toutes les informations stockées dans la fiche
----
### Ce que fait la branche en l'état
 - **branche non fonctionnelle**
 - début de création d'un nouveau champ `enumlevel2`

### Pour tester la branche en l'état
 - modifier un formulaire en mode texte en ajoutant une ligne comme si c'était `checkbox` mais en mettant `enumlevel2` à la place
