### PR TITLE
Add field in FormBuilder to specify file extension

### DIFF
--- a/tools/bazar/lang/bazarjs_fr.inc.php
+++ b/tools/bazar/lang/bazarjs_fr.inc.php
@@ -271,7 +271,7 @@ return [
     "BAZ_FORM_CONDITIONSCHEKING_NOCLEAN_HINT" => "Pour effacer ou non le contenu de ce qui est masqué",
 
     // jsvascripts/form-edit-templates/fields/file.js
-    'BAZ_FORM_EDIT_FILE_AUTHEXTS_LABEL' => 'Extensions privilégiées (avec le point, séparées par des virgules)',
+    'BAZ_FORM_EDIT_FILE_AUTHEXTS_LABEL' => 'Extension(s) présélectionnée(s) (avec le point, séparées par des virgules)',
     'BAZ_FORM_EDIT_FILE_AUTHEXTS_PLACEHOLDER' => 'ex: .pdf,.png',
 
     // reactions


### PR DESCRIPTION
Cette PR fait suite à cette discussion du forum : https://forum.yeswiki.net/t/souci-droit-champ-upload-de-fichier/543

Describe what it does / Expliquer ce que cela fait

Add a new field in FormBuilder to specify file extension.
Rendering and French translation also updated.

Pour tester
créer un formulaire avec un champ fichier
voir la nouvelle option dans le constructeur (dans les paramètres avancés du champ)
y spécifier une ou plusieurs extensions séparées par des virgules
créer une fiche avec un fichier
voir le nouveau bouton modifier et vérifier que les types d'extensions autorisées sont bien celles paramétrées dans le champ
