### PR TITLE
fix(barreredaction): display it when connected to display favorite button

### DIFF
--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -179,7 +179,7 @@ class EntryController extends YesWikiController
         }
 
         $user = $this->authController->getLoggedUser();
-        if (!empty($user) && $this->favoritesManager->areFavoritesActivated()) {
+        if (!empty($user) && $this->favoritesManager->areFavoritesActivated() && (testUrlInIframe() == 'iframe')) {
             $currentuser = $user['name'];
             $isUserFavorite = $this->favoritesManager->isUserFavorite($currentuser, $entryId);
         }

--- a/tools/templates/actions/barreredaction.php
+++ b/tools/templates/actions/barreredaction.php
@@ -9,7 +9,8 @@ use YesWiki\Core\Service\FavoritesManager;
 if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
 }
-if ($this->HasAccess("write") && $this->method != "revisions") {
+$user = $this->services->get(AuthController::class)->getLoggedUser();
+if ((!empty($user) || $this->HasAccess("write")) && $this->method != "revisions") {
     // on récupére la page et ses valeurs associées
     $page = $this->GetParameter('page');
     if (empty($page)) {
@@ -32,57 +33,58 @@ if ($this->HasAccess("write") && $this->method != "revisions") {
     // on peut ajouter des classes, la classe par défaut est .footer
     $barreredactionelements['class'] = ($this->GetParameter('class') ? 'footer '.$this->GetParameter('class') : 'footer');
 
-    // on ajoute le lien d'édition si l'action est autorisée
-    if ($this->HasAccess("write", $page) && !$this->services->get(SecurityController::class)->isWikiHibernated()) {
-        $barreredactionelements['linkedit'] = $this->href("edit", $page);
-    }
-
-    if ($time) {
-        // hack to hide E_STRICT error if no timezone set
-        date_default_timezone_set(@date_default_timezone_get());
-        $barreredactionelements['linkrevisions'] = $this->href("revisions", $page);
-        $barreredactionelements['time'] = date(_t('TEMPLATE_DATE_FORMAT'), strtotime($time));
-    }
-
-    // if this page exists
-    if ($content) {
-        $owner = $this->GetPageOwner($page);
-        // message
-        if ($this->UserIsOwner($page)) {
-            $barreredactionelements['owner'] = _t('TEMPLATE_OWNER')." : "._t('TEMPLATE_YOU');
-        } elseif ($owner) {
-            $barreredactionelements['owner'] = _t('TEMPLATE_OWNER')." : ".$owner;
-        } else {
-            $barreredactionelements['owner'] = _t('TEMPLATE_NO_OWNER');
+    if ($this->HasAccess("write")) {
+        // on ajoute le lien d'édition si l'action est autorisée
+        if ($this->HasAccess("write", $page) && !$this->services->get(SecurityController::class)->isWikiHibernated()) {
+            $barreredactionelements['linkedit'] = $this->href("edit", $page);
         }
 
-        // if current user is owner or admin
-        if ($this->UserIsOwner($page) || $this->UserIsAdmin()) {
-            $barreredactionelements['owner'] .= ' - '._t('TEMPLATE_PERMISSIONS');
-            if (!$this->services->get(SecurityController::class)->isWikiHibernated()) {
-                $barreredactionelements['linkacls'] = $this->href("acls", $page);
-                $barreredactionelements['linkdeletepage'] = $this->href("deletepage", $page);
+        if ($time) {
+            // hack to hide E_STRICT error if no timezone set
+            date_default_timezone_set(@date_default_timezone_get());
+            $barreredactionelements['linkrevisions'] = $this->href("revisions", $page);
+            $barreredactionelements['time'] = date(_t('TEMPLATE_DATE_FORMAT'), strtotime($time));
+        }
+
+        // if this page exists
+        if ($content) {
+            $owner = $this->GetPageOwner($page);
+            // message
+            if ($this->UserIsOwner($page)) {
+                $barreredactionelements['owner'] = _t('TEMPLATE_OWNER')." : "._t('TEMPLATE_YOU');
+            } elseif ($owner) {
+                $barreredactionelements['owner'] = _t('TEMPLATE_OWNER')." : ".$owner;
+            } else {
+                $barreredactionelements['owner'] = _t('TEMPLATE_NO_OWNER');
             }
-            $aclsService = $this->services->get(AclService::class);
-            $hasAccessComment = $aclsService->hasAccess('comment');
-            $barreredactionelements['wikigroups'] = $this->GetGroupsList();
-            if ($this->services->get(ParameterBagInterface::class)->get('comments_activated')) {
-                if ($hasAccessComment && $hasAccessComment !== 'comments-closed') {
-                    $barreredactionelements['linkclosecomments'] = $this->href("claim", $page, ['action' => 'closecomments'], false);
-                } else {
-                    $barreredactionelements['linkopencomments'] = $this->href("claim", $page, ['action' => 'opencomments'], false);
+
+            // if current user is owner or admin
+            if ($this->UserIsOwner($page) || $this->UserIsAdmin()) {
+                $barreredactionelements['owner'] .= ' - '._t('TEMPLATE_PERMISSIONS');
+                if (!$this->services->get(SecurityController::class)->isWikiHibernated()) {
+                    $barreredactionelements['linkacls'] = $this->href("acls", $page);
+                    $barreredactionelements['linkdeletepage'] = $this->href("deletepage", $page);
                 }
-            }
-        } elseif (!$owner && $this->GetUser()) {
-            $barreredactionelements['owner'] .= " - "._t('TEMPLATE_CLAIM');
-            if (!$this->services->get(SecurityController::class)->isWikiHibernated()) {
-                $barreredactionelements['linkacls'] = $this->href("claim", $page);
+                $aclsService = $this->services->get(AclService::class);
+                $hasAccessComment = $aclsService->hasAccess('comment');
+                $barreredactionelements['wikigroups'] = $this->GetGroupsList();
+                if ($this->services->get(ParameterBagInterface::class)->get('comments_activated')) {
+                    if ($hasAccessComment && $hasAccessComment !== 'comments-closed') {
+                        $barreredactionelements['linkclosecomments'] = $this->href("claim", $page, ['action' => 'closecomments'], false);
+                    } else {
+                        $barreredactionelements['linkopencomments'] = $this->href("claim", $page, ['action' => 'opencomments'], false);
+                    }
+                }
+            } elseif (!$owner && $this->GetUser()) {
+                $barreredactionelements['owner'] .= " - "._t('TEMPLATE_CLAIM');
+                if (!$this->services->get(SecurityController::class)->isWikiHibernated()) {
+                    $barreredactionelements['linkacls'] = $this->href("claim", $page);
+                }
             }
         }
     }
     $barreredactionelements['linkshare'] = $this->href("share", $page);
 
-    $user = $this->services->get(AuthController::class)->getLoggedUser();
     $favoritesManager = $this->services->get(FavoritesManager::class);
     if (!empty($user) && $favoritesManager->areFavoritesActivated()) {
         $barreredactionelements['currentuser'] = $user['name'];


### PR DESCRIPTION
Toute petite PR mais qui change l'affichage donc je préfère demander avant fusion.

@mrflos la barreredaction ne s'affiche pas si on a pas les droits de modification de la page.

Mais certains liens sont utiles pour les usagers même s'ils n'ont pas les droits de modification de la page :
 - bouton de partage
 - nouveau bouton pour les favoris

La proposition est d'afficher la barre de rédaction pour toutes les personnes connectées mais uniquement avec les boutons partage et favoris si la personne n'a pas les droits de modification de la page.
Pour éviter de surcharger l'interface, le bouton des favoris n'est affiché dans la barre d'action des fiches que pour `/iframe`

@mrflos serais-tu d'accord pour cette modification de comportement de la barre rédaction ? (modification légère)
