### PR TITLE
hide modal header for bazar list

### DIFF
--- a/javascripts/yeswiki-base.js
+++ b/javascripts/yeswiki-base.js
@@ -104,24 +104,20 @@ function toastMessage(
     }
 
     let $modal = $('#YesWikiModal')
-    const yesWikiModalHtml = `<div class="modal-dialog${
-      size
-    }">`
-      + '<div class="modal-content">'
-      + '<div class="modal-header">'
-      + `<button type="button" class="close" data-dismiss="modal">&times;</button>${
-        text
-      }</div>`
-      + '<div class="modal-body">'
-      + '</div>'
-      + '</div>'
-      + '</div>'
+    const yesWikiModalHtml = `
+      <div class="modal-dialog${size} ${$this.data('header') === false ? 'no-header' : ''}">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">&times;</button>
+            ${text}
+          </div>
+          <div class="modal-body"></div>
+          <button type="button" class="no-header-btn-close" data-dismiss="modal">&times;</button>
+        </div>
+      </div>`
+
     if ($modal.length == 0) {
-      $('body').append(
-        `<div class="modal fade" id="YesWikiModal">${
-          yesWikiModalHtml
-        }</div>`
-      )
+      $('body').append(`<div class="modal fade" id="YesWikiModal">${yesWikiModalHtml}</div>`)
       $modal = $('#YesWikiModal')
     } else {
       $modal.html(yesWikiModalHtml)

--- a/styles/yeswiki-base.css
+++ b/styles/yeswiki-base.css
@@ -249,6 +249,36 @@ li.toc5 {
   height: 70vh;
   border: 0;
 }
+#YesWikiModal .modal-dialog .no-header-btn-close {
+  display: none;
+}
+#YesWikiModal .modal-dialog.no-header .no-header-btn-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: -1rem;
+  right: -1rem;
+  background-color: #4e5056;
+  background-color: var(--neutral-color);
+  color: white;
+  border-radius: 50%;
+  width: 3rem;
+  height: 3rem;
+  font-size: 2rem;
+  font-weight: bold;
+  border: none;
+  cursor: pointer;
+}
+#YesWikiModal .modal-dialog.no-header .modal-header {
+  visibility: hidden;
+  height: 1rem;
+  max-height: 1rem;
+  overflow: hidden;
+  padding: 0;
+}
+
+
 /* remove first column of revisions */
 #YesWikiModal .first-revisions-selector,
 #YesWikiModal .current-page-revision,

--- a/styles/yeswiki-base.css
+++ b/styles/yeswiki-base.css
@@ -263,8 +263,8 @@ li.toc5 {
   background-color: var(--neutral-color);
   color: white;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
+  width: 2.5rem;
+  height: 2.5rem;
   font-size: 2rem;
   font-weight: bold;
   border: none;

--- a/tools/bazar/presentation/javascripts/components/BazarMap.js
+++ b/tools/bazar/presentation/javascripts/components/BazarMap.js
@@ -113,7 +113,7 @@ Vue.component('BazarMap', {
         const isLink = (this.isModalDisplay() || this.isDirectLinkDisplay() || this.isNewTabDisplay())
         const tagName = isLink ? 'a' : 'div'
         const url = entry.url + (this.isModalDisplay() ? '/iframe' : '')
-        const modalData = this.isModalDisplay() ? 'data-size="modal-lg" data-iframe="1"' : ''
+        const modalData = this.isModalDisplay() ? 'data-size="modal-lg" data-iframe="1" data-header="false"' : ''
         entry.marker.setIcon(
           L.divIcon({
             className: `bazar-marker ${this.params.smallmarker}`,
@@ -126,8 +126,8 @@ Vue.component('BazarMap', {
                   ${entry.markerhover || entry.bf_titre}
                 </span>
               </div>
-              <${tagName} class="bazar-entry${this.isModalDisplay() ? ' modalbox' : ''}" `
-              + `${isLink ? `href="${url}" title="${entry.bf_titre}"` : ''} style="color: ${entry.color}" ${modalData}>
+              <${tagName} class="bazar-entry ${this.isModalDisplay() ? 'modalbox' : ''}" `
+              + `${isLink ? `href="${url}"` : ''} style="color: ${entry.color}" ${modalData}>
                 <i class="${entry.icon || 'fa fa-bullseye'}"></i>
               </${tagName}>`
           })

--- a/tools/bazar/templates/entries/index-dynamic-templates/card.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/card.twig
@@ -25,12 +25,11 @@
     </div>
 
     {% if isLink %}<a{% else %}<div{% endif %} v-for="entry in entriesToDisplay" :key="entry.id_fiche" 
-        class="bazar-entry bazar-card{{ isModal ? ' modalbox' : ''}}" 
+        class="bazar-entry bazar-card{{ isModal ? ' modalbox' : ''}}"
         {% if not isLink %}@click="openEntry(entry)"{% endif %} 
         :class="{'with-image': Object.keys(entry).includes('visual')}"
         {% if isModal %}
-          data-size="modal-lg"
-          :data-iframe="1" :href="`${entry.url}/iframe`"
+          data-size="modal-lg" data-header="false" data-iframe="1"
         {% endif %}
         {% if isLink %}
           :href="`${entry.url + (({{ isModal ? 'true' : 'false' }} || $root.isInIframe()) ? '/iframe' : '')}`"

--- a/tools/bazar/templates/entries/index-dynamic-templates/table.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/table.twig
@@ -118,10 +118,10 @@
       </template>
       {#- supported fieldtype empty,link,email,image -#}
       <template v-if="addLink">
-        <a :href="`${url}/iframe`" v-html="anchorData" class="modalbox" data-size="modal-lg" data-iframe="1" :title="anchorData"></a>
+        <a :href="`${url}/iframe`" v-html="anchorData" class="modalbox" data-header="false" data-size="modal-lg" data-iframe="1" :title="anchorData"></a>
       </template>
       <template v-else-if="fieldtype === 'link'">
-        <a :href="anchorData" v-html="anchorData" class="modalbox" data-size="modal-lg" data-iframe="1"></a>
+        <a :href="anchorData" v-html="anchorData" class="modalbox" data-header="false" data-size="modal-lg" data-iframe="1"></a>
       </template>
       <template v-else-if="fieldtype === 'email' && anchorData.length > 0">
         <a :href="`mailto:${anchorData}`" v-html="anchorData"></a>
@@ -135,7 +135,7 @@
           :onError="`urlImageResizedOnError({id_fiche:'${entryId}',url:'${wiki.url(entryId)}',['${fieldName}']:'${anchorData}'},'${fieldName}',{{ imWidth }},{{ imHeight }},'crop','{{ firstTokenCrop|e('html') }}')`"/>
       </template>
       <template v-else-if="fieldtype === 'urlmodal' && anchorData.length > 0">
-        <a :href="url" v-html="anchorData" :title="anchorData" class="modalbox" data-size="modal-lg" data-iframe="1"></a>
+        <a :href="url" v-html="anchorData" :title="anchorData" class="modalbox" data-header="false" data-size="modal-lg" data-iframe="1"></a>
       </template>
       <template v-else-if="fieldtype === 'urlnewwindow' && anchorData.length > 0">
         <a :href="url" v-html="anchorData" :title="anchorData" target="blank"></a>

--- a/tools/bazar/templates/fields/checkboxentry.twig
+++ b/tools/bazar/templates/fields/checkboxentry.twig
@@ -1,10 +1,11 @@
 {% extends "@bazar/fields/checkbox.twig" %}
 
 {% block value_item -%}
-	<a href="{{ value.href|e ~ (field.isDistantJson ? '/iframe') }}"
+	<a href="{{ value.href|e ~ '/iframe' }}"
 			{{ not isInIframe ? 'class="modalbox" data-size="modal-lg"' : '' }}
 			{{ field.isDistantJson and not isInIframe ? 'data-iframe="1"' }}
-			title="{{ _t('BAZ_SEE_ENTRY') }} {{ value.value|striptags }}">
+			data-header="false" data-iframe="1"
+		 	title="{{ _t('BAZ_SEE_ENTRY') }} {{ value.value|striptags }}">
 	{{- value.value|raw -}}
 	</a>
 {%- endblock %}

--- a/tools/bazar/templates/fields/select_entry.twig
+++ b/tools/bazar/templates/fields/select_entry.twig
@@ -2,9 +2,10 @@
 
 {% block value_container %}
 	<span class="BAZ_texte">
-		<a href="{{ entryUrl|e ~ (field.isDistantJson ? '/iframe') }}"
+		<a href="{{ entryUrl|e ~ '/iframe' }}"
 			{{ not isInIframe ? 'class="modalbox" data-size="modal-lg"' : '' }}
 			{{ field.isDistantJson and not isInIframe ? 'data-iframe="1"' }}
+			data-header="false" data-iframe="1"
 			title="{{ _t('BAZ_SEE_ENTRY') }} {{ label|striptags }}">
 				{{- label|raw -}}
 		</a>


### PR DESCRIPTION
refs #1087 

J'ai ajouté un paramètre aux liens de type `modalbox` pour masquer le header. Dans ce cas là le boutton pour fermer se met en absolute dans le coin en haut à droite

![image](https://github.com/YesWiki/yeswiki/assets/17404254/0d186bbf-20cf-4bfb-bc72-fdd18953c302)


