### PR TITLE
Fix/entrycontroller delete

### DIFF
--- a/actions/EraseSpamedCommentsAction.php
+++ b/actions/EraseSpamedCommentsAction.php
@@ -21,6 +21,8 @@
  *
 */
 use YesWiki\Bazar\Controller\EntryController;
+use YesWiki\Bazar\Service\EntryManager;
+use YesWiki\Core\Service\PageManager;
 use YesWiki\Core\YesWikiAction;
 
 class EraseSpamedCommentsAction extends YesWikiAction
@@ -84,10 +86,14 @@ class EraseSpamedCommentsAction extends YesWikiAction
                     // (si DeleteOrphanedPage ne convient pas, soit on créé
                     // une autre, soit on la modifie
                     echo "Effacement de : " . $page . "<br />\n";
-                    $wiki->services->get(EntryController::class)->triggerDeletedEventIfNeeded(function()use($page,$wiki){
-                        $wiki->DeleteOrphanedPage($page);
-                    },$page);
-                    $deletedPages .= $page . ", ";
+                    if ($wiki->services->get(EntryManager::class)->isEntry($page)){
+                        if($wiki->services->get(EntryController::class)->delete($page)){
+                            $deletedPages .= $page . ", ";
+                        }
+                    } else {
+                        $wiki->services->get(PageManager::class)->deleteOrphaned($page);
+                        $deletedPages .= $page . ", ";
+                    }
                 }
                 $deletedPages = trim($deletedPages, ", ");
                 echo "<p><a href=\"".$wiki->Href()."\">"._t('FORM_RETURN').".</a></p>";

--- a/includes/services/PageManager.php
+++ b/includes/services/PageManager.php
@@ -275,6 +275,9 @@ class PageManager
             throw new \Exception(_t('WIKI_IN_HIBERNATION'));
         }
         unset($this->ownersCache[$tag]);
+        if (in_array($tag,$this->pageCache)){
+            unset($this->pageCache[$tag]);
+        }
         $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('pages')} WHERE tag='{$this->dbService->escape($tag)}' OR comment_on='{$this->dbService->escape($tag)}'");
         $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('links')} WHERE from_tag='{$this->dbService->escape($tag)}' ");
         $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('acls')} WHERE page_tag='{$this->dbService->escape($tag)}' ");

--- a/tools/bazar/actions/BazarAction.php
+++ b/tools/bazar/actions/BazarAction.php
@@ -122,7 +122,7 @@ class BazarAction extends YesWikiAction
                     case self::ACTION_ENTRY_EDIT:
                         return $entryController->update($_REQUEST['id_fiche']);
                     case self::ACTION_ENTRY_DELETE:
-                        return $entryController->delete($_REQUEST['id_fiche']);
+                        return $entryController->delete($_REQUEST['id_fiche'],true);
                     case self::ACTION_PUBLIER:
                         return $entryController->publish($_REQUEST['id_fiche'], true);
                     case self::ACTION_PAS_PUBLIER:

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -378,17 +378,6 @@ class EntryController extends YesWikiController
         }
     }
 
-    public function triggerDeletedEventIfNeeded($callback,$entryId)
-    {
-        if ($this->entryManager->isEntry($entryId)){
-            $entry = $this->entryManager->getOne($entryId);
-            $callback();
-            $this->triggerDeletedEvent($entryId,$entry);
-        } else {
-            $callback();
-        }
-    }
-
     protected function triggerDeletedEvent($entryId, $entry)
     {
         return $this->eventDispatcher->yesWikiDispatch('entry.deleted', [

--- a/tools/bazar/controllers/EntryController.php
+++ b/tools/bazar/controllers/EntryController.php
@@ -354,8 +354,8 @@ class EntryController extends YesWikiController
         $this->triggerDeletedEventIfNeeded(function()use($entryId){
             $this->entryManager->delete($entryId);
         },$entryId);
-        // WARNING : 'delete_ok' is not used
-        header('Location: ' . $this->wiki->Href('', 'BazaR', ['vue' => 'consulter', 'message' => 'delete_ok']));
+        flash(_t('BAZ_FICHE_SUPPRIMEE')." ($entryId)" , 'success');
+        $this->wiki->Redirect($this->wiki->Href('', 'BazaR', ['vue' => 'consulter'],false));
     }
 
     public function triggerDeletedEventIfNeeded($callback,$entryId)

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -732,7 +732,7 @@ class EntryManager
         if ($this->securityController->isWikiHibernated()) {
             throw new Exception(_t('WIKI_IN_HIBERNATION'));
         }
-        if (!$this->wiki->UserIsOwner($tag) || !$this->wiki->UserIsAdmin()){
+        if (!$this->wiki->UserIsAdmin() && !$this->wiki->UserIsOwner($tag)){
             throw new Exception(_t('DELETEPAGE_NOT_DELETED')._t('DELETEPAGE_NOT_OWNER'));
         }
 

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -738,12 +738,6 @@ class EntryManager
 
         $fiche = $this->getOne($tag);
 
-        // Si besoin, on supprime l'utilisateur associé
-        if (isset($fiche['nomwiki'])) {
-            $request = 'DELETE FROM ' . $this->dbService->prefixTable('users') . ' WHERE `name` = "' . $fiche['nomwiki'] . '"';
-            $this->dbService->query($request);
-        }
-
         $this->pageManager->deleteOrphaned($tag);
         $this->tripleStore->delete($tag, TripleStore::TYPE_URI, null, '', '');
         $this->tripleStore->delete($tag, TripleStore::SOURCE_URL_URI, null, '', '');

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -730,13 +730,16 @@ class EntryManager
     public function delete($tag)
     {
         if ($this->securityController->isWikiHibernated()) {
-            throw new \Exception(_t('WIKI_IN_HIBERNATION'));
+            throw new Exception(_t('WIKI_IN_HIBERNATION'));
         }
         if (!$this->wiki->UserIsOwner($tag) || !$this->wiki->UserIsAdmin()){
             throw new Exception(_t('DELETEPAGE_NOT_DELETED')._t('DELETEPAGE_NOT_OWNER'));
         }
 
         $fiche = $this->getOne($tag);
+        if (empty($fiche)){
+            throw new Exception("Not existing entry : $tag");
+        }
 
         $this->pageManager->deleteOrphaned($tag);
         $this->tripleStore->delete($tag, TripleStore::TYPE_URI, null, '', '');

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -732,8 +732,8 @@ class EntryManager
         if ($this->securityController->isWikiHibernated()) {
             throw new \Exception(_t('WIKI_IN_HIBERNATION'));
         }
-        if (!$this->aclService->hasAccess('write', $tag)) {
-            throw new Exception(_t('BAZ_ERROR_DELETE_UNAUTHORIZED'));
+        if (!$this->wiki->UserIsOwner($tag) || !$this->wiki->UserIsAdmin()){
+            throw new Exception(_t('DELETEPAGE_NOT_DELETED')._t('DELETEPAGE_NOT_OWNER'));
         }
 
         $fiche = $this->getOne($tag);

--- a/tools/security/actions/despam.php
+++ b/tools/security/actions/despam.php
@@ -1,6 +1,8 @@
 <?php
 
 use YesWiki\Bazar\Controller\EntryController;
+use YesWiki\Bazar\Service\EntryManager;
+use YesWiki\Core\Service\PageManager;
 use YesWiki\Security\Controller\SecurityController;
 
 // TODO
@@ -147,10 +149,14 @@ if ($this->UserIsAdmin()) {
                 // Effacement de la page en utilisant la méthode adéquate
                 // (si DeleteOrphanedPage ne convient pas, soit on créé
                 // une autre, soit on la modifie
-                $this->services->get(EntryController::class)->triggerDeletedEventIfNeeded(function()use($page){
-                    $this->DeleteOrphanedPage($page);
-                },$page);
-                $deletedPages .= $page . ", ";
+                if ($this->services->get(EntryManager::class)->isEntry($page)){
+                  if($this->services->get(EntryController::class)->delete($page)){
+                      $deletedPages .= $page . ", ";
+                  }
+                } else {
+                    $this->services->get(PageManager::class)->deleteOrphaned($page);
+                    $deletedPages .= $page . ", ";
+                }
             }
             $deletedPages = trim($deletedPages, ", ");
         }

--- a/tools/tags/handlers/page/ajaxdeletepage.php
+++ b/tools/tags/handlers/page/ajaxdeletepage.php
@@ -1,6 +1,8 @@
 <?php
 
 use YesWiki\Bazar\Controller\EntryController;
+use YesWiki\Bazar\Service\EntryManager;
+use YesWiki\Core\Service\PageManager;
 use YesWiki\Tags\Service\TagsManager;
 
 if (!defined("WIKINI_VERSION")) {
@@ -8,7 +10,6 @@ if (!defined("WIKINI_VERSION")) {
 }
 
 $tagsManager = $this->services->get(TagsManager::class);
-$entryController = $this->services->get(EntryController::class);
 
 // on ne fait quelque chose uniquement dans le cas d'une requete jsonp
 if (isset($_GET['jsonp_callback'])) {
@@ -16,10 +17,13 @@ if (isset($_GET['jsonp_callback'])) {
     header('Content-type:application/json');
     if ($this->UserIsOwner() || $this->UserIsAdmin()) {
         $tag = $this->GetPageTag();
-        $entryController->triggerDeletedEventIfNeeded(function()use($tag){
-            $this->DeleteOrphanedPage($tag);
-        },$tag);
-        $this->LogAdministrativeAction($this->GetUserName(), "Suppression de la page ->\"\"" . $tag . "\"\"");
+        
+        if ($this->services->get(EntryManager::class)->isEntry($page)){
+            $this->services->get(EntryController::class)->delete($page);
+        } else {
+            $this->services->get(PageManager::class)->deleteOrphaned($page);
+            $this->LogAdministrativeAction($this->GetUserName(), "Suppression de la page ->\"\"" . $tag . "\"\"");
+        }
         echo $_GET['jsonp_callback']."(".json_encode(array("reponse"=>mb_convert_encoding("succes", 'UTF-8', 'ISO-8859-1'))).")";
     } else {
         echo $_GET['jsonp_callback']."(".json_encode(array("reponse"=>mb_convert_encoding("interdit", 'UTF-8', 'ISO-8859-1'))).")";


### PR DESCRIPTION
Je crée cette PR pour permettre d'assurer le suivi des discussions sur les commits en question mais je les fusionne directement car ils assurent des correctifs concernant les acl lors de la suppression d'une fiche.
J'espère @mrflos que ça te va.

**Le souci**:
 - j'ai découvert que lors de la suppression d'une fiche, nous n'utilisions pas `EntryManager::delete` mais uniquement `PageManager::deleteOrpheanPage`
 - `EntryManager::delete` ne semblait utilisée que dans le cas de `?BazaR&vue=saisir&action=supprimer&id_fiche=MYID`
 - `EntryManager::delete` semble ne pas utiliser les bonnes acls pour la suppression et aurait tendance à supprimer des usagers

**Ce que ça fait**:
 - passage des acl à "propriétaire ou admin" pour pouvoir supprimer une fiche dans `EntryManager::delete`
 - `EntryManager::delete` : ne pas supprimer un utilisateur lors de la suppression d'une fiche (pour correspondre au comportement actuel de YesWiki)
 - `EntryController::delete` refactor pour rendre la fonction plus facile à lire et réutilisable dans le code
 - suppression de `EntryController::triggerDeletedEventIfNeeded` pour la remplacer par `EntryController::delete` car la première fonction n'était pas très compréhensible (j'en suis l'auteur)
 - petit correctif de `PageManager` pour mettre à jour son cache lors de la suppression d'une fiche
 - et aussi modification de `LogAdministrativeAction` pour ne garder que les 10 dernières versions de la page du jour (vu qu'elle est rempli par un append, ça n'a pas de sens de surcharger la base de données avec les révisions plus anciennes)
