### PR TITLE
feat(docsify+exts): add docs for extensions

### DIFF
--- a/docs/users/fr/_navbar.md
+++ b/docs/users/fr/_navbar.md
@@ -8,6 +8,7 @@
 * [Administration](/docs/users/fr/admin.md)
 * [Installation](/docs/users/fr/webmaster.md)
 * [Développement](/docs/users/fr/dev.md)
+* [Extensions](/ ':id=extensions-links')
 * 🔧
   * [Comment contribuer à cette doc](/docs/users/README.md)
   * [Liste des choses à faire sur la doc](/docs/users/TODO.md)

--- a/includes/controllers/DocumentationController.php
+++ b/includes/controllers/DocumentationController.php
@@ -13,10 +13,23 @@ class DocumentationController extends YesWikiController
      */
     public function show()
     {
-      return new Response($this->render('@core/documentation.twig', [
-        'config' => $this->wiki->config,
-        'i18n' => json_encode($GLOBALS['translations_js']),
-        'locale' => $GLOBALS['prefered_language']
-      ]));
+        return new Response($this->render('@core/documentation.twig', [
+          'config' => $this->wiki->config,
+          'i18n' => $GLOBALS['translations_js'],
+          'locale' => $GLOBALS['prefered_language'],
+          'extensions' => $this->getExtensionsWithDocs()
+        ]));
+    }
+
+    private function getExtensionsWithDocs(): array
+    {
+        $extensions = [];
+        foreach ($this->wiki->extensions as $extName => $extPath) {
+            $localizedPath = "{$extPath}docs/{$GLOBALS['prefered_language']}/README.md";
+            $path = "{$extPath}docs/README.md";
+            $docPath = glob($localizedPath)[0] ?? glob($path)[0] ?? null;
+            if ($docPath) $extensions[] = ["name" => $extName, "docPath" => $docPath];
+        }
+        return $extensions;
     }
 }

--- a/javascripts/documentation.js
+++ b/javascripts/documentation.js
@@ -41,14 +41,17 @@ window.$docsify = {
         html = html.replace(/<iframe(.*) src=([^\s]*)/g, '<iframe$1 class="lazyload" data-src=$2')
 
         // Adds footer
-        const url = `https://github.com/YesWiki/yeswiki/edit/doryphore-dev/${vm.route.file}`
-        const footer = `
-          <hr/>
-          <footer>
-            <a href="${url}" target="_blank">${i18n.DOC_EDIT_THIS_PAGE_ON_GITHUB}</a>
-          </footer>`
+        if (vm.route.file.match(/^docs\/.*$/)){
+          const url = `https://github.com/YesWiki/yeswiki/edit/doryphore-dev/${vm.route.file}`
+          const footer = `
+            <hr/>
+            <footer>
+              <a href="${url}" target="_blank">${i18n.DOC_EDIT_THIS_PAGE_ON_GITHUB}</a>
+            </footer>`
+          html = html + footer;
+        }
 
-        return html + footer;
+        return html;
       });
 
       hook.doneEach(function() {
@@ -139,7 +142,24 @@ function initCustomNavMenu() {
     const backBtnClone = backBtn.cloneNode(true)
     const li = document.createElement('li')
     li.appendChild(backBtnClone)
-      const nav = document.querySelector('nav > ul')
-      nav.insertBefore(li, nav.children[0])
+    const nav = document.querySelector('nav > ul')
+    nav.insertBefore(li, nav.children[0])
+  }
+
+  // extensions menu
+  const element = document.getElementById("extensions-links")
+  if (element) {
+    if (extensions.length > 0) {
+      element.removeAttribute("href")
+      let list = document.createElement('ul');
+      let html = ''
+      extensions.forEach((ext) => {
+        html += `<li><a href="#/${ext.docPath}">${ext.name}</a></li>`
+      });
+      list.innerHTML = html
+      element.parentNode.appendChild(list)
+    } else {
+      element.parentNode.parentNode.removeChild(element.parentNode)
     }
+  }
 }

--- a/styles/documentation.css
+++ b/styles/documentation.css
@@ -112,6 +112,9 @@ nav.app-nav {
     align-items: center;
     padding: 0;
 }
+.app-nav #extensions-links + ul a {
+    text-transform: capitalize;
+}
 .app-nav li {
     height: var(--nav-height);
     align-items: center;

--- a/templates/documentation.twig
+++ b/templates/documentation.twig
@@ -12,9 +12,10 @@
   <div id="app"></div>
 
   <script>
-    var locale = "{{ locale }}";
-    var baseUrl = "{{ config.base_url }}";
-    var i18n = {{ i18n|raw }};
+    var locale = {{ locale|json_encode|raw }};
+    var baseUrl = {{ config.base_url|json_encode|raw }};
+    var i18n = {{ i18n|json_encode|raw }};
+    var extensions = {{ extensions|json_encode|raw }};
   </script>
 
   <script src="javascripts/vendor/docsify/docsify.min.js"></script>


### PR DESCRIPTION
@seballot qu'en penses-tu de cette proposition pour gérer la documentation embarquée dans les extensions ?

Côté `css`, ça peut être amélioré mais j'ai besoin d'aide.

Je laisse volontiers la main pour l'intégration au bon endroit de la liste des extensions dans les menus.
