### PR TITLE
Add field in FormBuilder to specify file extension

### DIFF
--- a/tools/bazar/fields/FileField.php
+++ b/tools/bazar/fields/FileField.php
@@ -16,7 +16,10 @@ class FileField extends BazarField
 {
     protected $readLabel;
     protected const FIELD_READ_LABEL = 6;
+    protected const FIELD_AUTHORIZED_EXTS_LABEL = 7;
+
     protected $attach;
+    protected $authorizedExts;
 
     public function __construct(array $values, ContainerInterface $services)
     {
@@ -25,6 +28,14 @@ class FileField extends BazarField
         $this->propertyName = $this->type . $this->name;
         $this->readLabel = empty(trim($values[self::FIELD_READ_LABEL])) ? _t('BAZ_FILEFIELD_FILE') : $values[self::FIELD_READ_LABEL];
         $this->attach = null;
+        $exts = $values[self::FIELD_AUTHORIZED_EXTS_LABEL] ?? '';
+        $exts = is_string($exts) && !empty(trim($exts))
+            ? explode(',',trim($exts))
+            : [];
+        $exts = array_map('trim',$exts);
+        $this->authorizedExts = array_filter($exts,function($ext){
+            return preg_match('/^\.[a-z0-9]{1,4}+$/',$ext);
+        });
     }
 
     protected function renderInput($entry)
@@ -171,6 +182,11 @@ class FileField extends BazarField
         return $this->readLabel;
     }
 
+    public function getAuthorizedExts(): array
+    {
+        return $this->authorizedExts;
+    }
+
     // change return of this method to keep compatible with php 7.3 (mixed is not managed)
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
@@ -179,6 +195,7 @@ class FileField extends BazarField
             parent::jsonSerialize(),
             [
               'readLabel' => $this->getReadLabel(),
+              'authorizedExts' => $this->getAuthorizedExts(),
             ]
         );
     }

--- a/tools/bazar/lang/bazar_fr.inc.php
+++ b/tools/bazar/lang/bazar_fr.inc.php
@@ -134,6 +134,7 @@ return [
     'BAZ_MODIFIER_LA_FICHE' => 'Modifier la fiche',
     'BAZ_MODIFY_ENTRY_AGAIN' => 'Modifier la fiche à nouveau',
     'BAZ_ADD_NEW_ENTRY' => 'Ajouter une nouvelle fiche',
+    'BAZ_MODIFIER_FICHIER' => 'Modifier le fichier',
     'BAZ_SUPPRIMER' => 'Supprimer',
     'BAZ_SUPPRIMER_IMAGE' => 'Supprimer l\'image',
     'BAZ_CONFIRMATION_SUPPRESSION_IMAGE' => 'Etes vous s&ucirc;rs de vouloir supprimer cette image? (les autres modifications en cours ne seront pas sauvegardées)',

--- a/tools/bazar/lang/bazarjs_fr.inc.php
+++ b/tools/bazar/lang/bazarjs_fr.inc.php
@@ -270,6 +270,11 @@ return [
     "BAZ_FORM_EDIT_CONDITIONS_CHECKING_NOCLEAN_OPTION" => "Ne pas effacer",
     "BAZ_FORM_CONDITIONSCHEKING_NOCLEAN_HINT" => "Pour effacer ou non le contenu de ce qui est masqué",
 
+    // jsvascripts/form-edit-templates/fields/file.js
+    'BAZ_FORM_EDIT_FILE_AUTHEXTS_LABEL' => 'Extensions privilégiée',
+    'BAZ_FORM_EDIT_FILE_AUTHEXTS_HINT' => 'avec le point, séparée par des virgules ; ex: .pdf,.png',
+    'BAZ_FORM_EDIT_FILE_AUTHEXTS_PLACEHOLDER' => 'ex: .pdf,.png',
+
     // reactions
     'BAZ_ACTIVATE_REACTIONS' => 'Activer les réactions sur cette fiche ?',
     'BAZ_REACTIONS_FIELD' => 'Réactions',

--- a/tools/bazar/presentation/javascripts/form-edit-template/fields/file.js
+++ b/tools/bazar/presentation/javascripts/form-edit-template/fields/file.js
@@ -1,3 +1,4 @@
+import renderHelper from './commons/render-helper.js'
 import { readConf, writeconf, semanticConf, defaultMapping } from './commons/attributes.js'
 
 export default {
@@ -7,14 +8,26 @@ export default {
       value: '',
       placeholder: _t('BAZ_FILEFIELD_FILE')
     },
+    authorizedExts:{
+      label: _t('BAZ_FORM_EDIT_FILE_AUTHEXTS_LABEL'),
+      value: '',
+      placeholder: _t('BAZ_FORM_EDIT_FILE_AUTHEXTS_PLACEHOLDER')
+    },
     maxsize: { label: _t('BAZ_FORM_EDIT_FILE_MAXSIZE_LABEL'), value: '' },
     hint: { label: _t('BAZ_FORM_EDIT_HELP'), value: '' },
     read: readConf,
     write: writeconf,
     semantic: semanticConf
   },
-  advancedAttributes: ['read', 'write', 'semantic', 'maxsize'],
+  advancedAttributes: ['read', 'write', 'semantic', 'maxsize','authorizedExts'],
   // disabledAttributes: [],
-  attributesMapping: { ...defaultMapping, ...{ 3: 'maxsize', 6: 'readlabel' } },
-  // renderInput(fieldData) {},
+  attributesMapping: { ...defaultMapping, ...{ 3: 'maxsize', 6: 'readlabel', 7: 'authorizedExts' } },
+  renderInput(field) {
+    return {
+      field: `<input type="file"/>`,
+      onRender() {
+        renderHelper.defineLabelHintForGroup(field, 'authorizedExts', _t('BAZ_FORM_EDIT_FILE_AUTHEXTS_HINT'))
+      }
+    }
+  }
 }

--- a/tools/bazar/templates/inputs/file.twig
+++ b/tools/bazar/templates/inputs/file.twig
@@ -8,6 +8,7 @@
             <label class="btn btn-sm btn-default">
                 <i class="fa fa-pencil-alt"></i>
                 {{ _t('BAZ_MODIFIER_FICHIER') }}
+                {% set style = 'display:none;' %}
                 {{ block('inputblock') }}
             </label>   
              {% if isAllowedToDeleteFile %}
@@ -29,14 +30,17 @@
                 value="{{ value }}"
             />
         {% else %}
+          {% block inputblock %}
             <input
                 type="file"
                 id="{{ field.propertyName }}"
                 name="{{ field.propertyName }}"
+                {% if style %}style="{{ style }}"{% endif %}
                 class="form-control"
                 {% if field.authorizedExts is not empty %}accept="{{field.authorizedExts|join(',')}}"{% endif %}
                 {% if field.required %}required{% endif %}
             />
+            {% endblock %}
         {% endif %}
     </div>
 {% endblock %}

--- a/tools/bazar/templates/inputs/file.twig
+++ b/tools/bazar/templates/inputs/file.twig
@@ -4,13 +4,25 @@
     <div class="input-group">
         {% if value %}
             <a href="{{ fileUrl }}" target="_blank" download="{{ shortFileName }}">{{ shortFileName }}</a>
-            &nbsp;-&nbsp;            
-            {% if isAllowedToDeleteFile %}
-                <a href="{{ deleteUrl }}" 
+            &nbsp;-&nbsp;
+            <label class="btn btn-sm btn-default">
+                <i class="fa fa-pencil-alt"></i>
+                {{ _t('BAZ_MODIFIER_FICHIER') }}
+                <input
+                    type="file"
+                    style="display: none;"
+                    class="form-control"
+                    id="{{ field.propertyName }}"
+                    name="{{ field.propertyName }}"
+                    accept=".pdf"
+                >
+            </label>   
+             {% if isAllowedToDeleteFile %}
+                <a class="btn btn-sm btn-danger" href="{{ deleteUrl }}" 
                    onClick="javascript:return confirm('{{ _t('BAZ_CONFIRMATION_SUPPRESSION_FICHIER') }}');">
                     {{- _t('BAZ_SUPPRIMER') -}}
                 </a>            
-            {% else %}            
+             {% else %}            
                 <button class="btn btn-sm btn-danger" disabled="disabled"
                     data-toggle="tooltip" data-placement="bottom" title="{{ _t('BAZ_DROIT_INSUFFISANT') }}">
                     <i class="fa fa-trash"></i>
@@ -29,6 +41,7 @@
                 id="{{ field.propertyName }}"
                 name="{{ field.propertyName }}"
                 class="form-control"
+                accept=".pdf"
                 {% if field.required %}required{% endif %}
             />
         {% endif %}

--- a/tools/bazar/templates/inputs/file.twig
+++ b/tools/bazar/templates/inputs/file.twig
@@ -8,14 +8,7 @@
             <label class="btn btn-sm btn-default">
                 <i class="fa fa-pencil-alt"></i>
                 {{ _t('BAZ_MODIFIER_FICHIER') }}
-                <input
-                    type="file"
-                    style="display: none;"
-                    class="form-control"
-                    id="{{ field.propertyName }}"
-                    name="{{ field.propertyName }}"
-                    accept=".pdf"
-                >
+                {{ block('inputblock') }}
             </label>   
              {% if isAllowedToDeleteFile %}
                 <a class="btn btn-sm btn-danger" href="{{ deleteUrl }}" 

--- a/tools/bazar/templates/inputs/file.twig
+++ b/tools/bazar/templates/inputs/file.twig
@@ -41,7 +41,7 @@
                 id="{{ field.propertyName }}"
                 name="{{ field.propertyName }}"
                 class="form-control"
-                accept=".pdf"
+                {% if field.authorizedExts is not empty %}accept="{{field.authorizedExts|join(',')}}"{% endif %}
                 {% if field.required %}required{% endif %}
             />
         {% endif %}


### PR DESCRIPTION
Cette PR fait suite à cette discussion du forum : https://forum.yeswiki.net/t/souci-droit-champ-upload-de-fichier/543

Describe what it does / Expliquer ce que cela fait

Add a new field in FormBuilder to specify file extension.
Rendering and French translation also updated.

Pour tester
créer un formulaire avec un champ fichier
voir la nouvelle option dans le constructeur (dans les paramètres avancés du champ)
y spécifier une ou plusieurs extensions séparées par des virgules
créer une fiche avec un fichier
voir le nouveau bouton modifier et vérifier que les types d'extensions autorisées sont bien celles paramétrées dans le champ

