### PR TITLE
Create page and entry events

### DIFF
--- a/includes/services/PageManager.php
+++ b/includes/services/PageManager.php
@@ -14,45 +14,45 @@ use YesWiki\Wiki;
 
 class PageManager
 {
-    protected $wiki;
+    protected $aclService;
     protected $authController;
     protected $dbService;
-    protected $aclService;
     protected $eventDispatcher;
+    protected $params;
     protected $securityController;
+    protected $tagsManager;
     protected $tripleStore;
     protected $userManager;
-    protected $tagsManager;
-    protected $params;
+    protected $wiki;
 
-    protected $pageCache;
     protected $ownersCache; // different cache because to set at the same time to prevent infinite loop
+    protected $pageCache;
 
     public function __construct(
-        Wiki $wiki,
+        AclService $aclService,
         AuthController $authController,
         DbService $dbService,
-        AclService $aclService,
-        TripleStore $tripleStore,
         EventDispatcher $eventDispatcher,
-        UserManager $userManager,
         ParameterBagInterface $params,
         SecurityController $securityController,
-        TagsManager $tagsManager
+        TagsManager $tagsManager,
+        TripleStore $tripleStore,
+        UserManager $userManager,
+        Wiki $wiki
     ) {
-        $this->wiki = $wiki;
+        $this->aclService = $aclService;
         $this->authController = $authController;
         $this->dbService = $dbService;
-        $this->aclService = $aclService;
         $this->eventDispatcher = $eventDispatcher;
-        $this->tripleStore = $tripleStore;
-        $this->userManager = $userManager;
         $this->params = $params;
         $this->securityController = $securityController;
         $this->tagsManager = $tagsManager;
+        $this->tripleStore = $tripleStore;
+        $this->userManager = $userManager;
+        $this->wiki = $wiki;
 
-        $this->pageCache = [];
         $this->ownersCache = [];
+        $this->pageCache = [];
     }
 
     /**

--- a/includes/services/PageManager.php
+++ b/includes/services/PageManager.php
@@ -283,7 +283,7 @@ class PageManager
         $this->tagsManager->deleteAll($tag);
         
         $errors = $this->eventDispatcher->yesWikiDispatch('page.deleted', [
-            'tag' => $tag
+            'id' => $tag
         ]);
     }
 
@@ -357,11 +357,15 @@ class PageManager
             unset($this->pageCache[$tag]);
             $this->ownersCache[$tag] = $owner;
             
-            $errors = $this->eventDispatcher->yesWikiDispatch('page.saved', [
-                'tag' => $tag,
-                'body' => $body,
-                'comment_on' => $comment_on,
-                'owner' => $owner,
+            $errors = $this->eventDispatcher->yesWikiDispatch(empty($oldPage) ? 'page.created' : 'page.updated', [
+                'id' => $tag,
+                'data' => [
+                    'tag' => $tag,
+                    'body' => $body,
+                    'comment_on' => $comment_on,
+                    'owner' => $owner,
+                    'user' => $user
+                ]
             ]);
 
             return 0;

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -22,40 +22,40 @@ use YesWiki\Security\Controller\SecurityController;
 
 class EntryController extends YesWikiController
 {
+    protected $aclService;
+    protected $authController;
+    protected $config;
     protected $entryManager;
     protected $favoritesManager;
     protected $formManager;
-    protected $aclService;
-    protected $authController;
-    protected $semanticTransformer;
     protected $pageManager;
-    protected $templateEngine;
-    protected $config;
     protected $securityController;
+    protected $semanticTransformer;
+    protected $templateEngine;
 
     private $parentsEntries ;
 
     public function __construct(
+        AclService $aclService,
+        AuthController $authController,
         EntryManager $entryManager,
         FavoritesManager $favoritesManager,
         FormManager $formManager,
-        AclService $aclService,
-        AuthController $authController,
-        SemanticTransformer $semanticTransformer,
         PageManager $pageManager,
         ParameterBagInterface $config,
-        SecurityController $securityController
+        SecurityController $securityController,
+        SemanticTransformer $semanticTransformer
     ) {
+        $this->aclService = $aclService;
         $this->authController = $authController;
+        $this->config = $config->all();
         $this->entryManager = $entryManager;
         $this->favoritesManager = $favoritesManager;
         $this->formManager = $formManager;
-        $this->aclService = $aclService;
-        $this->semanticTransformer = $semanticTransformer;
         $this->pageManager = $pageManager;
-        $this->config = $config->all();
-        $this->securityController = $securityController;
         $this->parentsEntries = [];
+        $this->securityController = $securityController;
+        $this->semanticTransformer = $semanticTransformer;
     }
 
     /**

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -243,7 +243,8 @@ class EntryController extends YesWikiController
                 if ($state && isset($_POST['bf_titre'])) {
                     $entry = $this->entryManager->create($formId, $_POST);
                     $errors = $this->eventDispatcher->yesWikiDispatch('entry.created', [
-                        'entry' => $entry,
+                        'id' => $entry['id_fiche'],
+                        'data' => $entry
                     ]);
                     // get the GET parameter 'incomingurl' for the incoming url
                     $redirectUrl = !empty($incomingUrl)
@@ -303,7 +304,8 @@ class EntryController extends YesWikiController
             if ($state && isset($_POST['bf_titre'])) {
                 $entry = $this->entryManager->update($entryId, $_POST);
                 $errors = $this->eventDispatcher->yesWikiDispatch('entry.updated', [
-                    'entry' => $entry,
+                    'id' => $entry['id_fiche'],
+                    'data' => $entry
                 ]);
                 $redirectUrl = !empty($incomingUrl)
                     ? $incomingUrl
@@ -351,7 +353,7 @@ class EntryController extends YesWikiController
     {
         $this->entryManager->delete($entryId);
         $errors = $this->eventDispatcher->yesWikiDispatch('entry.deleted', [
-            'entryId' => $entryId,
+            'id' => $entryId,
         ]);
         // WARNING : 'delete_ok' is not used
         header('Location: ' . $this->wiki->Href('', 'BazaR', ['vue' => 'consulter', 'message' => 'delete_ok']));


### PR DESCRIPTION
@mrflos @acheype pour cette PR je vais avoir besoin de votre aval à tous les deux.

L'extension `webhooks` utilise des moyens compliqués pour attraper les évènements de création modification, suppression d'une fiche

Avec les récentes améliorations des commentaires, j'ai introduit la notion de `EventDispatcher`, ce qui permet de simplifier la propagation des évènements.

Je propose donc l'introduction de 6 évènements:
 - `entry.created`
 - `entry.updated`
 - `entry.deleted`
 - `page.created`
 - `page.updated`
 - `page.deleted`
 - ~~`page.saved`~~

Pour chaque évènement, il nous faut déterminer les données à transmettre aux méthodes qui vont traiter les évènements. 
Les critères sont : 
 - est-ce utile et nécessaire ?
 - est-ce que les informations transmises ne peuvent pas contourner un système de sécurité ?

|Event|Data|
|:-|:-|
|`entry.created`|['id'=>$entry['id_fiche'],'data'=>$entry]|
|`entry.updated`|['id'=>$entry['id_fiche'],'data'=>$entry]|
|`entry.deleted`|['id'=>$entryId]
|`page.created`|['id'=>$tag,'data'=>['tag'=>$tag,'body'=>$body,'comment_on'=>$comment_on,'owner'=>$owner,'user'=>$user]]|
|`page.updated`|['id'=>$tag,'data'=>['tag'=>$tag,'body'=>$body,'comment_on'=>$comment_on,'owner'=>$owner,'user'=>$user]]|
|`page.deleted`|['id'=>$tag]|
|~~`page.saved`~~|~~['tag'=>$tag,'body'=>$body,'comment_on'=>$comment_on,'owner'=>$owner]~~|

Qu'en pensez-vous ?

Nous pourrions être exhaustif sur l'ensemble des évènements à déterminer dans `YesWiki` mais j'ai peur que ce soit long et j'aimerais bien faire une PR simple pour pouvoir réparer l'extension `webhooks` qui sera en panne lors de la mise en production de `doryphore-dev` (cas du nouveau paramètre `incomingurl`)