### PR TITLE
Install message admin account

### DIFF
--- a/setup/default.php
+++ b/setup/default.php
@@ -231,6 +231,7 @@ if (!defined('WIKINI_VERSION')) {
           <label class="col-sm-3 control-label"><?php echo _t('ADMIN'); ?></label>
           <div class="col-sm-9">
             <input type="text" required class="form-control" name="admin_name" value="" />
+            <p class="help-block"><?php echo _t('USERNAME_MUST_BE_WIKINAME'); ?></p>
           </div>
         </div>
 

--- a/setup/default.php
+++ b/setup/default.php
@@ -230,8 +230,7 @@ if (!defined('WIKINI_VERSION')) {
         <div class="form-group">
           <label class="col-sm-3 control-label"><?php echo _t('ADMIN'); ?></label>
           <div class="col-sm-9">
-            <input type="text" required class="form-control" name="admin_name" value="WikiAdmin" />
-            <p class="help-block"><?php echo _t('MUST_BE_WIKINAME'); ?></p>
+            <input type="text" required class="form-control" name="admin_name" value="" />
           </div>
         </div>
 

--- a/tools/login/templates/user-signup-form.twig
+++ b/tools/login/templates/user-signup-form.twig
@@ -12,7 +12,6 @@
   <div class="control-group form-group">
   <label class="control-label col-sm-3">{{ _t('USER_USERNAME') }}
     <span class='form-help fa fa-question-circle'
-      title="{{ _t('USERNAME_MUST_BE_WIKINAME') }}"
       onclick="$(this).tooltip('toggle');"
       onmouseover="$(this).tooltip('toggle');">
     </span>

--- a/tools/login/templates/user-signup-form.twig
+++ b/tools/login/templates/user-signup-form.twig
@@ -12,6 +12,7 @@
   <div class="control-group form-group">
   <label class="control-label col-sm-3">{{ _t('USER_USERNAME') }}
     <span class='form-help fa fa-question-circle'
+      title="{{ _t('USERNAME_MUST_BE_WIKINAME') }}"
       onclick="$(this).tooltip('toggle');"
       onmouseover="$(this).tooltip('toggle');">
     </span>


### PR DESCRIPTION
There is no need for username to be camelcase. But there are some rules stil, which are provided in `USERNAME_MUST_BE_WIKINAME` but only for french and english. Other translations are not up to date.

Also, suggesting the username for admin, imho, is not good, as many times the first person installing will then think they have to create another account for personal use. I like it when I can just create the first admin account with my own name. Leaving that field empty makes it clearer that it is just a user choice.