### PR TITLE
feat(tabdyn): import

### DIFF
--- a/docs/actions/bazarliste.yaml
+++ b/docs/actions/bazarliste.yaml
@@ -811,6 +811,10 @@ actions:
         hint: _t(AB_bazartableau_columnfieldsids_hint)
         multiple: true
         default: ''
+        extraFields: 
+          - id_typeannonce
+          - date_creation_fiche
+          - date_maj_fiche
       columntitles:
         type: text
         label: _t(AB_bazartableau_columntitles_label)

--- a/docs/actions/bazarliste.yaml
+++ b/docs/actions/bazarliste.yaml
@@ -30,6 +30,7 @@ actions:
         showOnlyFor:
           - bazarliste
           - bazarcarto
+          - bazarmapandtable
         showExceptFor:
           - bazarcarousel
       dynamic:
@@ -37,7 +38,9 @@ actions:
         showOnlyFor:
           - bazarliste
           - bazarcarto
+          - bazarmapandtable
           - bazarcalendar
+          - bazartableau
         type: checkbox
         advanced: true
       pagination:
@@ -46,6 +49,7 @@ actions:
         type: number
         showExceptFor:
           - bazarcarto
+          - bazarmapandtable
           - bazargogocarto
           - bazartimeline
           - bazarcarousel
@@ -59,6 +63,7 @@ actions:
         only: lists # ce champ doit être de type checkboxListe, listeListe ...
         showOnlyFor:
           - bazarcarto
+          - bazarmapandtable
           - bazargogocarto
           - bazarliste
           - bazarcalendar
@@ -68,6 +73,7 @@ actions:
         showif: colorfield
         showOnlyFor:
           - bazarcarto
+          - bazarmapandtable
           - bazargogocarto
           - bazarliste
           - bazarcalendar
@@ -88,6 +94,7 @@ actions:
         only: lists # ce champ doit être de type checkboxListe, listeListe ...
         showOnlyFor:
           - bazarcarto
+          - bazarmapandtable
           - bazargogocarto
           - bazarliste
           - bazarcalendar
@@ -97,6 +104,7 @@ actions:
         showif: iconfield
         showOnlyFor:
           - bazarcarto
+          - bazarmapandtable
           - bazargogocarto
           - bazarliste
           - bazarcalendar
@@ -892,3 +900,267 @@ actions:
         advanced: true
         type: checkbox
         default: 'false'
+
+  bazarmapandtable:
+    label: _t(AB_BAZAR_MAP_AND_TABLE_LABEL)
+    description: _t(AB_bazarcarto_description)
+    hint: _t(AB_bazarcarto_hint)
+    width: 35%
+    properties:
+      template:
+        value: map-and-table
+      provider:
+        label: _t(AB_bazarcarto_provider_label)
+        required: true
+        type: list
+        default: OpenStreetMap.Mapnik # TODO change to Stadia.OSMBright if community agrees?
+        options:
+          - OpenStreetMap.Mapnik
+          - OpenStreetMap.BlackAndWhite
+          - OpenStreetMap.DE
+          - OpenStreetMap.France
+          - OpenStreetMap.HOT
+          - OpenTopoMap
+          - Stadia.AlidadeSmooth
+          - Stadia.AlidadeSmoothDark
+          - Stadia.OSMBright
+          - Stamen.Toner
+          - Stamen.TonerBackground
+          - Stamen.TonerLite
+          - Stamen.Watercolor
+          - Stamen.Terrain
+          - Stamen.TerrainBackground
+          - Esri.WorldStreetMap
+          - Esri.DeLorme
+          - Esri.WorldTopoMap
+          - Esri.WorldImagery
+          - Esri.WorldTerrain
+          - Esri.WorldShadedRelief
+          - Esri.WorldPhysical
+          - Esri.OceanBasemap
+          - Esri.NatGeoWorldMap
+          - Esri.WorldGrayCanvas
+          - HERE.normalDay
+          - MtbMap
+          - CartoDB.Positron
+          - CartoDB.PositronNoLabels
+          - CartoDB.PositronOnlyLabels
+          - CartoDB.DarkMatter
+          - CartoDB.DarkMatterNoLabels
+          - CartoDB.DarkMatterOnlyLabels
+          - HikeBike.HikeBike
+          - HikeBike.HillShading
+          - BasemapAT.orthofoto
+          - NASAGIBS.ViirsEarthAtNight2012
+      coordinates:
+        label: _t(AB_bazarcarto_coordinates_label)
+        type: geo
+      cluster:
+        label: _t(AB_bazarcarto_cluster_label)
+        type: checkbox
+        default: "false"
+      width:
+        advanced: true
+        label: _t(AB_bazarcarto_width_label)
+        hint: 500px, 100%...
+        type: text
+        default: 100%
+      height:
+        advanced: true
+        label: _t(AB_bazarcarto_height_label)
+        type: text
+        default: 300px
+      entrydisplay:
+        label: _t(AB_bazarcarto_entrydisplay_label)
+        type: list
+        default: sidebar
+        advanced: true
+        showif: dynamic
+        options:
+          direct: _t(AB_bazarcarto_entrydisplay_option_direct)
+          sidebar: _t(AB_bazarcarto_entrydisplay_option_sidebar)
+          modal: _t(AB_bazarcarto_entrydisplay_option_modal)
+          newtab: _t(AB_bazarcarto_entrydisplay_option_newtab)
+          popup: _t(AB_bazarcarto_entrydisplay_option_popup)
+      popuptemplate: 
+        label: _t(AB_bazarcarto_popuptemplate_label)
+        type: list
+        value: '_map_popup_html.twig'
+        advanced: true
+        options:
+          '_map_popup_html.twig': _t(AB_bazarcarto_popuptemplate_entry_from_html)
+          '_map_popup_from_data.twig': _t(AB_bazarcarto_popuptemplate_entry_from_data)
+          'custom': _t(AB_bazarcarto_popuptemplate_custom)
+        showif: 
+          dynamic: true
+          entrydisplay: 'popup'
+      popupcustomtemplate:
+        label: _t(AB_bazarcarto_popupcustomtemplate_label)
+        type: text
+        value: 'custom_map_popup.twig'
+        hint: _t(AB_bazarcarto_popupcustomtemplate_hint)
+        advanced: true
+        showif: 
+          dynamic: true
+          entrydisplay: 'popup'
+          popuptemplate: 'custom'
+      popupselectedfields:
+        type: form-field
+        label: _t(AB_bazarliste_popupselectedfields_label)
+        multiple: true
+        advanced: true
+        default: ""
+        showif: 
+          dynamic: true
+          entrydisplay: 'popup'
+          popuptemplate: '_map_popup_html.twig|custom'
+      necessary_fields:
+        type: form-field
+        label: _t(AB_bazarliste_popupneededfields_label)
+        multiple: true
+        advanced: true
+        value: "bf_titre,imagebf_image"
+        showif: 
+          dynamic: true
+          entrydisplay: 'popup'
+          popuptemplate: '_map_popup_from_data.twig|custom'
+      displayfields:
+        type: correspondance
+        showif: dynamic
+        advanced: true
+        subproperties:
+          markerhover:
+            type: form-field
+            label: _t(AB_bazarcarto_displayfields_markhover_label)
+            default: bf_titre
+      smallmarker:
+        advanced: true
+        label: _t(AB_bazarcarto_smallmarker_label)
+        type: checkbox
+        default: "0"
+        checkedvalue: "1"
+        uncheckedvalue: "0"
+      # spider:
+      #   advanced: true
+      #   label: _t(AB_bazarcarto_spider_label)
+      #   hint: _t(AB_bazarcarto_spider_hint)
+      #   type: checkbox
+      #   default: "false"
+      # barregestion:
+      #   advanced: true
+      #   label: _t(AB_bazarcarto_barregestion_label)
+      #   type: checkbox
+      #   default: "false"
+      # navigation:
+      #   advanced: true
+      #   label: _t(AB_bazarcarto_navigation_label)
+      #   type: checkbox
+      #   default: "true"
+      zoommolette:
+        advanced: true
+        label: _t(AB_bazarcarto_zoommolette_label)
+        type: checkbox
+        default: "false"
+      columnfieldsids:
+        type: form-field
+        label: _t(AB_bazartableau_columnfieldsids_label)
+        hint: _t(AB_bazartableau_columnfieldsids_hint)
+        multiple: true
+        default: ''
+      columntitles:
+        type: text
+        label: _t(AB_bazartableau_columntitles_label)
+        hint: _t(AB_bazartableau_columntitles_hint)
+        default: ''
+      checkboxfieldsincolumns:
+        type: checkbox
+        label: _t(AB_bazartableau_checkboxfieldsincolumns_label)
+        default: "true"
+        checkedvalue: "true"
+        uncheckedvalue: "false"
+      displayimagesasthumbnails:
+        type: checkbox
+        label: _t(AB_bazartableau_displayimagesasthumbnails_label)
+        default: "false"
+        checkedvalue: "true"
+        uncheckedvalue: "false"
+      displayvaluesinsteadofkeys:
+        type: checkbox
+        label: _t(AB_bazartableau_displayvaluesinsteadofkeys_label)
+        default: "false"
+        checkedvalue: "true"
+        uncheckedvalue: "false"
+      sumfieldsids:
+        type: form-field
+        label: _t(AB_bazartableau_sumfieldsids_label)
+        hint: _t(AB_bazartableau_sumfieldsids_hint)
+        multiple: true
+        default: ''
+      displayadmincol:
+        type: list
+        label: _t(AB_bazartableau_displayadmincol_label)
+        hint: _t(AB_bazartableau_displayadmincol_hint)
+        default: ''
+        options: 
+          '': _t(NO)
+          yes: _t(YES)
+          onlyadmins: _t(AB_bazartableau_displayadmincol_onlyadmins)
+      displaycreationdate:
+        type: list
+        label: _t(AB_bazartableau_displaycreationdate_label)
+        advanced: true
+        default: ''
+        options: 
+          '': _t(NO)
+          yes: _t(YES)
+          onlyadmins: _t(AB_bazartableau_displayadmincol_onlyadmins)
+      displaylastchangedate:
+        type: list
+        label: _t(AB_bazartableau_displaylastchangedate_label)
+        advanced: true
+        default: ''
+        options: 
+          '': _t(NO)
+          yes: _t(YES)
+          onlyadmins: _t(AB_bazartableau_displayadmincol_onlyadmins)
+      displayowner:
+        type: list
+        label: _t(AB_bazartableau_displayowner_label)
+        advanced: true
+        default: ''
+        options: 
+          '': _t(NO)
+          yes: _t(YES)
+          onlyadmins: _t(AB_bazartableau_displayadmincol_onlyadmins)
+      defaultcolumnwidth:
+        label: _t(AB_bazartableau_defaultcolumnwidth_label)
+        hint: _t(AB_bazartableau_defaultcolumnwidth_hint)
+        type: text
+        advanced: true
+        default: ''
+      columnswidth:
+        label: _t(AB_bazartableau_columnswidth_label)
+        hint: _t(AB_bazartableau_columnswidth_hint)
+        type: columns-width
+        advanced: true
+        subproperties:
+          field:
+            label: _t(AB_bazartableau_columnswidth_field_label)
+            type: form-field
+          width:
+            label: _t(AB_bazartableau_columnswidth_width_label)
+            type: text
+            default: ''
+      exportallcolumns:
+        label: _t(AB_bazartableau_exportallcolumns_label)
+        advanced: true
+        type: checkbox
+        default: 'false'
+      tablewith:
+        label: _t(AB_BAZAR_MAP_AND_TABLE_TABLEWITH_LABEL)
+        type: list
+        default: ''
+        options:
+          '': _t(AB_BAZAR_MAP_AND_TABLE_TABLEWITH_ALL)
+          only-geolocation : _t(AB_BAZAR_MAP_AND_TABLE_TABLEWITH_ONLY_GEOLOC)
+          no-geolocation: _t(AB_BAZAR_MAP_AND_TABLE_TABLEWITH_NO_GEOLOC)

--- a/docs/actions/lang/actionsbuilder_en.inc.php
+++ b/docs/actions/lang/actionsbuilder_en.inc.php
@@ -120,6 +120,12 @@ return [
     // "AB_bazarcard_style_vertical" => 'Vertical',
     // "AB_bazarcard_style_square" => 'Carré',
     // "AB_bazarcard_style_horizontal" => 'Horizontal',
+    // BazarTable
+    'AB_BAZAR_MAP_AND_TABLE_LABEL' => 'Map and table',
+    'AB_BAZAR_MAP_AND_TABLE_TABLEWITH_LABEL' => 'Table with all entries',
+    'AB_BAZAR_MAP_AND_TABLE_TABLEWITH_ALL' => 'with or withour geolocalization',
+    'AB_BAZAR_MAP_AND_TABLE_TABLEWITH_ONLY_GEOLOC' => 'only with geolocalization',
+    'AB_BAZAR_MAP_AND_TABLE_TABLEWITH_NO_GEOLOC' => 'only without geolocalization',
     // // BazarTrombi
     // "AB_bazartrombi_label" => "Trombinoscope",
     // "AB_bazartrombi_description" => "Les fiches seront sous forme de Trombinoscope.",

--- a/docs/actions/lang/actionsbuilder_fr.inc.php
+++ b/docs/actions/lang/actionsbuilder_fr.inc.php
@@ -120,6 +120,12 @@ return [
     "AB_bazarcard_style_vertical" => 'Vertical',
     "AB_bazarcard_style_square" => 'Carré',
     "AB_bazarcard_style_horizontal" => 'Horizontal',
+    // BazarTable
+    'AB_BAZAR_MAP_AND_TABLE_LABEL' => 'Carte et tableau',
+    'AB_BAZAR_MAP_AND_TABLE_TABLEWITH_LABEL' => 'Tableau contenant toutes les fiches',
+    'AB_BAZAR_MAP_AND_TABLE_TABLEWITH_ALL' => 'avec ou sans geolocalisation',
+    'AB_BAZAR_MAP_AND_TABLE_TABLEWITH_ONLY_GEOLOC' => 'seulement avec geolocalisation',
+    'AB_BAZAR_MAP_AND_TABLE_TABLEWITH_NO_GEOLOC' => 'seulement sans geolocalisation',
     // BazarTrombi
     "AB_bazartrombi_label" => "Trombinoscope",
     "AB_bazartrombi_description" => "Les fiches seront sous forme de Trombinoscope.",

--- a/docs/actions/lang/actionsbuilder_pt.inc.php
+++ b/docs/actions/lang/actionsbuilder_pt.inc.php
@@ -120,6 +120,12 @@ return [
     // "AB_bazarcard_style_vertical" => 'Vertical',
     // "AB_bazarcard_style_square" => 'Carré',
     // "AB_bazarcard_style_horizontal" => 'Horizontal',
+    // BazarTable
+    // 'AB_BAZAR_MAP_AND_TABLE_LABEL' => 'Carte et tableau',
+    // 'AB_BAZAR_MAP_AND_TABLE_TABLEWITH_LABEL' => 'Tableau contenant toutes les fiches',
+    // 'AB_BAZAR_MAP_AND_TABLE_TABLEWITH_ALL' => 'avec ou sans geolocalisation',
+    // 'AB_BAZAR_MAP_AND_TABLE_TABLEWITH_ONLY_GEOLOC' => 'seulement avec geolocalisation',
+    // 'AB_BAZAR_MAP_AND_TABLE_TABLEWITH_NO_GEOLOC' => 'seulement sans geolocalisation',
     // BazarTrombi
     // "AB_bazartrombi_label" => "Trombinoscope",
     // "AB_bazartrombi_description" => "Les fiches seront sous forme de Trombinoscope.",

--- a/includes/controllers/ApiController.php
+++ b/includes/controllers/ApiController.php
@@ -470,6 +470,7 @@ class ApiController extends YesWikiController
      */
     public function getDeleteToken($tag)
     {
+        // TODO : elete this api routes after refactor of names of tokens
         return new ApiResponse([
             'token'=>$this->regenerateToken($tag)
         ]);
@@ -481,6 +482,7 @@ class ApiController extends YesWikiController
      */
     public function getDeleteTokens()
     {
+        // TODO : elete this api routes after refactor of names of tokens
         $pageIds = (empty($_GET['pages']) || !is_string($_GET['pages'])) ? [] : explode(',',strval($_GET['pages']));
         $tokens = [];
         foreach ($pageIds as $tag) {

--- a/includes/controllers/ApiController.php
+++ b/includes/controllers/ApiController.php
@@ -7,6 +7,7 @@ use Throwable;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use Symfony\Component\Security\Csrf\Exception\TokenNotFoundException;
 use YesWiki\Bazar\Controller\EntryController;
 use YesWiki\Bazar\Service\EntryManager;
@@ -462,6 +463,40 @@ class ApiController extends YesWikiController
         return (empty($result))
             ? $this->deletePage($tag)
             : new ApiResponse($result, $code);
+    }
+
+    /**
+     * @Route("/api/pages/{tag}/delete/getToken",methods={"GET"},options={"acl":{"public","+"}})
+     */
+    public function getDeleteToken($tag)
+    {
+        return new ApiResponse([
+            'token'=>$this->regenerateToken($tag)
+        ]);
+    }
+
+    /**
+     * use 'example' as tag, to keep same format for route
+     * @Route("/api/pages/example/delete/getTokens",methods={"GET"},options={"acl":{"public","+"}})
+     */
+    public function getDeleteTokens()
+    {
+        $pageIds = (empty($_GET['pages']) || !is_string($_GET['pages'])) ? [] : explode(',',strval($_GET['pages']));
+        $tokens = [];
+        foreach ($pageIds as $tag) {
+            $tokens[$tag] = $this->regenerateToken($tag);
+        }
+        return new ApiResponse([
+            'tokens'=>$tokens
+        ]);
+    }
+
+    protected function regenerateToken(string $tag): string
+    {
+        $page = $this->wiki->services->get(PageManager::class)->getOne($tag);
+        return (!empty($page) && ($this->wiki->UserIsAdmin() || $this->wiki->UserIsOwner($tag)))
+            ? $this->wiki->services->get(CsrfTokenManager::class)->refreshToken("api\\pages\\$tag\\delete")->getValue()
+            : 'not-authorized';
     }
 
     /**

--- a/tools/bazar/actions/BazarCartoAction.php
+++ b/tools/bazar/actions/BazarCartoAction.php
@@ -80,7 +80,7 @@ class BazarCartoAction extends YesWikiAction
              * Exemple: provider="OpenStreetMap.France" providers="OpenStreetMap.Mapnik,OpenStreetMap.France"
              * TODO: ajouter gestion "providers_credentials"
              */
-            'providers' => isset($arg['providers']) ? explode(',', $arg['providers']) : [],
+            'providers' => $this->formatArray($arg['providers'] ?? []),
             /*
              * Une liste de layers (couches).
              * Exemple avec 1 layer tiles, 1 layer geojson:
@@ -95,7 +95,7 @@ class BazarCartoAction extends YesWikiAction
              *  Le plus simple est de recopier les data GeoJson dans une page du Wiki puis de l'appeler avec le handler "/raw".
              * TODO: ajouter gestion "layers_credentials"
              */
-            'layers' => isset($arg['layers']) ? explode(',', $arg['layers']) : [],
+            'layers' => $this->formatArray($arg['layers'] ?? []),
             // Mettre des puces petites ? non par defaut
             'markersize' => $markerSize,
             'smallmarker' => $smallMarker === '1' ? '' : ' xl',

--- a/tools/bazar/actions/BazarCartoAction.php
+++ b/tools/bazar/actions/BazarCartoAction.php
@@ -52,11 +52,18 @@ class BazarCartoAction extends YesWikiAction
 
         // Filters entries via query to remove whose withou bf_latitude nor bf_longitude
         $query = $this->getService(EntryController::class)->formatQuery($arg, $_GET);
-        if (!isset($query['bf_latitude!'])) {
-            $query['bf_latitude!'] = "";
-        }
-        if (!isset($query['bf_longitude!'])) {
-            $query['bf_longitude!'] = "";
+        if ($template != 'map-and-table' ||
+            (
+                !empty($arg['tablewith']) && 
+                $arg['tablewith'] === 'only-geolocation'
+            )
+        ) {
+            if (!isset($query['bf_latitude!'])) {
+                $query['bf_latitude!'] = "";
+            }
+            if (!isset($query['bf_longitude!'])) {
+                $query['bf_longitude!'] = "";
+            }
         }
 
         return([

--- a/tools/bazar/actions/BazarListeAction.php
+++ b/tools/bazar/actions/BazarListeAction.php
@@ -10,7 +10,8 @@ use YesWiki\Core\YesWikiAction;
 
 class BazarListeAction extends YesWikiAction
 {
-    protected const BAZARCARTO_TEMPLATES = ["map", "gogomap", "gogocarto"] ; // liste des templates sans .twig ni .tpl.html
+    protected const BAZARCARTO_TEMPLATES = ["map", "gogomap", "gogocarto","map-and-table"] ; // liste des templates sans .twig ni .tpl.html
+    protected const BAZARTABLE_TEMPLATES = ["table","map-and-table"] ; // liste des templates sans .twig ni .tpl.html
     protected const CALENDRIER_TEMPLATES = ["calendar"] ; // liste des templates sans .twig ni .tpl.html
 
     protected $debug;
@@ -90,11 +91,14 @@ class BazarListeAction extends YesWikiAction
             }
         }
 
-        if (in_array($template, ['list', 'card'])) {
+        if (in_array($template, ['list', 'card','map-and-table','table'])) {
             $dynamic = true;
         }
         if ($dynamic && $template == 'liste_accordeon') {
             $template = 'list';
+        }
+        if ($dynamic && in_array($template,['tableau.tpl.html','tableau'])) {
+            $template = 'table';
         }
         $searchfields = $this->formatArray($arg['searchfields'] ?? null);
         $searchfields = empty($searchfields) ? ['bf_titre'] : $searchfields;
@@ -225,11 +229,14 @@ class BazarListeAction extends YesWikiAction
         // If the template is a map or a calendar, call the dedicated action so that
         // arguments can be properly formatted. The second first condition prevents infinite loops
         if (self::specialActionFromTemplate($this->arguments['template'], "BAZARCARTO_TEMPLATES")
-                && (!isset($this->arguments['calledBy']) || $this->arguments['calledBy'] !== 'BazarCartoAction')) {
+                && (!isset($this->arguments['calledBy']) || !in_array($this->arguments['calledBy'],['BazarCartoAction','BazarTableAction']))) {
             return $this->callAction('bazarcarto', $this->arguments);
         } elseif (self::specialActionFromTemplate($this->arguments['template'], "CALENDRIER_TEMPLATES")
                 && (!isset($this->arguments['calledBy']) || $this->arguments['calledBy'] !== 'CalendrierAction')) {
             return $this->callAction('calendrier', $this->arguments);
+        } elseif (self::specialActionFromTemplate($this->arguments['template'], "BAZARTABLE_TEMPLATES")
+                && (!isset($this->arguments['calledBy']) || $this->arguments['calledBy'] !== 'BazarTableAction')) {
+            return $this->callAction('bazartable', $this->arguments);
         }
 
         $bazarListService = $this->getService(BazarListService::class);
@@ -239,9 +246,11 @@ class BazarListeAction extends YesWikiAction
             if (isset($this->arguments['zoom'])) {
                 $this->arguments['zoom'] = intval($this->arguments['zoom']) ;
             }
+            $currentUser = $this->getService(AuthController::class)->getLoggedUser();
             return $this->render("@bazar/entries/index-dynamic-templates/{$this->arguments['template']}.twig", [
                 'params' => $this->arguments,
                 'forms' => count($this->arguments['idtypeannonce']) === 0 ? $forms : '',
+                'currentUserName' => empty($currentUser['name']) ? '' : $currentUser['name']
             ]);
         } else {
             $entries = $bazarListService->getEntries($this->arguments, $forms);
@@ -351,6 +360,9 @@ class BazarListeAction extends YesWikiAction
                 break;
             case "CALENDRIER_TEMPLATES":
                 $baseArray = self::CALENDRIER_TEMPLATES ;
+                break;
+            case "BAZARTABLE_TEMPLATES":
+                $baseArray = self::BAZARTABLE_TEMPLATES ;
                 break;
             default:
                 return false;

--- a/tools/bazar/actions/BazarTableAction.php
+++ b/tools/bazar/actions/BazarTableAction.php
@@ -9,6 +9,7 @@ class BazarTableAction extends YesWikiAction
     public function formatArguments($arg)
     {
         $newArg = [];
+        $newArg['pagination'] = -1;
         if (empty($arg['columnfieldsids'])){
             $this->appendAllFieldsIds($arg,$newArg,'columnfieldsids');
         } elseif ($this->formatBoolean($arg,false,'exportallcolumns')){

--- a/tools/bazar/actions/BazarTableAction.php
+++ b/tools/bazar/actions/BazarTableAction.php
@@ -1,0 +1,39 @@
+<?php
+
+use YesWiki\Bazar\Controller\EntryController;
+use YesWiki\Bazar\Service\FormManager;
+use YesWiki\Core\YesWikiAction;
+
+class BazarTableAction extends YesWikiAction
+{
+    public function formatArguments($arg)
+    {
+        $newArg = [];
+        if (empty($arg['columnfieldsids'])){
+            $this->appendAllFieldsIds($arg,$newArg,'columnfieldsids');
+        } elseif ($this->formatBoolean($arg,false,'exportallcolumns')){
+            $this->appendAllFieldsIds($arg,$newArg,'exportallcolumnsids');
+        }
+
+        return($newArg);
+    }
+
+    public function run()
+    {
+        return $this->callAction('bazarliste', $this->arguments);
+    }
+
+    protected function appendAllFieldsIds(array $arg, array &$newArg,string $key){
+        $formId = empty($arg['id']) ? '1' : array_values(array_filter(explode(',',$arg['id']),function($id){
+            return strval($id) == strval(intval($id));
+        }))[0];
+        $form = $this->getService(FormManager::class)->getOne($formId);
+        if (!empty($form['prepared'])){
+            $newArg[$key] = implode(',',array_map(function($field){
+                return $field->getPropertyName();
+            },array_filter($form['prepared'],function($field){
+                return !empty($field->getPropertyName());
+            })));
+        }
+    }
+}

--- a/tools/bazar/presentation/javascripts/components/BazarTable.js
+++ b/tools/bazar/presentation/javascripts/components/BazarTable.js
@@ -190,7 +190,7 @@ let componentParams = {
                                 field:fields[id],
                                 visible:true,
                                 printable:true,
-                                addLink:idx === 0 && !('bf_titre' in columnfieldsids)
+                                addLink:(idx === 0 && !columnfieldsids.includes('bf_titre')) || id === 'bf_titre'
                             }
                         })
                     } else if (fieldsToRegister.includes(id)) {
@@ -593,8 +593,6 @@ let componentParams = {
                     } else {
                         anchorData = ''
                     }
-                } else if (fieldtype === 'checkboxfiche' && typeof data === 'object' && data !== null && 'raw' in data) {
-                    return data.raw.map(({key,title})=>this.renderCell({fieldtype:'urlmodal',fieldName,idx})({display:title},type,{id_fiche:key,url:wiki.url(`${key}/iframe`)})).join(',<br/>')
                 } else if (typeof fieldtype === 'string' && ['listefiche','radiofiche','checkboxfiche'].includes(fieldtype) && formattedData.length > 0) {
                     const intFieldType = (typeof data === 'object' && data !== null && 'externalBaseUrl' in data)
                         ? (
@@ -607,14 +605,17 @@ let componentParams = {
                         : formattedData.split(',').map((key)=>{return {key,title:key}})
                     return formattedArray.map(({key,title})=>{
                         return this.renderCell({fieldtype:intFieldType,fieldName,idx})({display:title},type,{
-                            id_fiche:key,
-                            url:(intFieldType === 'urlmodal') 
-                                ? wiki.url(`${key}/iframe`)
-                                :(
-                                    intFieldType === 'urlnewwindow'
-                                    ? data.externalBaseUrl + key
-                                    : ''
-                                )
+                            ...row,
+                            ...{
+                                id_fiche:key,
+                                url:(intFieldType === 'urlmodal') 
+                                    ? wiki.url(`${key}/iframe`)
+                                    :(
+                                        intFieldType === 'urlnewwindow'
+                                        ? data.externalBaseUrl + key
+                                        : ''
+                                    )
+                            }
                         }).trim()
                     }).join(',\n')
                 }

--- a/tools/bazar/presentation/javascripts/components/BazarTable.js
+++ b/tools/bazar/presentation/javascripts/components/BazarTable.js
@@ -184,7 +184,7 @@ let componentParams = {
                         })
                     } else if (fieldsToRegister.includes(id)) {
                         fieldsToRegister = fieldsToRegister.filter((e)=>e!=id)
-                        this.registerSpecialFields([id],false,params,data)
+                        this.registerSpecialFields([id],false,params,data,options)
                     }
                 })
                 if (await this.sanitizedParamAsync('exportallcolumns')){
@@ -204,7 +204,7 @@ let componentParams = {
                     })
                 }
 
-                this.registerSpecialFields(fieldsToRegister,true,params,data)
+                this.registerSpecialFields(fieldsToRegister,true,params,data,options)
 
                 this.columns = data.columns
             }
@@ -464,7 +464,7 @@ let componentParams = {
                 }
             }
         },
-        registerSpecialFields(fieldsToRegister,test,params,data){
+        registerSpecialFields(fieldsToRegister,test,params,data,options){
             if (Array.isArray(fieldsToRegister) && fieldsToRegister.length > 0){
                 const parameters = {
                     'date_creation_fiche': {
@@ -499,7 +499,7 @@ let componentParams = {
                         if (canPushColumn){
                             data.columns.push({
                                 data: propertyName,
-                                title: this.getTemplateFromSlot(parameters[propertyName].slotName,{}),
+                                title: options.columntitles[propertyName] || this.getTemplateFromSlot(parameters[propertyName].slotName,{}),
                                 footer: ''
                             })
                         }

--- a/tools/bazar/presentation/javascripts/components/BazarTable.js
+++ b/tools/bazar/presentation/javascripts/components/BazarTable.js
@@ -12,6 +12,7 @@ let componentParams = {
             columns: [],
             dataTable: null,
             displayedEntries: {},
+            fastSearch: false,
             fields: {},
             forms: {},
             isReady:{
@@ -258,7 +259,8 @@ let componentParams = {
             return {
                 ...DATATABLE_OPTIONS,
                 ...{
-                  searching: false,
+                  searching: true,// allow search but ue dom option not display filter
+                  dom:'lrtip', // instead of default lfrtip , with f for filter, see help : https://datatables.net/reference/option/dom
                   footerCallback: ()=>{
                     this.updateFooter()
                   },
@@ -534,6 +536,14 @@ let componentParams = {
                 return !('id_fiche' in data) || entryIdsToRemove.includes(data.id_fiche)
             }).remove()
         },
+        resetFastSearch(isOk){
+            if (isOk){
+                this.fastSearch = false
+            }
+            if (this.dataTable !== null){
+                this.$nextTick(()=>{this.dataTable.search(this.$root.search).draw()})
+            }
+        },
         resolve(name){
             this.isReady[name] = true
             if (name in this.cacheResolveReject &&
@@ -744,6 +754,12 @@ let componentParams = {
             this.addRows(dataTable,columns,newEntries,currentusername,this.isadmin)
             this.dataTable.draw()
         },
+        updateFastSearch(newSearch){
+            if (this.dataTable !== null){
+                this.dataTable.search(newSearch).draw()
+                this.fastSearch = true
+            }
+        },
         updateFieldsFromRoot(){
             this.fields = this.$root.formFields
             if (Object.keys(this.fields).length > 0){
@@ -786,6 +802,10 @@ let componentParams = {
         });
         this.updateFieldsFromRoot()
         window.urlImageResizedOnError = this.$root.urlImageResizedOnError
+        this.$root.$watch('search',(newSearch)=>{this.updateFastSearch(newSearch)})
+        this.$root.$watch('ready',(newVal)=>{this.resetFastSearch(newVal)})
+        this.$root.$watch('isLoading',(newVal)=>{this.resetFastSearch(!newVal)})
+        this.$root.$watch('searchedEntries',()=>{this.resetFastSearch(true)})
     },
     watch: {
         entries(newVal, oldVal) {

--- a/tools/bazar/presentation/javascripts/components/BazarTable.js
+++ b/tools/bazar/presentation/javascripts/components/BazarTable.js
@@ -1,0 +1,767 @@
+import SpinnerLoader from './SpinnerLoader.js'
+
+let componentName = 'BazarTable';
+let isVueJS3 = (typeof Vue.createApp == "function");
+
+let componentParams = {
+    props: ['currentusername','params','entries','ready','root','isadmin'],
+    components: {SpinnerLoader},
+    data: function() {
+        return {
+            cacheResolveReject: {},
+            columns: [],
+            dataTable: null,
+            displayedEntries: {},
+            fields: {},
+            forms: {},
+            isReady:{
+                fields: false,
+                params: false
+            },
+            templatesForRendering: {},
+            uuid: null
+        };
+    },
+    methods:{
+        addRows(dataTable,columns,entries,currentusername,isadmin){
+            const entriesToAdd = entries.filter((entry)=>typeof entry === 'object' && 'id_fiche' in entry && !(entry.id_fiche in this.displayedEntries))
+            let formattedDataList = []
+            entriesToAdd.forEach((entry)=>{
+                this.displayedEntries[entry.id_fiche] = entry
+                let formattedData = {}
+                columns.forEach((col)=>{
+                    if (!(typeof col.data === 'string')){
+                        formattedData[col.data] = ''
+                    } else if (col.data === '==canDelete=='){
+                        formattedData[col.data] = !this.$root.isExternalUrl(entry) && 
+                            'owner' in entry &&
+                            (isadmin || entry.owner == currentusername)
+                    } else if (['==adminsbuttons=='].includes(col.data)) {
+                        formattedData[col.data] = ''
+                    } else if ('firstlevel' in col && typeof col.firstlevel === 'string' && col.firstlevel.length > 0){
+                        formattedData[col.data] = (
+                            col.firstlevel in entry && 
+                            (typeof entry[col.firstlevel] === 'object') &&
+                            entry[col.firstlevel] !== null && 
+                            col.data in entry[col.firstlevel]
+                        ) ? entry[col.firstlevel][col.data] : ''
+                    } else if ('checkboxfield' in col && typeof col.checkboxfield === 'string' && col.checkboxfield.length > 0){
+                        formattedData[col.data] = (
+                            col.checkboxfield in entry &&
+                            'checkboxkey' in col &&
+                            typeof entry[col.checkboxfield] === 'string'
+                            && entry[col.checkboxfield].split(',').includes(col.checkboxkey)
+                        ) ? 'X' : ''
+                    } else if ('displayValOptions' in col){
+                        formattedData[col.data] = (col.data in entry && typeof entry[col.data] === 'string') ? {
+                            display:entry[col.data].split(',').map((v)=>v in col.displayValOptions ? col.displayValOptions[v] : v).join(",\n"),
+                            export: entry[col.data].split(',').map((v)=>v in col.displayValOptions ? `"${col.displayValOptions[v]}"` : v).join(',')
+                        } : ''
+                    } else {
+                        formattedData[col.data] = (col.data in entry && typeof entry[col.data] === 'string' ) ? entry[col.data] : ''
+                    }
+                });
+                ['id_fiche','color','icon','url'].forEach((key)=>{
+                    if (!(key in formattedData)){
+                        formattedData[key] = entry[key] || ''
+                    }
+                })
+                formattedDataList.push(formattedData)
+            })
+            dataTable.rows.add(formattedDataList)
+        },
+        arraysEqual(a, b) {
+            if (a === b) return true
+            if (a == null || b == null || !Array.isArray(a) || !Array.isArray(b)) return false
+            if (a.length !== b.length) return false
+    
+            a.sort()
+            b.sort()
+            return a.every((val,idx)=>a[idx] !== b[idx])
+        },
+        deleteAllSelected(event){
+            const uuid = this.getUuid()
+            multiDeleteService.updateNbSelected(`MultiDeleteModal${uuid}`)
+            const entriesIdsToRefreshDeleteToken = []
+            $(`#${uuid}`).find('tr > td:first-child input.selectline[type=checkbox]:visible:checked').each(function (){
+                const csrfToken = $(this).data('csrftoken')
+                const itemId = $(this).data('itemid')
+                if (typeof itemId === 'string' && itemId.length > 0 && (typeof csrfToken !== 'string' || csrfToken === 'to-be-defined')){
+                    entriesIdsToRefreshDeleteToken.push({elem:$(this),itemId})
+                }
+            })
+            if (entriesIdsToRefreshDeleteToken.length > 0){
+                this.getCsrfDeleteTokens(entriesIdsToRefreshDeleteToken.map((e)=>e.itemId))
+                    .then((tokens)=>{
+                        entriesIdsToRefreshDeleteToken.forEach(({elem,itemId})=>{
+                            $(elem).data('csrftoken',tokens[itemId] || 'error')
+                        })
+                    })
+                    .catch(this.manageError)
+            }
+            // if something to do before showing modal (like get csrf token ?)
+        },
+        getAdminsButtons(entryId,entryTitle,entryUrl,candelete){
+            const isExternal =this.$root.isExternalUrl({id_fiche:entryId,url:entryUrl})
+            return this.getTemplateFromSlot(
+                'adminsbuttons',
+                {
+                    entryId:'entryId',
+                    entryTitle:'entryTitle',
+                    entryUrl:'entryUrl',
+                    isExternal,
+                    candelete: [true,'true'].includes(candelete)
+                }
+            ).replace(/entryId/g,entryId)
+            .replace(/entryTitle/g,entryTitle)
+            .replace(/entryUrl/g,entryUrl)
+        },
+        async getColumns(){
+            if (this.columns.length == 0){
+                const fields = await this.waitFor('fields')
+                const params = await this.waitFor('params');
+                let columnfieldsids = this.sanitizedParam(params,this.isAdmin,'columnfieldsids')
+                let defaultcolumnwidth = this.sanitizedParam(params,this.isAdmin,'defaultcolumnwidth')
+                if (columnfieldsids.every((id)=>id.length ==0)){
+                    // backup
+                    columnfieldsids = ['bf_titre']
+                }
+                const data = {columns:[]}
+                const width = defaultcolumnwidth.length > 0 ? {width:defaultcolumnwidth}: {}
+                if (this.sanitizedParam(params,this.isAdmin,'displayadmincol')){
+                    const uuid = this.getUuid()
+                    data.columns.push({
+                        ...{
+                            data: '==canDelete==',
+                            class: 'not-export-this-col',
+                            orderable: false,
+                            render: (data,type,row)=>{
+                                return type === 'display' ? this.getDeleteChekbox(uuid,row.id_fiche,!data) : ''
+                            },
+                            title: this.getDeleteChekboxAll(uuid,'top'),
+                            footer: this.getDeleteChekboxAll(uuid,'bottom')
+                        },
+                        ...width
+                    })
+                    data.columns.push({
+                        ...{
+                            data: '==adminsbuttons==',
+                            orderable: false,
+                            class: 'horizontal-admins-btn not-export-this-col',
+                            render: (data,type,row)=>{
+                                return type === 'display' ? this.getAdminsButtons(row.id_fiche,row.bf_titre || '',row.url || '',row['==canDelete==']) : ''
+                            },
+                            title: '',
+                            footer: ''
+                        },
+                        ...width
+                    })
+                }
+                const options={
+                    checkboxfieldsincolumns: this.sanitizedParam(params,this.isAdmin,'checkboxfieldsincolumns'),
+                    columnswidth: this.sanitizedParam(params,this.isAdmin,'columnswidth'),
+                    defaultcolumnwidth,
+                    sumfieldsids: this.sanitizedParam(params,this.isAdmin,'sumfieldsids'),
+                    visible:true,
+                    printable:true,
+                    addLink:false,
+                    columntitles:this.sanitizedParam(params,this.isAdmin,'columntitles'),
+                    displayimagesasthumbnails:this.sanitizedParam(params,this.isAdmin,'displayimagesasthumbnails'),
+                    displayvaluesinsteadofkeys:this.sanitizedParam(params,this.isAdmin,'displayvaluesinsteadofkeys'),
+                    baseIdx: data.columns.length
+                }
+                columnfieldsids.forEach((id,idx)=>{
+                    if (id.length >0 && id in fields){
+                        this.registerField(data,{
+                            ...options,
+                            ...{
+                                field:fields[id],
+                                visible:true,
+                                printable:true,
+                                addLink:idx === 0 && !('bf_titre' in columnfieldsids)
+                            }
+                        })
+                    }
+                })
+                if (await this.sanitizedParamAsync('exportallcolumns')){
+                    Object.keys(fields).forEach((id)=>{
+                        // append fields not displayed
+                        if (!columnfieldsids.includes(id)){
+                            this.registerField(data,{
+                                ...options,
+                                ...{
+                                    field:fields[id],
+                                    visible:false,
+                                    printable:false,
+                                    addLink:false
+                                }
+                            })
+                        }
+                    })
+                }
+
+                [
+                    ['displaycreationdate','date_creation_fiche','creationdatetranslate'],
+                    ['displaylastchangedate','date_maj_fiche','modifiydatetranslate'],
+                    ['displayowner','owner','ownertranslate']
+                ].forEach(([paramName,propertyName,slotName])=>{
+                    if (this.sanitizedParam(params,this.isadmin,paramName)){
+                        data.columns.push({
+                            data: propertyName,
+                            title: this.getTemplateFromSlot(slotName,{}),
+                            footer: ''
+                        })
+                    }
+                })
+                this.columns = data.columns
+            }
+            return this.columns
+        },
+        async getCsrfDeleteToken(entryId){
+            return await this.getJson(wiki.url(`?api/pages/${entryId}/delete/getToken`))
+            .then((json)=>('token' in json && typeof json.token === 'string') ? json.token : 'error')
+        },
+        async getCsrfDeleteTokens(entriesIds){
+            return await this.getJson(wiki.url(`?api/pages/example/delete/getTokens`,{pages:entriesIds.join(',')}))
+            .then((json)=>('tokens' in json && typeof json.tokens === 'object') ? json.tokens : entriesIds.reduce((o, key) => ({ ...o, [key]: 'error'}), {}))
+        },
+        getDatatableOptions(){
+            const buttons = []
+            DATATABLE_OPTIONS.buttons.forEach((option) => {
+              buttons.push({
+                ...option,
+                ...{ footer: true },
+                ...{
+                  exportOptions: (
+                    option.extend != 'print'
+                      ? {
+                        orthogonal: 'sort', // use sort data for export
+                        columns(idx, data, node) {
+                          return !$(node).hasClass('not-export-this-col')
+                        }
+                      }
+                      : {
+                        columns(idx, data, node) {
+                          const isVisible = $(node).data('visible')
+                          return !$(node).hasClass('not-export-this-col') && (
+                            isVisible == undefined || isVisible != false
+                          ) && !$(node).hasClass('not-printable')
+                        }
+                      })
+                }
+              })
+            })
+            return {
+                ...DATATABLE_OPTIONS,
+                ...{
+                  searching: false,
+                  footerCallback: ()=>{
+                    this.updateFooter()
+                  },
+                  buttons
+                }
+              }
+        },
+        async getDatatable(){
+            if (this.dataTable === null){
+                // create dataTable
+                const columns = await this.getColumns()
+                const sumfieldsids = await this.sanitizedParamAsync('sumfieldsids')
+                let firstColumnOrderable = 0
+                for (let index = 0; index < columns.length; index++) {
+                    if ('orderable' in columns[index]  && !columns[index].orderable){
+                        firstColumnOrderable += 1
+                    } else {
+                        break
+                    }
+                }
+                this.dataTable = $(this.$refs.dataTable).DataTable({
+                    ...this.getDatatableOptions(),
+                    ...{
+                        columns: columns,
+                        "scrollX": true,
+                        order: [[firstColumnOrderable,'asc']]
+                    }
+                })
+                $(this.dataTable.table().node()).prop('id',this.getUuid())
+                if (sumfieldsids.length > 0 || this.sanitizedParamAsync('displayadmincol')){
+                    this.initFooter(columns,sumfieldsids)
+                }
+            }
+            return this.dataTable
+        },
+        getDeleteChekbox(targetId,itemId,disabled = false){
+            return this.getTemplateFromSlot(
+                'deletecheckbox',
+                {targetId:'targetId',itemId:'itemId',disabled}
+            ).replace(/targetId/g,targetId)
+            .replace(/itemId/g,itemId)
+        },
+        getDeleteChekboxAll(targetId,selectAllType){
+            return this.getTemplateFromSlot('deletecheckboxall',{})
+                .replace(/targetId/g,targetId)
+                .replace(/selectAllType/g,selectAllType)
+        },
+        async getJson(url){
+            return await fetch(url)
+                .then((response)=>{
+                    if (response.ok){
+                        return response.json()
+                    } else {
+                        throw new Error(`reponse was not ok when getting "${url}"`)
+                    }
+                })
+        },
+        getTemplateFromSlot(name,params){
+            const key = name+'-'+JSON.stringify(params)
+            if (!(key in this.templatesForRendering)){
+                if (name in this.$scopedSlots){
+                    const slot = this.$scopedSlots[name]
+                    const constructor = Vue.extend({
+                        render: function(h){
+                            return h('div',{},slot(params))
+                        }
+                    })
+                    const instance = new constructor()
+                    instance.$mount()
+                    let outerHtml = '';
+                    for (let index = 0; index < instance.$el.childNodes.length; index++) {
+                        outerHtml += instance.$el.childNodes[index].outerHTML || instance.$el.childNodes[index].textContent
+                    }
+                    this.templatesForRendering[key] = outerHtml
+                } else {
+                    this.templatesForRendering[key] = ''
+                }
+            }
+            return this.templatesForRendering[key]
+        },
+        getUuid(){
+            if (this.uuid === null){
+                this.uuid = crypto.randomUUID()
+            }
+            return this.uuid
+        },
+        initFooter(columns,sumfieldsids){
+            const footerNode = this.dataTable.footer().to$()
+            if (footerNode[0] !== null){
+                const footer = $('<tr>')
+                let displayTotal = sumfieldsids.length > 0
+                columns.forEach((col)=>{
+                    if ('footer' in col && col.footer.length > 0){
+                        const element = $(col.footer)
+                        const isTh = $(element).prop('tagName') === 'TH'
+                        footer.append(isTh ? element : $('<th>').append(element))
+                    } else if (displayTotal) {
+                        displayTotal = false
+                        footer.append($('<th>').text(this.getTemplateFromSlot('sumtranslate',{})))
+                    } else {
+                        footer.append($('<th>'))
+                    }
+                })
+                footerNode.html(footer)
+            }
+        },
+        manageError(error){
+            if (wiki.isDebugEnabled){
+                console.error(error)
+            }
+            return null
+        },
+        registerField(data,{
+                field,
+                checkboxfieldsincolumns=false,
+                sumfieldsids=[],
+                visible=true,
+                printable=true,
+                addLink=false,
+                columnswidth={},
+                defaultcolumnwidth='',
+                columntitles={},
+                baseIdx=0,
+                displayimagesasthumbnails=false,
+                displayvaluesinsteadofkeys=false
+            }){
+            if (typeof field.propertyname === 'string' && field.propertyname.length > 0){
+                const className = (printable ? '' : 'not-printable')+(sumfieldsids.includes(field.propertyname) ? ' sum-activated': '')
+                const width = field.propertyname in columnswidth ? {width:columnswidth[field.propertyname]} : (defaultcolumnwidth.length > 0 ? {width:defaultcolumnwidth}: {})
+                const titleIdx = data.columns.length - baseIdx
+                if (typeof field.type === 'string' && field.type === 'map'){
+                    data.columns.push({
+                        ...{
+                            class: className,
+                            data: field.latitudeField,
+                            title: columntitles[field.latitudeField] || columntitles[titleIdx] || this.getTemplateFromSlot('latitudetext',{}),
+                            firstlevel: field.propertyname,
+                            render: this.renderCell({addLink,idx:titleIdx}),
+                            footer: '',
+                            visible
+                        },
+                        ...width
+                    })
+                    data.columns.push({
+                        ...{
+                            class: className,
+                            data: field.longitudeField,
+                            title: columntitles[field.longitudeField] || columntitles[titleIdx+1] || this.getTemplateFromSlot('longitudetext',{}),
+                            firstlevel: field.propertyname,
+                            render: this.renderCell({addLink}),
+                            footer: '',
+                            visible
+                        },
+                        ...width
+                    })
+                } else if (checkboxfieldsincolumns && 
+                    typeof field.type === 'string' && 
+                    ['checkboxfiche','checkbox'].includes(field.type) &&
+                    typeof field.options == 'object') {
+                    Object.keys(field.options).forEach((optionKey,idx)=>{
+                        const name = `${field.propertyname}-${optionKey}`
+                        data.columns.push({
+                            ...{
+                                class: className,
+                                data: name,
+                                title: columntitles[name] || 
+                                    (
+                                        field.propertyname in columntitles 
+                                        ? `${columntitles[field.propertyname]} - ${field.options[optionKey] || optionKey}` 
+                                        : undefined
+                                    ) || 
+                                    columntitles[titleIdx+idx] || 
+                                    `${field.label || field.propertyname} - ${field.options[optionKey] || optionKey}`,
+                                checkboxfield: field.propertyname,
+                                render: this.renderCell({addLink,idx:titleIdx+idx}),
+                                checkboxkey: optionKey,
+                                footer: '',
+                                visible
+                            },
+                            ...width
+                        })
+                    })
+                } else {
+                    const fieldtype = ['link','email'].includes(field.type) ? field.type: ((field.type === 'image' && displayimagesasthumbnails)?'image':'')
+                    const fieldName = (fieldtype === 'image' && displayimagesasthumbnails) ? field.propertyname : ''
+                    const displayValOptions = (displayvaluesinsteadofkeys && 'options' in field && typeof field.options === 'object')
+                    ? {
+                        displayValOptions:field.options
+                    } 
+                    : {}
+                    data.columns.push({
+                        ...{
+                            class: className,
+                            data: field.propertyname,
+                            title: columntitles[field.propertyname] || columntitles[titleIdx] || field.label || field.propertyname,
+                            render: this.renderCell({fieldtype,addLink,idx:titleIdx,fieldName}),
+                            footer: '',
+                            visible
+                        },
+                        ...width,
+                        ...displayValOptions
+                    })
+                }
+            }
+        },
+        removeRows(dataTable,newIds){
+            let entryIdsToRemove = Object.keys(this.displayedEntries).filter((id)=>!newIds.includes(id))
+            entryIdsToRemove.forEach((id)=>{
+                if (id in this.displayedEntries){
+                    delete this.displayedEntries[id]
+                }
+            })
+            dataTable.rows((idx,data,node)=>{
+                return !('id_fiche' in data) || entryIdsToRemove.includes(data.id_fiche)
+            }).remove()
+        },
+        resolve(name){
+            this.isReady[name] = true
+            if (name in this.cacheResolveReject &&
+                Array.isArray(this.cacheResolveReject[name])){
+                const listOfResolveReject = this.cacheResolveReject[name]
+                this.cacheResolveReject[name] = []
+                listOfResolveReject.forEach(({resolve})=>resolve(name in this ? this[name] : null))
+            }
+        },
+        renderCell({fieldtype='',fieldName='',addLink=false,idx=-1}){
+            return (data,type,row)=>{
+                if (type === 'sort' || type === 'filter'){
+                    return (typeof data === 'object' && 'export' in data) ? data.export : data
+                }
+                const formattedData = (typeof data === 'object' && data !== null && 'display' in data) ? data.display : (data === null ? '' : String(data))
+                let anchorData = 'anchorData'
+                let anchorImageSpecificPart = ''
+                let anchorImageOther = ''
+                let anchorImageExt = ''
+                let anchorOtherEntryId = ''
+                if (fieldtype === 'image'){
+                    if(formattedData.length > 0){
+                        let regExp = new RegExp(`^(${row.id_fiche}_${fieldName}_)(.*)_(\\d{14})_(\\d{14})\\.([^.]+)$`)
+                        if (regExp.test(formattedData)) {
+                            let anchorImageDate1 = ''
+                            let anchorImageDate2 = '';
+                            [,,anchorImageSpecificPart,anchorImageDate1,anchorImageDate2,anchorImageExt] = formattedData.match(regExp)
+                            anchorImageOther = `${anchorImageDate1}_${anchorImageDate2}`
+                            anchorData = 'entryIdAnchor_fieldNameAnchor_anchorImageSpecificPart_anchorImageOther.anchorImageExt'
+                        } else {
+                            regExp = new RegExp(`^(${row.id_fiche}_${fieldName}_)(.*)\\.([^.]+)$`)
+                            if (regExp.test(formattedData)) {
+                                [,,anchorImageSpecificPart,anchorImageExt] = formattedData.match(regExp)
+                                anchorData = 'entryIdAnchor_fieldNameAnchor_anchorImageSpecificPart.anchorImageExt'
+                            } else {
+                                // maybe from other entry
+                                regExp = new RegExp(`^([A-Za-z0-9-_]+)(_${fieldName}_)(.*)_(\\d{14})_(\\d{14})\\.([^.]+)$`)
+                                if (regExp.test(formattedData)) {
+                                    let anchorImageDate1 = ''
+                                    let anchorImageDate2 = '';
+                                    [,anchorOtherEntryId,,anchorImageSpecificPart,anchorImageDate1,anchorImageDate2,anchorImageExt] = formattedData.match(regExp)
+                                    anchorImageOther = `${anchorImageDate1}_${anchorImageDate2}`
+                                    anchorData = 'anchorOtherEntryId_fieldNameAnchor_anchorImageSpecificPart_anchorImageOther.anchorImageExt'
+                                } else {
+                                    // last possible format
+                                    regExp = new RegExp('^(.*)\\.([^.]+)$')
+                                    if (regExp.test(formattedData)) {
+                                        [,anchorImageSpecificPart,anchorImageExt] = formattedData.match(regExp)
+                                        anchorData = 'anchorImageSpecificPart.anchorImageExt'
+                                    } else {
+                                        anchorImageSpecificPart = formattedData
+                                        anchorData = 'anchorImageSpecificPart'
+                                    }
+                                }
+                            }                            
+                        }
+                    } else {
+                        anchorData = ''
+                    }
+                }
+                const template = this.getTemplateFromSlot('rendercell',{
+                    anchorData,
+                    fieldtype,
+                    addLink,
+                    entryId:'entryIdAnchor',
+                    fieldName, 
+                    url:'anchorUrl',
+                    color: (idx === 0 && row.color.length > 0) ? 'lightslategray' : '',
+                    icon: (idx === 0 && row.icon.length > 0) ? 'iconAnchor' : ''
+                })
+                return template.replace(/anchorData/g,formattedData.replace(/\n/g,'<br/>'))
+                  .replace(/entryIdAnchor/g,row.id_fiche)
+                  .replace(/anchorUrl/g,row.url)
+                  .replace(/lightslategray/g,row.color)
+                  .replace(/iconAnchor/g,row.icon)
+                  .replace(/fieldNameAnchor/g,fieldName)
+                  .replace(/anchorImageSpecificPart/g,anchorImageSpecificPart)
+                  .replace(/anchorImageOther/g,anchorImageOther)
+                  .replace(/anchorImageExt/g,anchorImageExt)
+                  .replace(/anchorOtherEntryId/g,anchorOtherEntryId)
+            }
+        },
+        async sanitizedParamAsync(name){
+            return this.sanitizedParam(await this.waitFor('params'),this.isadmin,name)
+        },
+        sanitizedParam(params,isAdmin,name){
+            switch (name) {
+                case 'displayadmincol':
+                case 'displaycreationdate':
+                case 'displaylastchangedate':
+                case 'displayowner':
+                    const paramValue = (
+                            name in params && 
+                            typeof params[name] === 'string' && 
+                            ['yes','onlyadmins'].includes(params[name]))
+                        ? params[name]
+                        : false
+                    switch (paramValue) {
+                        case 'onlyadmins':
+                            return [1,true,'1','true'].includes(isAdmin)
+                        case 'yes':
+                            return true
+                        case false:
+                        default:
+                            return false
+                    }
+                case 'checkboxfieldsincolumns':
+                    // default true
+                    return name in params ? !([false,0,'0','false'].includes(params[name])) : true
+                case 'displayvaluesinsteadofkeys':
+                case 'exportallcolumns':
+                case 'displayimagesasthumbnails':
+                    // default false
+                    return name in params ? [true,1,'1','true'].includes(params[name]) : false
+                    
+                case 'columnfieldsids':
+                case 'sumfieldsids':
+                    return (name in params && typeof params[name] === 'string')
+                        ? params[name].split(',').map((v)=>v.trim())
+                        : []
+                case 'columntitles':
+                    const columntitlesastab = (name in params && typeof params[name] === 'string')
+                        ? params[name].split(',').map((v)=>v.trim())
+                        : []
+                    const columntitles = {}
+                    columntitlesastab.forEach((val,idx)=>{
+                        const match = val.match(/^([A-Za-z0-9\-_]+)=(.+$)/)
+                        if (match){
+                            const [,key,title] = match
+                            columntitles[key] = title
+                        } else {
+                            columntitles[idx] = val
+                        }
+                    })
+                    return columntitles
+                case 'sumfieldsids':
+                    return (name in params && typeof params[name] === 'string')
+                        ? params[name].split(',').map((v)=>v.trim())
+                        : []
+                case 'columnswidth':
+                    const columnswidth = {}
+                    if (
+                        name in params && 
+                        typeof params[name] === 'string'
+                    ) {
+                        params[name].split(',').forEach((extract)=>{
+                            const [name,value] = extract.split('=',2)
+                            if (name && value && name.length > 0 && value.length > 0){
+                                columnswidth[name] = value
+                            }
+                        })
+                    }
+                    return columnswidth
+                case 'defaultcolumnwidth':
+                    return name in params ? String(params[name]) : ''
+                default:
+                    return params[name] || null
+            }
+        },
+        sanitizeValue(val) {
+          let sanitizedValue = val
+          if (Object.prototype.toString.call(val) === '[object Object]') {
+            // because if orthogonal data is defined, value is an object
+            sanitizedValue = val.display || ''
+          }
+          return (isNaN(sanitizedValue)) ? 1 : Number(sanitizedValue)
+        },
+        startDelete(event){
+            if (!multiDeleteService.isRunning) {
+                multiDeleteService.isRunning = true
+                const elem = event.target
+                if (elem) {
+                    $(elem).attr('disabled', 'disabled')
+                    multiDeleteService.deleteItems(elem)
+                }
+            }
+        },
+        async updateEntries(newEntries,newIds){
+            const columns = await this.getColumns()
+            const dataTable = await this.getDatatable()
+            const currentusername = this.currentusername
+            this.removeRows(dataTable,newIds)
+            this.addRows(dataTable,columns,newEntries,currentusername,this.isadmin)
+            this.dataTable.draw()
+        },
+        updateFieldsFromRoot(){
+            this.fields = this.$root.formFields
+            if (Object.keys(this.fields).length > 0){
+                this.resolve('fields')
+            }
+        },
+        updateFooter(){
+            if (this.dataTable !== null){
+                const activatedRows = []
+                this.dataTable.rows({ search: 'applied' }).every(function() {
+                  activatedRows.push(this.index())
+                })
+                this.dataTable.columns('.sum-activated').every((indexCol) => {
+                    let col = this.dataTable.column(indexCol)
+                    let sum = 0
+                    activatedRows.forEach((indexRow) => {
+                      const value = this.dataTable.row(indexRow).data()[col.dataSrc()]
+                      sum += this.sanitizeValue(Number(value))
+                    })
+                    this.dataTable.footer().to$().find(`> tr > th:nth-child(${indexCol+1})`).html(sum)
+                })
+            }
+        },
+        async waitFor(name){
+            if (this.isReady[name]){
+                return this[name] || null
+            }
+            if (!(name in this.cacheResolveReject)){
+                this.cacheResolveReject[name] = []
+            }
+            const promise = new Promise((resolve,reject)=>{
+                this.cacheResolveReject[name].push({resolve,reject})
+            })
+            return await promise.then((...args)=>Promise.resolve(...args)) // force .then()
+        }
+    },
+    mounted(){
+        $(isVueJS3 ? this.$el.parentNode : this.$el).on('dblclick',function(e) {
+          return false;
+        });
+        this.updateFieldsFromRoot()
+        window.urlImageResizedOnError = this.$root.urlImageResizedOnError
+    },
+    watch: {
+        entries(newVal, oldVal) {
+            this.updateFieldsFromRoot() // because updated in same time than entries (but not reactive)
+            const sanitizedNewVal = newVal.filter((e)=>(typeof e === 'object' && e !== null && 'id_fiche' in e))
+            const newIds = sanitizedNewVal.map((e) => e.id_fiche)
+            const oldIds = oldVal.map((e) => e.id_fiche || '').filter((e)=>(typeof e === 'string' && e.length > 0))
+            if (!this.arraysEqual(newIds, oldIds)) {
+                this.updateEntries(sanitizedNewVal,newIds).catch(this.manageError)
+            }
+        },
+        params() {
+            this.resolve('params')
+        },
+        ready(){
+            this.sanitizedParamAsync('displayadmincol').then((displayadmincol)=>{
+                if (displayadmincol){
+                    $(this.$refs.buttondeleteall).find(`#MultiDeleteModal${this.getUuid()}`).first().each(function(){
+                        $(this).on('shown.bs.modal', function() {
+                            multiDeleteService.initProgressBar($(this))
+                            $(this).find('.modal-body .multi-delete-results').html('')
+                            $(this).find('button.start-btn-delete-all').removeAttr('disabled')
+                        })
+                        $(this).on('hidden.bs.modal', function() {
+                            multiDeleteService.modalClosing($(this))
+                        })
+                    })
+                }
+            }).catch(this.manageError)
+        }
+    },
+    template: `
+    <div>
+        <slot name="header" v-bind="{displayedEntries,BazarTable:this}"/>
+        <table ref="dataTable" class="table prevent-auto-init table-condensed display">
+            <tfoot v-if="sanitizedParam(params,isadmin,'sumfieldsids').length > 0 || sanitizedParam(params,isadmin,'displayadmincol')">
+                <tr></tr>
+            </tfoot>
+        </table>
+        <div ref="buttondeleteall">
+            <slot v-if="ready && sanitizedParam(params,isadmin,'displayadmincol')" name="deleteallselectedbutton" v-bind="{uuid:getUuid(),BazarTable:this}"/>
+        </div>
+        <slot name="spinnerloader" v-bind="{displayedEntries,BazarTable:this}"/>
+        <slot name="footer" v-bind="{displayedEntries,BazarTable:this}"/>
+    </div>
+  `
+};
+
+if (isVueJS3){
+    if (window.hasOwnProperty('bazarVueApp')){ // bazarVueApp must be defined into bazar-list-dynamic
+        if (!bazarVueApp.config.globalProperties.hasOwnProperty('wiki')){
+            bazarVueApp.config.globalProperties.wiki = wiki;
+        }
+        if (!bazarVueApp.config.globalProperties.hasOwnProperty('_t')){
+            bazarVueApp.config.globalProperties._t = _t;
+        }
+        window.bazarVueApp.component(componentName,componentParams);
+    }
+} else {
+    if (!Vue.prototype.hasOwnProperty('wiki')){
+        Vue.prototype.wiki = wiki;
+    }
+    if (!Vue.prototype.hasOwnProperty('_t')){
+        Vue.prototype._t = _t;
+    }
+    Vue.component(componentName,componentParams);
+}

--- a/tools/bazar/presentation/javascripts/components/BazarTable.js
+++ b/tools/bazar/presentation/javascripts/components/BazarTable.js
@@ -267,6 +267,9 @@ let componentParams = {
                 // create dataTable
                 const columns = await this.getColumns()
                 const sumfieldsids = await this.sanitizedParamAsync('sumfieldsids')
+                const champField = await this.sanitizedParamAsync('champ')
+                const ordreField = await this.sanitizedParamAsync('ordre')
+                let order = (ordreField === 'desc') ? 'desc'  :'asc'
                 let firstColumnOrderable = 0
                 for (let index = 0; index < columns.length; index++) {
                     if ('orderable' in columns[index]  && !columns[index].orderable){
@@ -275,12 +278,20 @@ let componentParams = {
                         break
                     }
                 }
+                let columnToOrder = firstColumnOrderable
+                if (typeof champField === 'string' && champField.length > 0){
+                    for (let index = 0; index < columns.length; index++) {
+                        if ((!('orderable' in columns[index]) || columns[index].orderable) && columns[index].data == champField){
+                            columnToOrder = index
+                        }
+                    }
+                }
                 this.dataTable = $(this.$refs.dataTable).DataTable({
                     ...this.getDatatableOptions(),
                     ...{
                         columns: columns,
                         "scrollX": true,
-                        order: [[firstColumnOrderable,'asc']]
+                        order: [[columnToOrder,order]]
                     }
                 })
                 $(this.dataTable.table().node()).prop('id',this.getUuid())

--- a/tools/bazar/presentation/javascripts/components/BazarTableEntrySelector.js
+++ b/tools/bazar/presentation/javascripts/components/BazarTableEntrySelector.js
@@ -1,0 +1,27 @@
+Vue.component('BazarTableEntrySelector', {
+    props: ['params', 'entries'],
+    data() {
+      return {}
+    },
+    computed: {
+        entriesToDisplay(){
+            return (this.params !== null && typeof this.params === 'object' && 'tablewith' in this.params && this.params.tablewith === 'no-geolocation') 
+                ? this.entries.filter((e)=>typeof e === 'object' && e !== null && (
+                    !('bf_latitude' in e) ||
+                    !('bf_longitude' in e) ||
+                    e.bf_latitude === null ||
+                    e.bf_longitude === null ||
+                    String(e.bf_longitude).length === 0 ||
+                    String(e.bf_latitude).length === 0 ||
+                    Number(e.bf_longitude) === 0 ||
+                    Number(e.bf_latitude) === 0 
+                ))
+                : this.entries
+        }
+    },
+    template: `
+      <div>
+        <slot name="bazarlist" v-bind="{entriesToDisplay:entriesToDisplay}"/>
+      </div>
+    `
+})

--- a/tools/bazar/templates/entries/index-dynamic-templates/map-and-table.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/map-and-table.twig
@@ -1,0 +1,20 @@
+{% set necessary_fields = (necessary_fields is defined ? necessary_fields : [])
+  |merge(['bf_latitude', 'bf_longitude'])
+  %}
+
+{% extends "@bazar/entries/index-dynamic-templates/table.twig" %}
+
+{% block assets %}
+  {{ block('assets','@bazar/entries/index-dynamic-templates/map.twig') }}
+  {{ parent() }} {# from table.twig #}
+  {{ include_javascript('tools/bazar/presentation/javascripts/components/BazarTableEntrySelector.js', false, true) }}
+{% endblock %}
+
+{% block display_entries %}
+  {{ block("display_entries",'@bazar/entries/index-dynamic-templates/map.twig') }}
+  <Bazar-Table-Entry-Selector :entries="entriesToDisplay" :params="params">
+    <template #bazarlist="{entriesToDisplay}">
+      {{ parent() }} {# from table.twig #}
+    </template>
+  <Bazar-Table-Entry-Selector/>
+{% endblock %}

--- a/tools/bazar/templates/entries/index-dynamic-templates/table.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/table.twig
@@ -32,7 +32,7 @@
   <Bazar-Table :currentusername="{{ currentUserName|json_encode }}" :params="params" :entries="entriesToDisplay" :ready="ready" :root="$root" isadmin="{{ hasAcl("@admins")|json_encode }}">
     <template #header="{displayedEntries,BazarTable}"></template>
     <template #spinnerloader="{displayedEntries,BazarTable}">
-      <spinner-loader v-if="isLoading || !ready" class="overlay super-overlay" :height="500"></spinner-loader>
+      <spinner-loader v-if="!BazarTable.fastSearch && (isLoading || !ready)" class="overlay super-overlay" :height="500"></spinner-loader>
     </template>
     <template #footer="{displayedEntries,BazarTable}"></template>
     <template #deletecheckbox="{targetId,itemId,disabled}">

--- a/tools/bazar/templates/entries/index-dynamic-templates/table.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/table.twig
@@ -1,0 +1,140 @@
+{% import "@core/multidelete-macro.twig" as multidelete %}
+
+{% extends "@bazar/entries/index-dynamic.twig" %}
+
+{% set necessary_fields = (necessary_fields is defined ? necessary_fields : (params.necessary_fields is defined ? params.necessary_fields|split(',') : []))
+  |merge(['owner'])
+  |merge((
+    (params.exportallcolumns is defined and (params.exportallcolumns == '1' or params.exportallcolumns == 'true'))
+    ? params.exportallcolumnsids|split(',')
+    : (params.columnfieldsids is defined
+      ? params.columnfieldsids|split(',')
+      : []
+    )
+  ))
+  |merge((params.displaycreationdate is defined and (params.displaycreationdate != 'no'))? ['date_creation_fiche']: [])
+  |merge((params.displaylastchangedate is defined and (params.displaycreationdate != 'no'))? ['date_maj_fiche']: [])
+  %}
+
+{% block assets %}
+  {{ include_css('styles/vendor/datatables-full/dataTables.bootstrap.min.css') }}
+  {{ include_css('tools/bazar/presentation/styles/tableau.css') }}
+
+  {{ include_javascript('javascripts/vendor/datatables-full/jquery.dataTables.min.js') }} 
+  {{ include_javascript('tools/bazar/presentation/javascripts/components/BazarTable.js', false, true) }}
+   
+{% endblock %}
+
+{% block display_entries %}
+  {% set imWidth = 150 %}
+  {% set imHeight = 100 %}
+  {% set firstTokenCrop = csrfToken("GET api/images/cache/#{imWidth}/#{imHeight}/crop") %}
+  <Bazar-Table :currentusername="{{ currentUserName|json_encode }}" :params="params" :entries="entriesToDisplay" :ready="ready" :root="$root" isadmin="{{ hasAcl("@admins")|json_encode }}">
+    <template #header="{displayedEntries,BazarTable}"></template>
+    <template #spinnerloader="{displayedEntries,BazarTable}">
+      <spinner-loader v-if="isLoading || !ready" class="overlay super-overlay" :height="500"></spinner-loader>
+    </template>
+    <template #footer="{displayedEntries,BazarTable}"></template>
+    <template #deletecheckbox="{targetId,itemId,disabled}">
+      <td>
+        {% set id = "`selectline_${targetId}_${itemId}`" %}
+        <label :for="{{id}}">
+          <input
+            :disabled="disabled" 
+            :class="disabled ? null : {selectline:true}" 
+            :data-itemid="disabled ? null : itemId"
+            type="checkbox"
+            :id="{{id}}" 
+            :name="{{id}}" 
+            data-csrftoken="to-be-defined"
+            value="">
+          <span></span>
+        </label>
+      </td>
+    </template>
+    <template #deletecheckboxall>
+      {{ multidelete.insertSelectAll('targetId','selectAllType') }}
+    </template>
+    <template #deleteallselectedbutton="{BazarTable,uuid}">
+      {# generate template reative for vuejs #}
+      {{ multidelete.insertButton('targetId','pages')|replace({
+        "onclick=\"multiDeleteService.updateNbSelected('MultiDeleteModaltargetId')\"": '@click="BazarTable.deleteAllSelected"',
+        'href="#MultiDeleteModaltargetId"': ':href="`#MultiDeleteModal${uuid}`"',
+        'MultiDeleteModaltargetIdLabel': '`MultiDeleteModal${uuid}Label`',
+        'MultiDeleteModaltargetId': '`MultiDeleteModal${uuid}`',
+        'targetId': 'uuid',
+        'id="': ':id="',
+        'aria-labelledby="': ':aria-labelledby="',
+        'data-target="': ':data-target="',
+        'start-btn-delete-all"': 'start-btn-delete-all" @click.prevent.stop="BazarTable.startDelete"'
+      })|raw }}
+    </template>
+    <template #adminsbuttons="{entryId,entryTitle,entryUrl,isExternal,candelete}">
+      <a :href="isExternal ? `${entryUrl}/editiframe` : `{{ url({tag:'${entryId}',handler:'editiframe'}) }}`"
+        data-toggle="tooltip"
+        data-placement="left"
+        class="btn btn-default btn-icon btn-xs modalbox"
+        data-size="modal-lg"
+        data-iframe="1"
+        :title="`{{ _t('MODIFY') }} ${entryId}`"
+        onclick="$(this).tooltip('hide');$(this).attr('title',$(this).data('original-title'));"
+        >
+        <i class="fas fa-pencil-alt"></i>
+      </a>
+      <a v-if="candelete"
+        :href="`{{ url({tag:'${entryId}',handler:'deletepage',params:{incomingurl:url({handler:''})}}) }}`"
+        data-toggle="tooltip"
+        data-placement="left"
+        class="btn btn-danger btn-icon btn-xs modalbox"
+        :title="`{{ _t('DELETE') }} ${entryId}`"
+        onclick="$(this).tooltip('hide');$(this).attr('title',$(this).data('original-title'));"
+        >
+        <i class="fas fa-trash"></i>
+      </a>
+      <button
+        v-else-if="!isExternal"
+        disabled="disabled"
+        data-toggle="tooltip"
+        data-placement="left"
+        class="btn btn-danger btn-icon btn-xs"
+        title="{{ _t('DELETEPAGE_NOT_OWNER') }}"
+        >
+        <i class="fas fa-trash"></i>
+      </button>
+    </template>
+    <template #creationdatetranslate>{{ _t('BAZ_DATE_CREATION') }}</template>
+    <template #latitudetext>{{ _t('BAZ_LATITUDE') }}</template>
+    <template #longitudetext>{{ _t('BAZ_LONGITUDE') }}</template>
+    <template #modifiydatetranslate>{{ _t('BAZ_DATE_MAJ') }}</template>
+    <template #ownertranslate>{{ _t('TEMPLATE_OWNER') }}</template>
+    <template #sumtranslate>{{ _t('SUM') }}</template>
+    <template #rendercell="{anchorData,fieldtype,fieldName,addLink,entryId,url,color='',icon=''}">
+      {# be careful, here a twig template create a VueJs template that is used to create a Datatable template #}
+      <template v-if="color.length > 0">
+        <span class="pellet" :style="{backgroundColor:`${color}`}"></span>
+      </template>
+      <template v-if="icon.length > 0">
+        <i :class="{[icon]:true}"></i>
+      </template>
+      {#- supported fieldtype empty,link,email,image -#}
+      <template v-if="addLink">
+        <a :href="`${url}/iframe`" v-html="anchorData" class="modalbox" data-size="modal-lg" data-iframe="1" :title="anchorData"></a>
+      </template>
+      <template v-else-if="fieldtype === 'link'">
+        <a :href="anchorData" v-html="anchorData" class="modalbox" data-size="modal-lg" data-iframe="1"></a>
+      </template>
+      <template v-else-if="fieldtype === 'email' && anchorData.length > 0">
+        <a :href="`mailto:${anchorData}`" v-html="anchorData"></a>
+      </template>
+      <template v-else-if="fieldtype === 'image' && anchorData.length > 0">
+        <img
+          loading="lazy"
+          :src="urlImage({id_fiche:entryId,url:wiki.url(entryId),[fieldName]:anchorData},fieldName,{{ imWidth }},{{ imHeight }},'crop')"
+          :onError="`urlImageResizedOnError({id_fiche:'${entryId}',url:'${wiki.url(entryId)}',['${fieldName}']:'${anchorData}'},'${fieldName}',{{ imWidth }},{{ imHeight }},'crop','{{ firstTokenCrop|e('html') }}')`"/>
+      </template>
+      <template v-else>
+        {{-'{{anchorData}}'-}}
+      </template>
+    </template>
+  </Bazar-Table>
+{% endblock %}

--- a/tools/bazar/templates/entries/index-dynamic-templates/table.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/table.twig
@@ -135,6 +135,12 @@
           :src="urlImage({id_fiche:entryId,url:wiki.url(entryId),[fieldName]:anchorData},fieldName,{{ imWidth }},{{ imHeight }},'crop')"
           :onError="`urlImageResizedOnError({id_fiche:'${entryId}',url:'${wiki.url(entryId)}',['${fieldName}']:'${anchorData}'},'${fieldName}',{{ imWidth }},{{ imHeight }},'crop','{{ firstTokenCrop|e('html') }}')`"/>
       </template>
+      <template v-else-if="fieldtype === 'urlmodal' && anchorData.length > 0">
+        <a :href="url" v-html="anchorData" :title="anchorData" class="modalbox" data-size="modal-lg" data-iframe="1"></a>
+      </template>
+      <template v-else-if="fieldtype === 'urlnewwindow' && anchorData.length > 0">
+        <a :href="url" v-html="anchorData" :title="anchorData" target="blank"></a>
+      </template>
       <template v-else>
         {{-'{{anchorData}}'-}}
       </template>

--- a/tools/bazar/templates/entries/index-dynamic-templates/table.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/table.twig
@@ -129,6 +129,8 @@
       <template v-else-if="fieldtype === 'image' && anchorData.length > 0">
         <img
           loading="lazy"
+          height="{{ imHeight }}"
+          width="{{ imWidth }}"
           :src="urlImage({id_fiche:entryId,url:wiki.url(entryId),[fieldName]:anchorData},fieldName,{{ imWidth }},{{ imHeight }},'crop')"
           :onError="`urlImageResizedOnError({id_fiche:'${entryId}',url:'${wiki.url(entryId)}',['${fieldName}']:'${anchorData}'},'${fieldName}',{{ imWidth }},{{ imHeight }},'crop','{{ firstTokenCrop|e('html') }}')`"/>
       </template>

--- a/tools/bazar/templates/entries/index-dynamic-templates/table.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/table.twig
@@ -103,6 +103,7 @@
       </button>
     </template>
     <template #creationdatetranslate>{{ _t('BAZ_DATE_CREATION') }}</template>
+    <template #formidtranslate>{{ _t('BAZ_ID') }}</template>
     <template #latitudetext>{{ _t('BAZ_LATITUDE') }}</template>
     <template #longitudetext>{{ _t('BAZ_LONGITUDE') }}</template>
     <template #modifiydatetranslate>{{ _t('BAZ_DATE_MAJ') }}</template>


### PR DESCRIPTION
J'ai récemment proposé l'extension [`tabdyn`](https://github.com/YesWiki/yeswiki-extension-tabdyn) qui permet de profiter du tableau dynamique et de pouvoir avoir un affichage carte + tableau dynamique avec `doryphore 4.3.1`

La présente PR permet de proposer d'intégrer ces fonctionnalités au sein de `doryphore 4.4`. Je te laisse @mrflos voir si c'est pertinent de l'intégrer ou plutôt de rester dans une extension dédiée.

**Ce que ça fait**:
 - créer un template dynamique `table`
 - créer un template dynamique `map-and-table`
 - créer les composants `javascripts` associés
 - créer la description pour le bouton `composants` avec les fichiers de langues associés
 - ajouter ce qu'il faut dans `BazarListeAction` `BazarCartoAction` pour paramétrer les `arguments` comme il faut
 - création d'un action `BazarTableAction` similaire à `BazarCartoAction` pour paramétrer les `arguments` comme il faut

_Les templates dynamiques utilisent `<template>` pour permettre une personnalisation plus facile sans avoir à modifier le `javascript`_

**Comment tester**
 - ajouter un template `tableau` en cochant la case `dynamique`
 - ou ajout et template `carte et tableau`