### PR TITLE
Fix/purgepages keep one

### DIFF
--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -301,8 +301,8 @@ class Wiki
     }
 
     /**
-     * Make the purge of page versions that are older than the last version older than 3 "pages_purge_time"
-     * This method permits to allways keep a version that is older than that period.
+     * Make the purge of page versions that are older than the last version older than "pages_purge_time"
+     * This method permits to allways keep a not latest version that is older than that period.
      */
     public function PurgePages()
     {
@@ -315,6 +315,7 @@ class Wiki
             $sql = <<<SQL
             SELECT DISTINCT a.id FROM $wnPages a,$wnPages b 
                 WHERE a.latest = 'N' 
+                    AND b.latest = 'N'
                     AND a.time < date_sub(now(), INTERVAL '$daysFormatted' DAY) 
                     AND a.tag = b.tag 
                     AND a.time < b.time 

--- a/includes/YesWiki.php
+++ b/includes/YesWiki.php
@@ -311,7 +311,15 @@ class Wiki
             // let's search which pages versions we have to remove
             // this is necessary beacause even MySQL does not handel multi-tables deletes before version 4.0
             $wnPages = $this->GetConfigValue('table_prefix') . 'pages';
-            $sql = 'SELECT DISTINCT a.id FROM ' . $wnPages . ' a,' . $wnPages . ' b WHERE a.latest = \'N\' AND a.time < date_sub(now(), INTERVAL \'' . mysqli_real_escape_string($this->dblink, $days) . '\' DAY) AND a.tag = b.tag AND a.time < b.time AND b.time < date_sub(now(), INTERVAL \'' . mysqli_real_escape_string($this->dblink, $days) . '\' DAY)';
+            $daysFormatted = mysqli_real_escape_string($this->dblink, $days);
+            $sql = <<<SQL
+            SELECT DISTINCT a.id FROM $wnPages a,$wnPages b 
+                WHERE a.latest = 'N' 
+                    AND a.time < date_sub(now(), INTERVAL '$daysFormatted' DAY) 
+                    AND a.tag = b.tag 
+                    AND a.time < b.time 
+                    AND b.time < date_sub(now(), INTERVAL '$daysFormatted' DAY);
+            SQL;
             $ids = $this->LoadAll($sql);
 
             if (count($ids)) {


### PR DESCRIPTION
## Description of pull request / Description de la demande d'ajout
Lors de l'opération de maintenance qui nettoie les versions plus anciennes qu'une certaine limite, la requête `SQL` qui sélectionne les éléments à supprimer teste qu'il reste toujours au moins une version plus ancienne que la limite.

**Exemple 1 : OK** (par ordre de temps décroissant):
|trop ancien ?|`latest` pour `yeswiki_pages` as `a`|`latest` pour `yeswiki_pages` as `b`|action|commentaire|
|:-|:-|:-|:-|:-|
|non||Y|conserver|`a` ne contient pas les `Y`|
|non|N|N|conserver||
|non|N|N|conserver||
|**oui**|N|N|conserver|le premier est conservé|
|oui|N|N|supprimer||
|oui|N|N|supprimer||

Il se passe un comportement différent si la version `latest=Y` est plus vielle que la limite de temps.

**Exemple 2: que des vieilles fiches** (par ordre de temps décroissant):
|trop ancien ?|`latest` pour `yeswiki_pages` as `a`|`latest` pour `yeswiki_pages` as `b`|action|commentaire|
|:-|:-|:-|:-|:-|
|oui||Y|conserver|`a` ne contient pas les `Y`|
|oui|N|N|supprimer||
|oui|N|N|supprimer||

Dans ce cas, toutes les versions de type `latest=N` sont supprimées.
Le cas embêtant est quand l'administrateur n'a pas vu qu'il s'est fait spammer une page et que la dernière version (celle spammée) devient plus ancienne que la limite de temps : seule la version spammée reste en base de données ne permettant pas à l'administrateur de récupérer la version précédente.

**Proposition**:
 - en deux temps:
   - un commit de `refactor` pour faciliter la lisibilité de la requête sql
   - un commit pour faire le changement
 - ajouter un test pour qu'il y ait toujours a minima une version de type `latest=N` conservée en mémoire, même si la version la plus récente est plus vieille que la limite
 
@mrflos est-ce que tu perçois la raison qui m'amène à ce correctif ? Je peux tenter d'expliquer autrement pour me faire comprendre. Préviens-moi.
Est-ce que le correctif proposé te semble utile et correct ?