### PR TITLE
Feat/packageext test php

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -7,6 +7,10 @@ define("YESWIKI_VERSION", 'doryphore');
 define("YESWIKI_RELEASE", '2020-01-22-1');
 define('T_START', microtime(true));
 
+// to update with constraint in composer.json > config > platform > php and 
+// and .github/workflow/phpunit.yml > php-version
+define("MINIMUM_PHP_VERSION_FOR_CORE", '7.3.0');
+
 // operational constants
 define('WAKKA_ENGINE', 'wakka.php');
 

--- a/tools/autoupdate/app/Package.php
+++ b/tools/autoupdate/app/Package.php
@@ -145,7 +145,7 @@ abstract class Package extends Files
         if (is_string($this->minimalPhpVersion) && preg_match('/^([0-9]*)\.([0-9]*)\.([0-9]*)$/', $this->minimalPhpVersion, $matches)) {
             return $this->minimalPhpVersion ;
         }
-        return '7.3.0'; // just in case of error give a number
+        return MINIMUM_PHP_VERSION_FOR_CORE; // just in case of error give a number
     }
     
     /**

--- a/tools/autoupdate/app/PackageCore.php
+++ b/tools/autoupdate/app/PackageCore.php
@@ -173,36 +173,6 @@ class PackageCore extends Package
         return $result;
     }
 
-    /**
-     * check if current PHP version enough high
-     * @param string $neededRevision
-     * @return bool
-     */
-    public function PHPVersionEnoughHigh(?string $neededRevision = null)
-    {
-        return version_compare(
-            PHP_VERSION,
-            (empty($neededRevision))
-            ? $this->getNeededPHPversion()
-            : $neededRevision,
-            '>='
-        );
-    }
-
-    /**
-     * get needed PHP version from json file from repository
-     * @return string formatted as '7.3.0', '7.3.0' is the wanted version in case of error
-     */
-    public function getNeededPHPversion(): string
-    {
-        // check format of JSON package 99.99.99
-        $matches = [];
-        if (preg_match('/^([0-9]*)\.([0-9]*)\.([0-9]*)$/', $this->minimalPhpVersion, $matches)) {
-            return $this->minimalPhpVersion ;
-        }
-        return '7.3.0'; // just in case of error give a number
-    }
-
     /***************************************************************************
      * Méthodes privée
      **************************************************************************/
@@ -226,37 +196,5 @@ class PackageCore extends Package
             return true;
         }
         return false;
-    }
-
-    /**
-     * get needed PHP version from json file from extracted folder
-     * @return string formatted as '7.3.0', '7.3.0' is the wanted version in case of error
-     */
-    private function getNeededPHPversionFromExtractedFolder(): string
-    {
-        $jsonPath = $this->extractionPath . 'composer.json';
-        if (file_exists($jsonPath)) {
-            $jsonFile = file_get_contents($jsonPath);
-            if (!empty($jsonFile)) {
-                $composerData = json_decode($jsonFile, true) ;
-                if (!empty($composerData['require']['php'])) {
-                    $rawNeededPHPRevision = $composerData['require']['php'];
-                    $matches = [];
-                    // accepted format '7','7.3','7.*','7.3.0','7.3.*
-                    // and these with '^', '>' or '>=' before
-                    if (preg_match('/^(\^|>=|>)?([0-9]*)(?:\.([0-9\*]*))?(?:\.([0-9\*]*))?/', $rawNeededPHPRevision, $matches)) {
-                        $major = $matches[2];
-                        $minor = $matches[3] ?? 0;
-                        $minor = ($minor == '*') ? 0 : $minor;
-                        $fix = $matches[4] ?? 0;
-                        $fix = ($fix == '*') ? 0 : $fix;
-                        return $major.'.'.$minor.'.'.$fix;
-                    }
-                }
-            }
-        } else {
-            trigger_error('Not existing file composer.json in extracted package.');
-        }
-        return $this->getNeededPHPversion();
     }
 }

--- a/tools/autoupdate/app/PackageCore.php
+++ b/tools/autoupdate/app/PackageCore.php
@@ -63,13 +63,12 @@ class PackageCore extends Package
         $neededPHPVersion = $this->getNeededPHPversionFromExtractedFolder() ;
         if (!$this->PHPVersionEnoughHigh($neededPHPVersion)) {
             $textAction = ($this->newVersionRequested()) ? _t('AU_PHP_TOO_LOW_VERSION_UPDATE') : _t('AU_PHP_TOO_LOW_UPDATE');
-            trigger_error(_t('AU_PHP_TOO_LOW_START')
-                .$textAction
-                ._t('AU_PHP_TOO_LOW_MIDDLE')
-                .$neededPHPVersion
-                ._t('AU_PHP_TOO_LOW_END').PHP_VERSION."\n"
-                ._t('AU_PHP_TOO_LOW_HINT')
-                ._t('AU_PHP_TOO_LOW_VERSION_UPDATE') . ' !');
+            trigger_error(_t('AU_PHP_TOO_LOW_ERROR',[
+                'textAction' => $textAction,
+                'NEEDEDPHPVERSION' => $neededPHPVersion,
+                'CURRENTPHPVERSION' => PHP_VERSION,
+                'hint' => _t('AU_PHP_TOO_LOW_HINT',['textAction' => $textAction])
+            ]));
             return false;
         }
 

--- a/tools/autoupdate/app/PackageExt.php
+++ b/tools/autoupdate/app/PackageExt.php
@@ -23,6 +23,18 @@ abstract class PackageExt extends Package
     public function upgrade()
     {
         $desPath = $this->localPath();
+        
+        $neededPHPVersion = $this->getNeededPHPversionFromExtractedFolder() ;
+        if (!$this->PHPVersionEnoughHigh($neededPHPVersion)) {
+            $textAction = strtolower((is_dir($desPath)) ? _t('AU_UPDATE') : _t('AU_INSTALL'));
+            trigger_error(_t('AU_PHP_TOO_LOW_ERROR',[
+                'textAction' => $textAction,
+                'NEEDEDPHPVERSION' => $neededPHPVersion,
+                'CURRENTPHPVERSION' => PHP_VERSION,
+                'hint' => _t('AU_PHP_TOO_LOW_HINT',['textAction' => $textAction])
+            ]));
+            return false;
+        }
 
         $this->deletePackage();
         mkdir($desPath);

--- a/tools/autoupdate/lang/autoupdate_fr.inc.php
+++ b/tools/autoupdate/lang/autoupdate_fr.inc.php
@@ -33,10 +33,10 @@ return [
     'AU_NO_DESCRIPTION' => "Description non disponible.",
     'AU_DOCUMENTATION_LINK' => "documentation",
     'AU_YESWIKI_DORYPHORE_POSTINSTALL' => "Welcome on Doryphore",
-    'AU_PHP_TOO_LOW_START' => "Vous ne pouvez pas ",
-    'AU_PHP_TOO_LOW_MIDDLE' => " car votre version PHP n'est pas supérieure à ",
-    'AU_PHP_TOO_LOW_END' => ". Vous avez la version ",
-    'AU_PHP_TOO_LOW_HINT' => "Veuillez mettre à jour PHP sur votre serveur avant de ",
+    'AU_PHP_TOO_LOW_ERROR' => "Vous ne pouvez pas %{textAction} car votre version PHP n'est pas supérieure à %{NEEDEDPHPVERSION}.\n".
+        "Vous avez la version %{CURRENTPHPVERSION}.\n".
+        "%{hint}",
+    'AU_PHP_TOO_LOW_HINT' => "Veuillez mettre à jour PHP sur votre serveur avant de %{textAction} !",
     'AU_PHP_TOO_LOW_VERSION_UPDATE' => "changer de version YesWiki",
     'AU_PHP_TOO_LOW_UPDATE' => "mettre à jour YesWiki",
     'AU_PHP_TOO_LOW_FORCE_UPDATE' => "réinstaller YesWiki",

--- a/tools/autoupdate/lang/autoupdate_pt.inc.php
+++ b/tools/autoupdate/lang/autoupdate_pt.inc.php
@@ -34,10 +34,10 @@ return [
     'AU_NO_DESCRIPTION' => "Descrição não disponível.",
     'AU_DOCUMENTATION_LINK' => "documentação",
     'AU_YESWIKI_DORYPHORE_POSTINSTALL' => "Bem-vindo ao Doryphore",
-    // 'AU_PHP_TOO_LOW_START' => "Vous ne pouvez pas ",
-    // 'AU_PHP_TOO_LOW_MIDDLE' => " car votre version PHP n'est pas supérieure à ",
-    // 'AU_PHP_TOO_LOW_END' => ". Vous avez la version ",
-    // 'AU_PHP_TOO_LOW_HINT' => "Veuillez mettre à jour PHP sur votre serveur avant de ",
+    // 'AU_PHP_TOO_LOW_ERROR' => "Vous ne pouvez pas %{textAction} car votre version PHP n'est pas supérieure à %{NEEDEDPHPVERSION}.\n".
+    //     "Vous avez la version %{CURRENTPHPVERSION}.\n".
+    //     "%{hint}",
+    // 'AU_PHP_TOO_LOW_HINT' => "Veuillez mettre à jour PHP sur votre serveur avant de %{textAction} !",
     // 'AU_PHP_TOO_LOW_VERSION_UPDATE' => "changer de version YesWiki",
     // 'AU_PHP_TOO_LOW_UPDATE' => "mettre à jour YesWiki",
     // 'AU_PHP_TOO_LOW_FORCE_UPDATE' => "réinstaller YesWiki",

--- a/tools/autoupdate/templates/core.twig
+++ b/tools/autoupdate/templates/core.twig
@@ -1,3 +1,12 @@
+{% macro phpTooLowText(actionText,core,phpVersion) %}
+    {{- _t('AU_PHP_TOO_LOW_ERROR',{
+        textAction: actionText,
+        NEEDEDPHPVERSION: (core.neededPHPversion ?? '99.99.99'),
+        CURRENTPHPVERSION: phpVersion,
+        hint: _t('AU_PHP_TOO_LOW_HINT',{textAction: actionText})
+    }) -}}
+{% endmacro %}
+
 <h2>YesWiki</h2>
 <p>
     {{ _t('AU_VERSION_WIKI') }} : <span class="label {{ (core.updateAvailable or core.newVersionRequested) ? 'label-warning' : 'label-primary' }}">{{ core.localVersion }} {{ core.localRelease }}</span>
@@ -15,13 +24,10 @@
             </a>
         {% else %}
             <button type="button" class="btn btn-danger" disabled data-toggle="tooltip"
-                data-placement="bottom" title="{{ _t('AU_PHP_TOO_LOW_START') 
-                        ~ _t('AU_PHP_TOO_LOW_VERSION_UPDATE') 
-                        ~ _t('AU_PHP_TOO_LOW_MIDDLE') ~ (core.neededPHPversion ?? '99.99.99')
-                        ~ _t('AU_PHP_TOO_LOW_END') ~ phpVersion }}">
+                data-placement="bottom" title="{{ _self.phpTooLowText(_t('AU_PHP_TOO_LOW_VERSION_UPDATE'),core,phpVersion) }}">
                 {{ _t('AU_VERSION_UPDATE') }}
             </button>
-            <p><i>{{ _t('AU_PHP_TOO_LOW_HINT') ~ _t('AU_PHP_TOO_LOW_VERSION_UPDATE') ~ ' !' }}</i></p>
+            <p><i>{{ _t('AU_PHP_TOO_LOW_HINT',{textAction: _t('AU_PHP_TOO_LOW_VERSION_UPDATE')}) }}</i></p>
         {% endif %}
     {% else %}
         <button type="button" class="btn btn-danger" disabled data-toggle="tooltip"
@@ -39,13 +45,10 @@
             </a>
         {% else %}
             <button type="button" class="btn btn-primary" disabled data-toggle="tooltip"
-                data-placement="bottom" title="{{ _t('AU_PHP_TOO_LOW_START') 
-                        ~ _t('AU_PHP_TOO_LOW_UPDATE') 
-                        ~ _t('AU_PHP_TOO_LOW_MIDDLE') ~ (core.neededPHPversion ?? '99.99.99')
-                        ~ _t('AU_PHP_TOO_LOW_END') ~ phpVersion }}">
+                data-placement="bottom" title="{{ _self.phpTooLowText(_t('AU_PHP_TOO_LOW_UPDATE'),core,phpVersion) }}">
                 {{ _t('AU_UPDATE') }}
             </button>
-            <p><i>{{ _t('AU_PHP_TOO_LOW_HINT') ~ _t('AU_PHP_TOO_LOW_UPDATE') ~ ' !' }}</i></p>
+            <p><i>{{ _t('AU_PHP_TOO_LOW_HINT',{textAction:_t('AU_PHP_TOO_LOW_UPDATE')}) }}</i></p>
         {% endif %}
     {% else %}
         <button type="button" class="btn btn-primary" disabled data-toggle="tooltip"
@@ -62,13 +65,10 @@
             </a>
         {% else %}
             <button type="button" class="btn btn-warning" disabled data-toggle="tooltip"
-                data-placement="bottom" title="{{ _t('AU_PHP_TOO_LOW_START') 
-                        ~ _t('AU_PHP_TOO_LOW_FORCE_UPDATE') 
-                        ~ _t('AU_PHP_TOO_LOW_MIDDLE') ~ (core.neededPHPversion ?? '99.99.99')
-                        ~ _t('AU_PHP_TOO_LOW_END') ~ phpVersion }}">
+                data-placement="bottom" title="{{ _self.phpTooLowText(_t('AU_PHP_TOO_LOW_FORCE_UPDATE'),core,phpVersion) }}">
                 {{ _t('AU_FORCE_UPDATE') }}
             </button>
-            <p><i>{{ _t('AU_PHP_TOO_LOW_HINT') ~ _t('AU_PHP_TOO_LOW_FORCE_UPDATE') ~ ' !' }}</i></p>
+            <p><i>{{ _t('AU_PHP_TOO_LOW_HINT',{textAction:_t('AU_PHP_TOO_LOW_FORCE_UPDATE')}) }}</i></p>
         {% endif %}
     {% else %}
         <button type="button" class="btn btn-warning" disabled data-toggle="tooltip"


### PR DESCRIPTION
_New feature_

**Test php revision requirement for tools and themes**

**What is done**:
 - refactor of concerned methods to move them in `Package` class
 - refactor of error message to make it more readable in lang's files
 - add test in `PackageExt` class

**How to test**
 - try to install or update an extension with not respecting requirement for `PHP` revision
 - it is possible to emulate it by adding `return false;` here : https://github.com/YesWiki/yeswiki/commit/7c69ba62b5d84fd357f9ee00929956f015cd2544#diff-dce78e7c44f718d75621d4b56ca1755a35a1f0e6e0cbf0ac91bc57b295c8ec67R187