### PR TITLE
Add account activation by mail functionality

### DIFF
--- a/actions/activateuser.php
+++ b/actions/activateuser.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * activateuser.php
+ *
+ * parameters :
+ *		user=user
+ *		key= key
+ * Author : Yves Gufflet
+ *
+*/
+
+	if (!defined('WIKINI_VERSION')) {
+		die('acc&egrave;s direct interdit');
+	}
+
+	use YesWiki\Core\Service\UserManager;
+	use YesWiki\Core\Service\Mailer;
+
+	// Retrieve user manger and triple store for further use
+
+	$vUserManager = $this->services->get(UserManager::class);
+	
+	// Retrieve user and key from action parameters
+
+	$vUser = $_GET [ACTIONPARAMETER_ACTIVATEUSER_USER];
+	$vKey = urldecode ($_GET [ACTIONPARAMETER_ACTIVATEUSER_KEY]);
+
+	// Try to activate the account
+	
+	if ($vUserManager->activateUser ($vUser, $vKey))
+	{	
+		echo ('<div class="alert alert-success">The account was activated successfully. You can now log in using your login credentials.</div>');
+
+		$vUserMail = $vUserManager->getOneByName ($vUser)["email"];
+		$vMailer = $this->services->get(Mailer::class);
+		$vMailer->notifyNewUser($vUser, $vUserMail);
+	}
+	else
+	{
+		echo ('<div class="alert alert-danger">Cannot activate the user account.</div>');
+	}
+		
+?>

--- a/actions/inactivateuser.php
+++ b/actions/inactivateuser.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * inactivateuser.php
+ *
+ * parameters :
+ *		user=user
+ *		key= key
+ * Author : Yves Gufflet
+ *
+*/
+
+	if (!defined('WIKINI_VERSION')) {
+		die('acc&egrave;s direct interdit');
+	}
+
+	use YesWiki\Core\Service\UserManager;
+	
+	// Retrieve user manger and triple store for further use
+
+	$vUserManager = $this->services->get(UserManager::class);
+	
+	// Retrieve user and key from action parameters
+
+	$vUser = $_GET [ACTIONPARAMETER_INACTIVATEUSER_USER];
+	$vKey = urldecode ($_GET [ACTIONPARAMETER_INACTIVATEUSER_KEY]);
+
+	// Try to activate the account
+	
+	if ($vUserManager->inactivateUser ($vUser, $vKey))
+	{
+		echo ('<div class="alert alert-success">The user account was inactivated successfully.</div>');
+	}
+	else
+	{
+		echo ('<div class="alert alert-danger">Cannot inactivate the user account.</div>');
+	}
+			
+?>

--- a/includes/YesWikiInit.php
+++ b/includes/YesWikiInit.php
@@ -243,6 +243,8 @@ class Init
             'wakka_name' => '', // backup wakka_name if deleted from wakka.config.php
             'htmlPurifierActivated' => false, // TODO ectoplasme set to true
             'favorites_activated' => true,
+            'signup_mail_activation' => true, 		// Activate the signup activation mail process
+		    'user_activation_key_length' => 20		// lenght of activation/inactivation keys
         );
         unset($_rewrite_mode);
 

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -55,3 +55,41 @@ define('WIKINI_VOC_ACLS_URI', WIKINI_VOC_PREFIX . WIKINI_VOC_ACLS);
 
 // for package updates
 define('SEMVER', '(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?');
+
+//////////////////////////////////////////////////////////////////////// - yg
+// ForUser signin validation process and login
+
+// User Activation/Inactivation pages
+
+define ("ACTIVATEUSERPAGE", "ActivateUser");
+define ("INACTIVATEUSERPAGE", "InactivateUser");
+
+// $_GET parameters name for activation/inactivation link
+
+define ("ACTIONPARAMETER_ACTIVATEUSER_USER", "u");	// user
+define ("ACTIONPARAMETER_ACTIVATEUSER_KEY", "k");	// key
+
+define ("ACTIONPARAMETER_INACTIVATEUSER_USER", ACTIONPARAMETER_ACTIVATEUSER_USER);
+define ("ACTIONPARAMETER_INACTIVATEUSER_KEY", ACTIONPARAMETER_ACTIVATEUSER_KEY);
+
+// Make it harder for a potential hacker who might have access to the DB and not the FS to read and understand the meaning of properties and values in the triples table
+// It is perhaps unusefull at his points since it may be understood quite easily by changing the values in the DB but it has no cost to do it since we use constants ("Y" = "whatever we want", ...)
+// Furthermore the activation status and key might be encrypted with a per-server generated key stored in the FS so that activating/inactivating an account by modifying the values in DB becomes "impossible"
+// The strings used are composed of 0 and O, more confusing for the eyes. Furthermore there is the same numbers of O and 0 to try to deal with statistics crytanaalysis.
+
+define ("TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY", '');			// Prefixes used in the 
+define ("TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY", "0O0O00OO");	// TripleStore methods : create, update, delete, etc...
+define ("TRIPLEVALUEPREFIX_ACCOUNTSECURITY", TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY); // Add confusion for values
+	
+define ("TRIPLEPROPERTY_USER_ACTIVATIONKEY", 		"0O00O0OO"); // properties name must differ (case insensitive)
+define ("TRIPLEPROPERTY_USER_INACTIVATIONKEY", 		"00O0O0OO");
+define ("TRIPLEPROPERTY_USER_ISACTIVATED", 			"0O0O00OO");
+	
+define ("TRIPLEVALUE_USER_ISACTIVATED_YES", TRIPLEVALUEPREFIX_ACCOUNTSECURITY .	"0O0OO00O"); // values name must differ (case insensitive)
+define ("TRIPLEVALUE_USER_ISACTIVATED_NO", TRIPLEVALUEPREFIX_ACCOUNTSECURITY .	"0O0O0O0O");
+
+//
+////////////////////////////////////////////////////////////////////////
+
+
+

--- a/includes/services/Mailer.php
+++ b/includes/services/Mailer.php
@@ -121,7 +121,7 @@ class Mailer
     public function sendEmailFromAdmin(string $address, string $subject, string $text, string $html = "")
     {
         include_once 'includes/email.inc.php';
-        send_mail(
+        return send_mail(
             $this->params->get('BAZ_ADRESSE_MAIL_ADMIN'),
             $this->params->get('BAZ_ADRESSE_MAIL_ADMIN'),
             $address,

--- a/includes/services/UserManager.php
+++ b/includes/services/UserManager.php
@@ -359,6 +359,393 @@ class UserManager implements UserProviderInterface, PasswordUpgraderInterface
         return is_a($class, User::class, true);
     }
 
+	/** 
+	 *	Get a new activation link
+	*/
+
+	public function getActivationLink ($pUser)
+	{
+		// Retrieve wiki and triplestore for further use
+	
+		$vWiki = $this->wiki;	
+		$vTripleStore = $vWiki->services->get(TripleStore::class);
+
+		// Let's create an activation key suitable for a mail
+
+		$vKey = base64_encode(random_bytes ($vWiki->GetConfigValue ("user_activation_key_length")));
+
+		// Store the key in the TripleStore
+							
+		$vTripleStore->Create ($pUser, TRIPLEPROPERTY_USER_ACTIVATIONKEY, $vKey, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY);
+
+		// Create and return the link
+		
+		return ($vWiki->GetConfigValue ("base_url")) . ACTIVATEUSERPAGE . "&" . ACTIONPARAMETER_ACTIVATEUSER_USER . "=" . $pUser . "&" . ACTIONPARAMETER_ACTIVATEUSER_KEY . "=" . (urlencode($vKey));
+	}
+	
+	/** 
+	 *	Get a new inactivation link
+	 * @params : 
+	 * - $pUser : the user name
+	*/
+
+	public function getInactivationLink ($pUser)
+	{
+		// Retrieve wiki and triplestore for further use
+	
+		$vWiki = $this->wiki;	
+		$vTripleStore = $vWiki->services->get(TripleStore::class);
+
+		// Let's create an activation key
+
+		$vKey = base64_encode(random_bytes ($vWiki->GetConfigValue ("user_activation_key_length")));
+
+		// Store the key in the TripleStore
+							
+		$vTripleStore->Create ($pUser, TRIPLEPROPERTY_USER_INACTIVATIONKEY, $vKey, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY);
+
+		// Create and return the link
+		
+		return ($vWiki->GetConfigValue ("base_url")) . INACTIVATEUSERPAGE . "&" . ACTIONPARAMETER_INACTIVATEUSER_USER . "=" . $pUser . "&" . ACTIONPARAMETER_INACTIVATEUSER_KEY . "=" .  (urlencode($vKey));
+	}
+
+	/* 
+     * Activate a user account
+     * @params : 
+     * - $pUser : the user name
+     * - $pKey : the activation key
+     * - $pForce : boolean indicating if we want to ignore the key and force activation
+	*/
+	
+	public function activateUser ($pUser, $pKey, $pForce = false)
+	{	
+		//////////////////////////////////////////
+		// INITIALIZATION
+		
+		// Retrieve wiki and triplestore for further use
+	
+		$vWiki = $this->wiki;	
+		$vTripleStore = $vWiki->services->get(TripleStore::class);
+
+		// There is no alert message and no error yet. The user was not activated yet.
+	
+		$vAlertMessage = "";	
+		$vError = false;
+		$vActivated = false;	
+
+		///////////////////////////////////////////
+		// CHECK PARAMETERS
+
+		// Validate user and key parameters
+
+		if (empty ($pUser))
+		{
+			// Trying to call activation with bad parameters : should not occures since the user is using a link provided by yeswiki
+			$vAlertMessage .= "Trying to call activation with bad parameters (empty user). ";
+			$vError = true;
+		}
+			
+		if (empty ($vWiki->LoadUser($pUser)))
+		{
+			// Trying to activate an inexistent user : the user might have been removed before
+			$vAlertMessage .= "Trying to activate an inexistent user. ";
+			$vError = true;
+		}
+		
+		if (!$pForce) // We check the key if needed (through activation link)
+		{
+			if (empty ($pKey))
+			{
+				// Trying to call activation with bad parameters : should not occures since the user is using a link provided by yeswiki
+				$vAlertMessage .= "Trying to call activation with bad parameters (empty key). ";
+				$vError = true;
+			}
+			
+			if (preg_match ('/[A-Za-z0-9+\/=]+/', $pKey) !== 1)
+			{
+				// The key has an invalid format. It should not occures since the user is using a link provided by yeswiki kernel
+				$vAlertMessage .= "The activation key for user " . $pUser . "is in an invalid format : " . (base64_encode($pKey)) . " (base64 encoded). ";
+				$vError = true;
+			}
+		}
+	
+		//////////////////////////////////////////
+		// ACTIVATION 
+	
+		// if there was no error we continue the activation process
+	
+		if (!$vError)
+		{	
+			// Check the activation status of the user
+			
+			$vIsActivated = $vTripleStore->GetOne ($pUser, TRIPLEPROPERTY_USER_ISACTIVATED, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY);
+
+			if ($vIsActivated === TRIPLEVALUE_USER_ISACTIVATED_NO)
+			{				
+				// If the activation/inactivation key for the user exists or if we force activation (yeswiki core call)...
+			
+				if ($pForce || $vTripleStore->exist ($pUser, TRIPLEPROPERTY_USER_ACTIVATIONKEY, $pKey, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY) !== null)
+				{
+	
+					// ... We activate the account ...
+								
+					$vRes = $vTripleStore->update ($pUser, TRIPLEPROPERTY_USER_ISACTIVATED, TRIPLEVALUE_USER_ISACTIVATED_NO, TRIPLEVALUE_USER_ISACTIVATED_YES, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY); 
+
+					// 0 (succès)
+					// 1 (échec)
+					// 2 ($resource, $property, $oldvalue does not exist)
+					// 3 ($resource, $property, $newvalue already exists)
+							
+					if ($vRes == 0) //succès
+					{
+						// We remove all obsolete activation keys from the database
+					
+						$vTripleStore->delete ($pUser, TRIPLEPROPERTY_USER_ACTIVATIONKEY, null, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY);				
+
+						$vActivated = true;						
+					}		
+					else
+					{			
+						$vError = true;						
+						$vAlertMessage .= "Cannot update activation status for user " . $pUser . " (error code = " . $vRes . ")";						
+					}							
+				}
+				else // ... else if the activation key is unknown we report it to the admin to deal with security issues
+				{					
+					// A activation link might have been clicked for a second time					
+					$vAlertMessage .= "The activation key " . (base64_encode($pKey)) . " (base64 encoded) for user " . $pUser .  " is invalid. Security issue ? ";
+					$vError = true;				
+				}
+			}
+			else
+			if ($vIsActivated === TRIPLEVALUE_USER_ISACTIVATED_YES)
+			{
+				// The account is already activated
+				// An activation link might have been clicked for a second time
+				// There is nothing to do
+				
+				$vActivated = true;
+				
+				echo ("The account is already activated. ");
+			}
+			else
+			if ($vIsActivated == null)
+			{				
+				if ($pForce) // The activation status is not yet defined (account creation)
+				{			
+					// We activate the account 
+								
+					$vRes = $vTripleStore->create ($pUser, TRIPLEPROPERTY_USER_ISACTIVATED, TRIPLEVALUE_USER_ISACTIVATED_YES, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY); 
+
+					// 0 (succès)
+					// 1 (échec)
+					// 3 ($resource, $property, $value already exists) - should not occures since we tested it before
+							
+					if ($vRes == 0) //succès
+					{
+						// We remove all obsolete activation keys from the database
+					
+						$vTripleStore->delete ($pUser, TRIPLEPROPERTY_USER_ACTIVATIONKEY, null, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY);				
+
+						$vActivated = true;			
+					}		
+					else
+					{		
+						$vError = true;						
+						$vAlertMessage .= "Cannot create activation status for user " . $pUser . " (error code = " . $vRes . ")";									
+					}			
+				}
+				else
+				{
+					// It should not occures : the activation process should have added the key before.
+					$vAlertMessage .= "It should not occures : the activation process should have added the IsActivated key before. ";
+					$vError = true;
+				}
+			}
+			else		
+			{
+				// Should not occures : security issue				
+				$vAlertMessage .= "It should not occures : the DB might have been corrupted. ";
+				$vError = true;
+			}
+		}
+		
+		if ($vAlertMessage !== "" && $vWiki->GetConfigValue ("debug") === "yes") echo ($vAlertMessage); // TODO : send $vAlertMessage to the security manager
+		
+		if ($vError && $vWiki->GetConfigValue ("debug") === "yes") echo ("Something wents wrong. ");
+
+		return $vActivated;
+	}	
+
+	/* 
+     * Inactivate a user account
+     * @params : 
+     * - $pUser : the user name
+     * - $pKey : the activation key
+     * - $pForce : boolean indicating if we want to ignore the key and force activation
+	*/
+	
+	public function inactivateUser ($pUser, $pKey, $pForce = false)
+	{				
+		//////////////////////////////////////////
+		// INITIALIZATION
+		
+		// Retrieve wiki and triplestore for further use
+	
+		$vWiki = $this->wiki;	
+		$vTripleStore = $vWiki->services->get(TripleStore::class);
+
+		// There is no alert message and no error yet. The user was not inactivated yet.
+	
+		$vAlertMessage = "";	
+		$vError = false;
+		$vInactivated = false;	
+
+		///////////////////////////////////////////
+		// CHECK PARAMETERS
+
+		// Validate user and key parameters
+
+		if (empty ($pUser))
+		{
+			// Trying to call inactivation with bad parameters : should not occures since the user is using a link provided by yeswiki
+			$vAlertMessage .= "Trying to call inactivation with bad parameters (empty user). ";
+			$vError = true;
+		}
+			
+		if (empty ($vWiki->LoadUser($pUser)))
+		{
+			// Trying to inactivate an inexistent user : the user might have been removed before
+			$vAlertMessage .= "Trying to inactivate an inexistent user. ";
+			$vError = true;
+		}
+		
+		if (!$pForce) // We check the key if needed (through activation link)
+		{
+			if (empty ($pKey))
+			{
+				// Trying to call inactivation with bad parameters : should not occures since the user is using a link provided by yeswiki
+				$vAlertMessage .= "Trying to call inactivation with bad parameters (empty key). ";
+				$vError = true;
+			}
+			
+			if (preg_match ('/[A-Za-z0-9+\/=]+/', $pKey) !== 1)
+			{
+				// The key has an invalid format. It should not occures since the user is using a link provided by yeswiki kernel
+				$vAlertMessage .= "The inactivation key for user " . $pUser . "is in an invalid format : " . (base64_encode($pKey)) . " (base64 encoded). ";
+				$vError = true;
+			}
+		}
+
+		//////////////////////////////////////////
+		// INACTIVATION 
+	
+		// if there was no error we continue the inactivation process
+	
+		if (!$vError)
+		{	
+			// Check the activation status of the user
+			
+			$vIsActivated = $vTripleStore->GetOne ($pUser, TRIPLEPROPERTY_USER_ISACTIVATED, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY);
+
+			if ($vIsActivated === TRIPLEVALUE_USER_ISACTIVATED_YES)
+			{			
+				// If the activation/inactivation key for the user exists...
+			
+				if ($pForce || $vTripleStore->exist ($pUser, TRIPLEPROPERTY_USER_INACTIVATIONKEY, $pKey, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY) !== null)
+				{
+	
+					// ... We inactivate the account ...
+								
+					$vRes = $vTripleStore->update ($pUser, TRIPLEPROPERTY_USER_ISACTIVATED, TRIPLEVALUE_USER_ISACTIVATED_YES, TRIPLEVALUE_USER_ISACTIVATED_NO, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY); 
+
+					// 0 (succès)
+					// 1 (échec)
+					// 2 ($resource, $property, $oldvalue does not exist)
+					// 3 ($resource, $property, $newvalue already exists)
+							
+					if ($vRes == 0) //succès
+					{
+						// We remove all obsolete inactivation keys from the database
+					
+						$vTripleStore->delete ($pUser, TRIPLEPROPERTY_USER_INACTIVATIONKEY, null, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY);				
+
+						$vInactivated = true;
+					}		
+					else
+					{			
+						$vError = true;						
+						$vAlertMessage .= "Cannot update activation status for user " . $pUser . " (error code = " . $vRes . ")";						
+					}							
+				}
+				else // ... else if the inactivation key is unknown we report it to the user and the admin
+				{					
+					// A inactivation link might have been clicked for a second time
+					$vError = true;
+					$vAlertMessage = "The inactivation key " . (base64_encode($pKey)) . " (base64 encoded) for user " . $pUser .  " is invalid. Security issue ?";
+				}
+			}
+			else
+			if ($vIsActivated === TRIPLEVALUE_USER_ISACTIVATED_NO)
+			{
+				// The account is already inactivated
+				// An inactivation link might have been clicked for a second time
+				// There is nothing to do
+				
+				$vInactivated = true;
+			}
+			else
+			if ($vIsActivated == null)
+			{				
+				if ($pForce) // The activation status is not yet defined (account creation)
+				{			
+					// We create the status and inactivate the account 
+								
+					$vRes = $vTripleStore->create ($pUser, TRIPLEPROPERTY_USER_ISACTIVATED, TRIPLEVALUE_USER_ISACTIVATED_NO, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY); 
+
+					// 0 (succès)
+					// 1 (échec)
+					// 3 ($resource, $property, $value already exists) - should not occures since we tested it before
+							
+					if ($vRes == 0) //succès
+					{
+						// We remove all obsolete activation/inactivation keys from the database
+					
+						$vTripleStore->delete ($pUser, TRIPLEPROPERTY_USER_INACTIVATIONKEY, null, TRIPLERESSOURCEPREFIX_ACCOUNTSECURITY, TRIPLEPROPERTYPREFIX_ACCOUNTSECURITY);				
+
+						$vInactivated = true;
+					}		
+					else
+					{		
+						$vError = true;						
+						$vAlertMessage .= "Cannot create activation status for user " . $pUser . " (error code = " . $vRes . ")";									
+					}			
+				}
+				else
+				{
+					// It should not occures : the inactivation process should have added the key before.
+					$vAlertMessage .= "It should not occures : the inactivation process should have added the IsActivated key before. ";
+					$vError = true;
+				}
+			}
+			else		
+			{
+				// Should not occures : security issue
+				// send $vAlertMessage to the security manager
+				$vAlertMessage .= "It should not occures : the DB might have been corrupted. ";
+				$vError = true;
+			}
+		}
+
+		// If there is an alert me might signal it to the security manager - TO DO
+		
+		if ($vAlertMessage !== "" && $vWiki->GetConfigValue ("debug") === "yes") echo ($vAlertMessage); // TODO : send $vAlertMessage to the security manager
+		
+		if ($vError && $vWiki->GetConfigValue ("debug") === "yes") echo ("Something wents wrong. ");
+
+		return $vInactivated;
+	}	
+
     /**
      * @return User
      *

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -19,7 +19,6 @@ use YesWiki\Core\Service\PageManager;
 use YesWiki\Core\Service\TemplateEngine;
 use YesWiki\Core\YesWikiController;
 use YesWiki\Security\Controller\SecurityController;
-use YesWiki\Core\Service\Mailer;
 
 class EntryController extends YesWikiController
 {

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -19,6 +19,7 @@ use YesWiki\Core\Service\PageManager;
 use YesWiki\Core\Service\TemplateEngine;
 use YesWiki\Core\YesWikiController;
 use YesWiki\Security\Controller\SecurityController;
+use YesWiki\Core\Service\Mailer;
 
 class EntryController extends YesWikiController
 {
@@ -32,7 +33,7 @@ class EntryController extends YesWikiController
     protected $templateEngine;
     protected $config;
     protected $securityController;
-
+    
     private $parentsEntries ;
 
     public function __construct(
@@ -236,7 +237,7 @@ class EntryController extends YesWikiController
             list($state, $error) = $this->securityController->checkCaptchaBeforeSave('entry');
             try {
                 if ($state && isset($_POST['bf_titre'])) {
-                    $entry = $this->entryManager->create($formId, $_POST);
+                    $entry = $this->entryManager->create($formId, $_POST);                    
                     if (empty($redirectUrl)) {
                         $redirectUrl = $this->wiki->Href(
                             testUrlInIframe(),

--- a/tools/bazar/fields/UserField.php
+++ b/tools/bazar/fields/UserField.php
@@ -181,7 +181,8 @@ class UserField extends BazarField
             // Do not send mails if we are importing
             // TODO improve import detection
             if (!$isImport) {
-                $mailer->notifyNewUser($wikiName, $entry[$this->emailField]);
+                if ($wiki->GetConfigValue ("signup_mail_activation") !== "1") // Do not notify the user now if we are waiting for an account activation by mail
+                	$mailer->notifyNewUser($wikiName, $entry[$this->emailField]);
 
                 // Check if we need to subscribe the user to a mailing list
                 if (isset($this->mailingList) && $this->mailingList != '') {

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -586,28 +586,11 @@ class EntryManager
 			{	
 				// Inactivate the account first
 			
-				$userManager->inactivateUser ($GLOBALS['utilisateur_wikini'], "", true);
+				$userManager->inactivateUser ($GLOBALS['utilisateur_wikini'], "" /* empty key */, true /* ignore key and force inactivation */);
 
-				// Ask for an activation link
-
-				$vActivationLink = $userManager->getActivationLink ($GLOBALS['utilisateur_wikini']);
-				
-				// Send a mail to the user with the activation link
-					
-				$vUser = $this->userManager->getOneByName($GLOBALS['utilisateur_wikini']);
-	
-				$vMail = $vUser ["email"];
-					
-				$vMailer = $vWiki->services->get(Mailer::class);
-
-				if ($vMailer->sendEmailFromAdmin($vMail, 
-							"Activation de votre compte", 
-							"Cliquez sur ce lien ou copier/coller le dans la barre d'adresse de votre navigateur pour activer votre compte : " . 
-								$vActivationLink, 
-							"Cliquez sur ce lien ou copier/coller le dans la barre d'adresse de votre navigateur pour activer votre compte : " . 
-								"<a href='" . $vActivationLink . "'>" . $vActivationLink . "</a>"))
+				if ($userManager->sendActivationLink ($GLOBALS['utilisateur_wikini']))
 				{										
-					// On redirige vers une page sans menu qui explique qu'il faut cliquer sur le lien pour activer le compte.
+					// We redirect to a page indicating that a mail was sent to the user in order to activate his account
 						
 					$userManager->logout ();										
 					$redirectUrl = ($vWiki->GetConfigValue("base_url")) . "ActivationLinkSent";

--- a/tools/login/actions/LoginAction.php
+++ b/tools/login/actions/LoginAction.php
@@ -204,6 +204,13 @@ class LoginAction extends YesWikiAction
                 throw new LoginException(_t('LOGIN_WRONG_PASSWORD'));
             }
             $remember = filter_input(INPUT_POST, 'remember', FILTER_VALIDATE_BOOL);
+            if (($this->wiki->GetConfigValue ("signup_mail_activation") === "1") && !$this->userManager->isActivated ($user["name"])){
+                throw new LoginException("Your account must be activated first. " . (
+                    $this->userManager->sendActivationLink ($user["name"])
+                    ? "An email was sent to you with the instruction to activate you account."
+                    : "There was a problem to send you an mail to activate you account. Please contact the website administrator."
+                ));
+            }
             $this->authController->login($user, $remember);
             
             // si l'on veut utiliser la page d'accueil correspondant au nom d'utilisateur


### PR DESCRIPTION
PR from #971 replace it after creation of a dedicated branch

from @VeveQNV (#971)

>Add account activation by mail functionnality. The functionnality uses some simple pages for actions or messages that need to be created in the DB ActivationLinkSent, ActivateUser, InactivateUser. If you want to go integrate these commits we need to discuss theses points. 

>If the parameter signup_mail_activation is set to true in the config then an account activation by mail procedure is used to handle account login.
In this case, after the user creation, the user is redirected to a page which indicates that a mail was sent with instruction to activate the account : ActivationLinkSent page need to be created.
In the mai there is a link : the link redirect to a page ActivateUser containing the action {{ activate user}}
Once the user click on the link in the email, the account is activated and the user can login.
If the user try to log in while his account is inactivated an error message is displayed and a new activation mail is sent.
The activation mail contain a link with a key that is checked before to execute activation.
The size of the key is defined by the parameter user_activation_key_length in the config file
Activation and inactivation keys are store in the tables triples.
The activation status of a user is stored in the tables triples.
The activation key and status properties and values are encoded see comments in constants.php 
An encryption of this data would be a further step to avoid activation of user by a hacker having access to the db.

>This works for my project : it was my goal.
Let me know if you are interested to include it in doryphore dev.
@mrflos @J9rem 

>ps : I am not yet fully operationnal with git, perhaps there are some strange things in the process. Please let me know what I am doing wrong. sorry for the approximate english