### PR TITLE
Correction texte explicatif redirecturl

### DIFF
--- a/docs/actions/lang/actionsbuilder_fr.inc.php
+++ b/docs/actions/lang/actionsbuilder_fr.inc.php
@@ -195,7 +195,7 @@ return [
     // BazarAction
     "AB_bazar_action_label" => "Afficher un formulaire de création de fiche",
     "AB_bazar_action_description" => "Permet d'afficher le formulaire pour créer une fiche.",
-    "AB_bazar_action_redirecturl_label" => "Nom de la page de ce wiki à afficher après création d'une fiche",
+    "AB_bazar_action_redirecturl_label" => "URL complet de la page de ce wiki à afficher après création d'une fiche",
     // attach
     "AB_attach_commons_title" => "Pour les images",
     "AB_attach_link_label" => "Lien quand on cliquera sur l'image",


### PR DESCRIPTION
Proposition de modification du texte explicatif de redirecturl, car actuellement de sutilisateurices mettente comme indiquer simplement le nomd e la page et celà est non fonctionnel.

