### PR TITLE
add missing docker-dompose.local.yml in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ tools/*
 
 # Docker
 .db
+docker-compose.local.yml
 
 # Other
 .phpintel/


### PR DESCRIPTION
Makefile optionaly accepts a docker-compose.local.yml file, but it should be gitignored.