### PR TITLE
better mobile facettes

### DIFF
--- a/tools/bazar/presentation/styles/bazar.css
+++ b/tools/bazar/presentation/styles/bazar.css
@@ -82,25 +82,6 @@ color:#E9322D;
   margin-bottom: 2rem;
 }
 
-.facette-container:not([data-filter-align=left]) > .filters-col > .bazar-search {
-  margin-top: 2rem;
-}
-@media (min-width: 768px){
-  .facette-container:not([data-filter-align=left]) > .filters-col.col-sm-1 > .bazar-search,
-  .facette-container:not([data-filter-align=left]) > .filters-col.col-sm-2 > .bazar-search,
-  .facette-container:not([data-filter-align=left]) > .filters-col.col-sm-3 > .bazar-search,
-  .facette-container:not([data-filter-align=left]) > .filters-col.col-sm-4 > .bazar-search,
-  .facette-container:not([data-filter-align=left]) > .filters-col.col-sm-5 > .bazar-search,
-  .facette-container:not([data-filter-align=left]) > .filters-col.col-sm-6 > .bazar-search,
-  .facette-container:not([data-filter-align=left]) > .filters-col.col-sm-7 > .bazar-search,
-  .facette-container:not([data-filter-align=left]) > .filters-col.col-sm-8 > .bazar-search,
-  .facette-container:not([data-filter-align=left]) > .filters-col.col-sm-9 > .bazar-search,
-  .facette-container:not([data-filter-align=left]) > .filters-col.col-sm-10 > .bazar-search,
-  .facette-container:not([data-filter-align=left]) > .filters-col.col-sm-11 > .bazar-search {
-    margin-top: 0;
-  }
-}
-
 .bazar-table {
   table-layout:fixed;
   word-wrap:break-word;
@@ -220,15 +201,27 @@ ul.list-sortables li, ul.valeur_formulaire li {list-style-type:none; padding:0; 
 	-webkit-box-shadow: 0 0 90px #000;
 }
 
+/* facette */
 .facette-container {
   display: flex;
   flex-direction: row;
+}
+.facette-container .panel-heading {
+  cursor: pointer;
+}
+.facette-container:not([data-filter-align=left]) > .filters-col > .bazar-search {
+  margin-top: 2rem;
 }
 .facette-container-fullwidth {
   flex-wrap: wrap;
 }
 .facette-container[data-filter-align=left] {
   flex-direction: row-reverse;
+}
+@media (min-width: 768px){
+  .facette-container:not([data-filter-align=left]) > [class^="filters-col "][class*="col-sm-"] > .bazar-search {
+    margin-top: 0;
+  }
 }
 @media (max-width: 768px) {
   .facette-container {
@@ -238,7 +231,6 @@ ul.list-sortables li, ul.valeur_formulaire li {list-style-type:none; padding:0; 
     flex-direction: column-reverse;
   }
 }
-.facette-container .panel-heading {cursor: pointer;}
 
 .bazar-lists select {
     width: 250px;

--- a/tools/bazar/presentation/styles/bazar.css
+++ b/tools/bazar/presentation/styles/bazar.css
@@ -215,7 +215,7 @@ ul.list-sortables li, ul.valeur_formulaire li {list-style-type:none; padding:0; 
 .facette-container-fullwidth {
   flex-wrap: wrap;
 }
-.facette-container[data-filter-align=left] {
+.facette-container[data-filter-align=right] {
   flex-direction: row-reverse;
 }
 @media (min-width: 768px){
@@ -224,11 +224,8 @@ ul.list-sortables li, ul.valeur_formulaire li {list-style-type:none; padding:0; 
   }
 }
 @media (max-width: 768px) {
-  .facette-container {
+  .facette-container, .facette-container[data-filter-align=right] {
     flex-direction: column;
-  }
-  .facette-container[data-filter-align=left] {
-    flex-direction: column-reverse;
   }
 }
 

--- a/tools/bazar/presentation/styles/bazar.css
+++ b/tools/bazar/presentation/styles/bazar.css
@@ -227,6 +227,27 @@ ul.list-sortables li, ul.valeur_formulaire li {list-style-type:none; padding:0; 
   .facette-container, .facette-container[data-filter-align=right] {
     flex-direction: column;
   }
+  .facette-container .filter-box .panel-body {
+    max-height: 11em;
+    overflow-y: scroll;
+    /* for firefox custom scrollbar */
+    scrollbar-color: var(--neutral-color) white;
+    scrollbar-width: auto;
+    /* the scrollbar width is too thin, we may fix it by using a scrollbar JS library */
+  }
+  .facette-container .filter-box .panel-body::-webkit-scrollbar {
+    -webkit-appearance: none;
+  }
+  .facette-container .filter-box .panel-body:vertical {
+    width: 15px;
+  }
+  .facette-container .filter-box .panel-body::-webkit-scrollbar:horizontal {
+    height: 15px;
+  }
+  .facette-container .filter-box .panel-body::-webkit-scrollbar-thumb {
+    background-color: var(--neutral-color);
+    border-radius: 10px;
+  }
 }
 
 .bazar-lists select {

--- a/tools/bazar/templates/entries/index-dynamic.twig
+++ b/tools/bazar/templates/entries/index-dynamic.twig
@@ -24,8 +24,8 @@
   {% set resultsColSize = params.groups ? resultsColSize : 12 %}
 
   <div class="facette-container dynamic row {{ resultsColSize == 12 ? 'facette-container-fullwidth' : ''}}" data-filter-align="{{ params.groups ? params.filterposition : '' }}">
-    
-    {% if params.groups and params.filterposition == "left" and resultsColSize == 12 %}
+
+    {% if params.groups %}
       {{ include("@bazar/entries/index-dynamic/_filters.twig") }}
     {% endif %}
 
@@ -36,10 +36,6 @@
       </div>      
       {{ include("@bazar/entries/index-dynamic/_pagination.twig") }}
     </div>
-
-    {% if params.groups and not (params.filterposition == "left" and resultsColSize == 12) %}
-      {{ include("@bazar/entries/index-dynamic/_filters.twig") }}
-    {% endif %}
     
   </div>
 

--- a/tools/bazar/templates/entries/index.twig
+++ b/tools/bazar/templates/entries/index.twig
@@ -5,17 +5,15 @@
 {% if filters %}
   {% set resultsColSize = params.filtercolsize|number_format == 12 ? 12 : 12 - params.filtercolsize|number_format %}
   <div class="facette-container row {{ resultsColSize == 12 ? 'facette-container-fullwidth' : ''}}" data-filter-align="{{ params.filterposition }}" data-template="{{ params.template }}">
-    
-    {% if resultsColSize == 12 and params.filterposition == "left" %}
+
+    {% if params.groups %}
       {{ include("@bazar/entries/index/_filters.twig") }}
     {% endif %}
+
     <div class="results-col col-sm-{{ resultsColSize }}">
       {{ include("@bazar/entries/index/_entries.twig") }}
     </div>
 
-    {% if params.filterposition != "left" or resultsColSize != 12 %}
-      {{ include("@bazar/entries/index/_filters.twig") }}
-    {% endif %}
   </div>
 {% else %}
   {{ include("@bazar/entries/index/_entries.twig") }}


### PR DESCRIPTION
Refactoring du code des facettes comme [ici](https://framateam.org/yeswiki/pl/nm7hozjxmfy68815uhd6d6zf8h) sur framateam

et les facettes en mobile s'affichent maintenant en haut et dans un panneau limité en taille et avec des scrollbars
 (scrollbar encore un peu petit pour Firefox, le mieux serait d'utiliser une librairie js qui gère les scrollbars indépendamment du navigateur)
-> discussion [ici](https://framateam.org/yeswiki/pl/iapysix5mbdjfrdcipcf7478kc) sur le framateam