### PR TITLE
fix(bazar) : more classical image upload to avoid errors on big inputs

### DIFF
--- a/includes/entities/User.php
+++ b/includes/entities/User.php
@@ -80,7 +80,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, ArrayAc
         return (in_array($offset, self::PROPS_LIST));
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset) : mixed
     {
         if (!$this->offsetExists($offset)) {
             throw new UserNotExistingOffset("Not existing $offset in User!");

--- a/tools/bazar/presentation/javascripts/image-field.js
+++ b/tools/bazar/presentation/javascripts/image-field.js
@@ -68,8 +68,6 @@ function handleFileSelect(evt) {
           var span = document.createElement('span');
           span.innerHTML = `<img class="img-responsive" style="${css}" src="${e.target.result}" title="${escape(theFile.name)}"/>`;
           document.getElementById('img-'+id).innerHTML = span.innerHTML;
-          document.getElementById('data-'+id).value = e.target.result;
-          document.getElementById('filename-'+id).value = theFile.name;
         });
 
       };

--- a/tools/bazar/templates/inputs/image.twig
+++ b/tools/bazar/templates/inputs/image.twig
@@ -43,6 +43,4 @@
         >
         <output id="img-{{ field.propertyName }}" class="col-xs-9"></output>
     {% endif %}
-    <input type="hidden" id="data-{{ field.propertyName }}" name="data-{{ field.propertyName }}" />
-    <input type="hidden" id="filename-{{ field.propertyName }}" name="filename-{{ field.propertyName }}" />
 {% endblock %}


### PR DESCRIPTION
## Description of pull request / Description de la demande d'ajout
On some hosting services like infomaniak.ch , big input hidden with image content are cut while POST on server is executed.
cf. Louis Derrac messages on "Centre-ville" channel of framateam
I propose to use classical and standard file upload like for the other files.

@J9rem what do you think?

PS: i also included a type on return funciton in includes/entities/user.php to handle an deprecated error on php 8.1
