### PR TITLE
Docsify - prevent syntax conflict with {{ }}

### DIFF
--- a/javascripts/documentation.js
+++ b/javascripts/documentation.js
@@ -1,4 +1,8 @@
 window.$docsify = {
+    vueGlobalOptions: {
+      // use {% %} for Vue code so it does not conflict with our {{ }} action syntax
+      delimiters: ['{%', '%}'],
+    },
     homepage: `docs/${wiki.locale}/README.md`,
     loadSidebar: true,
     loadNavbar: true,


### PR DESCRIPTION
## Problem
Docsify use Vue behind the scene. And Vue default delimiter is `{{ }}`
So when in the doc we want to display a yeswiki action like `{{bazarliste}}` it's interpreted as Vue interpolation

## Solution
Change default Vue delimiter to use `{% %}` so there are no more conflicts