### PR TITLE
Feat/duplicate pages entries

### DIFF
--- a/docs/fr/admin.md
+++ b/docs/fr/admin.md
@@ -551,7 +551,7 @@ Cette page permet de modifier la configuration de son Yeswiki sans passer par le
  - **Activer le mode de debug (yes ou no) - debug** :  ce paramètre active le mode de débogage s'il est passé à la valeur 'yes' (infos sur le nombre de requêtes, le temps écoulé et force l'affichage des erreurs php pour les développeurs). Astuce : on peut aussi passer &debug dans l'url pour debugguer
  - **Fuseau horaire du site (ex. UTC, Europe/Paris, Europe/London) - timezone** : à la création du wiki, le fuseau horaire choisi est GMT et se cale sur celui du serveur. Cela peut amener des différences d'affichage. Il peut arriver que l'affichage de l'heure de début d'un évènement sur le calendrier soit décalée car la configuration serveur peut être en décalage par rapport au fuseau horaire de l'administrateurice du wiki.
 Pour bien configurer, on peut mettre dans le paramètre Fuseau horaire du site la valeur : Europe/Paris (ou sinon UTC).
- - **Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,all = autoriser tout) - allowed_methods_in_iframe**
+ - **Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,duplicateiframe,all = autoriser tout) - allowed_methods_in_iframe**
  - **Nombre maximum de versions d'une page affichées par le handler `/revisions`. - revisionscount** : 
  - **Image d'avatar par défaut pour les commentaires (URL vers une image) - default_comment_avatar**
  - **Activer le nettoyage HTML avant sauvegarde. Attention, modifie le contenu à la sauvegarde ! (true ou false) - htmlPurifierActivated**

--- a/handlers/DuplicateHandler.php
+++ b/handlers/DuplicateHandler.php
@@ -1,0 +1,187 @@
+<?php
+
+use YesWiki\Bazar\Controller\EntryController;
+use YesWiki\Bazar\Field\BazarField;
+use YesWiki\Bazar\Service\EntryManager;
+use YesWiki\Bazar\Service\FormManager;
+use YesWiki\Core\Service\AclService;
+use YesWiki\Core\Service\DuplicationFollower;
+use YesWiki\Core\Service\PageManager;
+use YesWiki\Core\Service\Performer;
+use YesWiki\Core\YesWikiHandler;
+
+class DuplicateHandler extends YesWikiHandler
+{
+    protected $aclService;
+    protected $duplicationFollower;
+    protected $entryController;
+    protected $entryManager;
+    protected $formManager;
+    protected $pageManager;
+    protected $performer;
+
+    public function run()
+    {
+        // get services
+        $this->aclService = $this->getService(AclService::class);
+        $this->duplicationFollower = $this->getService(DuplicationFollower::class);
+        $this->entryController = $this->getService(EntryController::class);
+        $this->entryManager = $this->getService(EntryManager::class);
+        $this->formManager = $this->getService(FormManager::class);
+        $this->pageManager = $this->getService(PageManager::class);
+        $this->performer = $this->getService(Performer::class);
+
+        // check current user can read
+        if (!$this->aclService->hasAccess('read')){
+            return $this->finalRender($this->render('@templates/alert-message.twig',[
+                'type' => 'danger',
+                'message' => _t('TEMPLATE_NO_ACCESS_TO_PAGE')
+            ]));
+        }
+        $tag = $this->wiki->getPageTag();
+        $page = $this->pageManager->getOne($tag);
+        $isEntry = $this->entryManager->isEntry($tag);
+
+        $canDuplicateEntryIfNotRightToWrite = $this->params->has('canDuplicateEntryIfNotRightToWrite')
+            ? $this->formatBoolean($this->params->get('canDuplicateEntryIfNotRightToWrite'),false)
+            : false;
+
+        // check current user can write for new entry/page
+        if (!$this->aclService->hasAccess('write','--unknown-tag--') && (!$isEntry || !$canDuplicateEntryIfNotRightToWrite)){
+            return $this->finalRender($this->render('@templates/alert-message.twig',[
+                'type' => 'danger',
+                'message' => _t('EDIT_NO_WRITE_ACCESS')
+            ]));
+        }
+
+        if (!empty($page)){
+            return $isEntry
+                ? $this->duplicateEntry($tag)
+                : $this->duplicatePage($tag);
+        }
+        $this->wiki->method = $this->isInIframe() ?  'editiframe' : 'edit';
+        return $this->performer->run($this->wiki->method,'handler',[]);
+    }
+
+    protected function finalRender(string $content, bool $includePage = false): string
+    {
+        $output = $includePage
+            ? <<<HTML
+            <div class="page">
+                $content
+            </div>
+            HTML
+            : $content;
+        return $this->wiki->Header().$content.$this->wiki->Footer() ;
+    }
+
+    protected function duplicateEntry(string $tag): string
+    {
+        $entry = $this->entryManager->getOne($tag); // with current rights
+        $form = $this->formManager->getOne($entry['id_typeannonce']);
+        if (empty($form['prepared'])){
+            throw new Exception("Impossible to duplicate because form is not existing !");
+        }
+        if (!empty($_GET['created']) && $_GET['created'] === '1'){
+            $followedEntryIds = [];
+            if ($this->duplicationFollower->isFollowed($tag, $followedEntryIds)){
+                $firstId = array_shift($followedEntryIds);
+                if (count($followedEntryIds) > 0){
+                    flash(_t('DUPLICATE_OTHER_ENTRIES_CREATED',[
+                        'links'=> implode(',',array_map(
+                            function ($id) {
+                                return <<<HTML
+                                    <a class="new-tab" href="{$this->wiki->Href('',$id)}">$id</a>
+                                    HTML;
+                            },
+                            $followedEntryIds
+                        ))
+                    ]),'success');
+                }
+                $this->wiki->Redirect($this->wiki->Href(
+                    $this->isInIframe() ? 'iframe' : '', // handler
+                    $firstId,
+                    [
+                        'message' => 'ajout_ok'
+                    ],
+                    false
+                ));
+                throw new Exception("Error Processing Request");
+            } else {
+                return $this->finalRender(
+                    $this->render('@templates/alert-message.twig',[
+                        'type' => 'info',
+                        'message' => _t('DUPLICATION_TROUBLE')
+                    ]).
+                    $this->entryController->view($tag),true);
+            }
+        }
+        if (!isset($_POST['bf_titre'])){
+            foreach ($form['prepared'] as $field) {
+                if ($field instanceof BazarField){
+                    $propName = $field->getPropertyName();
+                    if (!empty($propName) && isset($entry[$propName])){
+                        $_POST[$propName] = $entry[$propName];
+                        $_REQUEST[$propName] = $entry[$propName];
+                    }
+                }
+            }
+            // clean inputs
+            if (isset($_POST['bf_titre'])){
+                unset($_POST['bf_titre']);
+            }
+            $redirectUrl = $this->wiki->Href(
+                $this->isInIframe() ? 'iframe' : '', // handler
+                $tag
+            );
+            return $this->finalRender($this->entryController->create($form['bn_id_nature'], $redirectUrl),true);
+        }
+        $redirectUrl = $this->wiki->Href(
+            $this->isInIframe() ? 'duplicateiframe' : 'duplicate', // handler
+            $tag,
+            ['created'=>true], // params
+            false // html outputs ?
+        );
+        
+        return $this->finalRender($this->entryController->create($form['bn_id_nature'], $redirectUrl),true);
+    }
+
+    protected function duplicatePage(string $tag): string
+    {
+        $message = '';
+        $type = '';
+        if (isset($_POST['newName'])){
+            if(empty($_POST['newName']) || !is_string($_POST['newName'])){
+                $type = 'warning';
+                $message = _t('DUPLICATION_NOT_POSSIBLE_IF_NO_NAME');
+            } else {
+                $page = $this->pageManager->getOne($_POST['newName']);
+                if (!empty($page)){
+                    $type = 'danger';
+                    $message = _t('DUPLICATION_NOT_POSSIBLE_IF_EXISTING');
+                } else {
+                    // fake body for new Tag
+                    $this->wiki->page['tag'] = $_POST['newName'];
+                    $this->wiki->tag = $_POST['newName'];
+                    unset($_POST['submit']);
+                    $this->wiki->method = $this->isInIframe() ? 'editiframe' : 'edit';
+                    flash(_t('DUPLICATION_IN_COURSE',[
+                        'originTag' => $tag,
+                        'destinationTag' => $_POST['newName'],
+                    ]),'info');
+                    return $this->performer->run($this->wiki->method,'handler',[]);
+                }
+            }
+        }
+        return $this->finalRender($this->render('@core/duplicate-handler-ask-new-name.twig',[
+            'type' => $type,
+            'message' => $message,
+            'isInIframe' => $this->isInIframe()
+        ]));
+    }
+
+    protected function isInIframe()
+    {
+        return preg_match('/duplicateiframe(?:&|\?|$)/Ui', getAbsoluteUrl());
+    }
+}

--- a/handlers/DuplicateIframeHandler.php
+++ b/handlers/DuplicateIframeHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+if (!class_exists(DuplicateHandler::class)){
+    include_once 'handlers/DuplicateHandler.php';
+}
+
+class DuplicateIframeHandler extends DuplicateHandler
+{
+    protected function finalRender(string $content, bool $includePage = false): string
+    {
+        // inspired from IframeHandler.php and EditIframeHandler.php
+
+        // on recupere les entetes html mais pas ce qu'il y a dans le body
+        $header = explode('<body', $this->wiki->Header());
+        $output = $header[0].$content;
+        // on recupere juste les javascripts et la fin des balises body et html
+        $output .= preg_replace('/^.+<script/Us', '<script', $this->wiki->Footer());
+
+        return $output;
+    }
+}

--- a/includes/YesWikiInit.php
+++ b/includes/YesWikiInit.php
@@ -226,7 +226,7 @@ class Init
             'preview_before_save' => false,
             'allow_raw_html' => true,
             'disable_wiki_links' => false,
-            'allowed_methods_in_iframe' => ['iframe','editiframe','bazariframe','render'],
+            'allowed_methods_in_iframe' => ['iframe','editiframe','bazariframe','render','duplicateiframe'],
             'revisionscount' => 30,
             'timezone' => 'Europe/Paris', // Only used if not set in wakka.config.php nor in php.ini
             'root_page' => 'PagePrincipale', // backup root_page if deleted from wakka.config.php

--- a/includes/services.yaml
+++ b/includes/services.yaml
@@ -26,3 +26,6 @@ services:
   YesWiki\Core\Service\CommentService:
     tags:
       - { name: yeswiki.event_subscriber }
+  YesWiki\Core\Service\DuplicationFollower:
+    tags:
+      - { name: yeswiki.event_subscriber }

--- a/includes/services/DuplicationFollower.php
+++ b/includes/services/DuplicationFollower.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace YesWiki\Core\Service;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use YesWiki\Core\Entity\Event;
+use YesWiki\Wiki;
+
+class DuplicationFollower implements EventSubscriberInterface
+{
+    protected $wiki;
+    
+    public static function getSubscribedEvents()
+    {
+        return [
+            'entry.created' => 'followEntryCreation',
+        ];
+    }
+
+    public function __construct(
+        Wiki $wiki
+    ) {
+        $this->wiki = $wiki;
+    }
+
+    /**
+     * @param Event $event
+     */
+    public function followEntryCreation($event)
+    {
+        $entry = $this->getEntry($event);
+        if ($this->shouldFollowEntry($entry)){
+            $this->registerFollowInSession($this->wiki->tag,$entry['id_fiche']);
+        }
+    }
+
+    /**
+     * @param Event $event
+     * @return array $entry
+     */
+    protected function getEntry(Event $event): array
+    {
+        $data = $event->getData();
+        $entry = $data['data'] ?? [];
+        return is_array($entry) ? $entry : [];
+    }
+
+    /**
+     * @param array $entry
+     * @return bool
+     */
+    protected function shouldFollowEntry(array $entry): bool
+    {
+        return (
+            !empty($entry['id_fiche'])
+            && !empty($this->wiki->tag)
+            && !empty($this->wiki->method))
+            && in_array($this->wiki->method,['duplicate','duplicateiframe'],true
+        );
+    }
+
+    /**
+     * append association to follow in session
+     * @param string $createdEntryId
+     * @param string $copiedEntryId
+     */
+    public function registerFollowInSession(string $copiedEntryId, string $createdEntryId)
+    {
+        if (empty($_SESSION['duplicateIds'])){
+            $_SESSION['duplicateIds'] = [];
+        }
+        if (!array_key_exists($copiedEntryId,$_SESSION['duplicateIds'])){
+            $_SESSION['duplicateIds'][$copiedEntryId] = [];
+        }
+        if (!in_array($createdEntryId,$_SESSION['duplicateIds'][$copiedEntryId])){
+            $_SESSION['duplicateIds'][$copiedEntryId][] = $createdEntryId;
+        }
+    }
+
+    /**
+     * check if the current entry is followed
+     * @param string $entryId
+     * @param array &$followedEntryIds
+     * @return bool
+     */
+    public function isFollowed(string $entryId, array &$followedEntryIds): bool
+    {
+        $isFollowed = !empty($_SESSION['duplicateIds'][$entryId]);
+        if ($isFollowed){
+            $followedEntryIds = $_SESSION['duplicateIds'][$entryId];
+            unset($_SESSION['duplicateIds'][$entryId]);
+        }
+        if (isset($_SESSION['duplicateIds']) && empty($_SESSION['duplicateIds'])){
+            unset($_SESSION['duplicateIds']);
+        }
+        return $isFollowed;
+    }
+}

--- a/lang/yeswiki_ca.php
+++ b/lang/yeswiki_ca.php
@@ -536,7 +536,7 @@ return [
     // 'EDIT_CONFIG_HINT_PASSWORD_FOR_EDITING_MESSAGE' => 'Message informatif pour demander le mot de passe (voir doc gestion des spams)',
     // 'EDIT_CONFIG_HINT_ALLOW_DOUBLECLIC' => 'Autoriser le doubleclic pour éditer les menus et pages spéciales (true ou false)',
     'EDIT_CONFIG_HINT_TIMEZONE' => 'Fus horari del lloc (per exemple, UTC, Europa/Paris, Europa/Londres)',
-    'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Mètodes permesos per ser mostrats en iframes (iframe,editiframe,bazariframe,render,all = allow all)',
+    'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Mètodes permesos per ser mostrats en iframes (iframe,editiframe,bazariframe,render,duplicateiframe,all = allow all)',
     // 'EDIT_CONFIG_HINT_REVISIONSCOUNT' => 'Nombre maximum de versions d\'une page affichées par le handler `/revisions`.',
     'EDIT_CONFIG_HINT_HTMLPURIFIERACTIVATED' => 'Habilita la neteja HTML abans de fer la còpia de seguretat. Aneu amb compte, modifiqueu el contingut a la còpia de seguretat! (vertader o fals)',
     'EDIT_CONFIG_HINT_FAVORITES_ACTIVATED' => 'Habilitar favorits (vertader o fals)',

--- a/lang/yeswiki_ca.php
+++ b/lang/yeswiki_ca.php
@@ -564,6 +564,15 @@ return [
     // 'DELETEPAGE_PAGES_WITH_LINKS_TO' => 'Pages ayant un lien vers {tag} :',
     'DELETEPAGE_NOT_DELETED' => 'La pàgina no s\'ha suprimit.',
 
+    // handlers/DuplicationHandler.php
+    // 'DUPLICATE' => 'Dupliquer',
+    // 'DUPLICATION_IN_COURSE' => 'Vous être en train de dupliquer la page \'%{originTag}\' vers \'%{destinationTag}\' !',
+    // 'DUPLICATION_NOT_POSSIBLE_IF_EXISTING' => 'Copie de la page impossible car le nouveau nom choisi est déjà utilisé !',
+    // 'DUPLICATION_NOT_POSSIBLE_IF_NO_NAME' => 'Copie de la page impossible car le nouveau nom choisi est vide !',
+    // 'DUPLICATION_TROUBLE' => 'La duplication de la présente fiche a bien eu lieu mais il n\'a pas été possible de retrouver le lien vers la nouvelle fiche.',
+    // 'DUPLICATE_OTHER_ENTRIES_CREATED' => 'D\'autres fiches ont été créées : %{links}',
+    // 'DUPLICATE_PAGE_NEW_NAME' => 'Nom de la nouvelle page à créer',
+
     // handlers/edit
     // 'EDIT_ALERT_ALREADY_SAVED_BY_ANOTHER_USER' => 'ALERTE : '.
     //     'Cette page a &eacute;t&eacute; modifi&eacute;e par quelqu\'un d\'autre pendant que vous l\'&eacute;ditiez.'."\n".

--- a/lang/yeswiki_en.php
+++ b/lang/yeswiki_en.php
@@ -538,7 +538,7 @@ return [
     'EDIT_CONFIG_HINT_PASSWORD_FOR_EDITING_MESSAGE' => 'Message displayed above the password asked password to modify forms (see doc on spam management)',
     'EDIT_CONFIG_HINT_ALLOW_DOUBLECLIC' => 'Allow double click to edit menus and special pages (true ou false)',
     'EDIT_CONFIG_HINT_TIMEZONE' => 'Time zone of the site (e.g. UTC, Europe/Paris, Europe/London)',
-    'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Methods allowed to be displayed in iframes (iframe,editiframe,bazariframe,render,all = allow all)',
+    'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Methods allowed to be displayed in iframes (iframe,editiframe,bazariframe,render,duplicateiframe,all = allow all)',
     'EDIT_CONFIG_HINT_REVISIONSCOUNT' => 'Maximum number of page\'s revisions displayed by the handler `/revisions`.',
     'EDIT_CONFIG_HINT_HTMLPURIFIERACTIVATED' => 'Enable HTML purifier before backup. Be careful, modify the content to backup! (true or false)',
     'EDIT_CONFIG_HINT_FAVORITES_ACTIVATED' => 'Enable favorites (true or false)',

--- a/lang/yeswiki_en.php
+++ b/lang/yeswiki_en.php
@@ -566,6 +566,15 @@ return [
     'DELETEPAGE_PAGES_WITH_LINKS_TO' => 'Pages with a link to {tag} :',
     'DELETEPAGE_NOT_DELETED' => 'Not deleted page.',
 
+    // handlers/DuplicationHandler.php
+    'DUPLICATE' => 'Duplicate',
+    'DUPLICATION_IN_COURSE' => 'You are duplicating the page \'%{originTag}\' to \'%{destinationTag}\'!',
+    'DUPLICATION_NOT_POSSIBLE_IF_EXISTING' => 'Not possible to copy the page because the new choosen name is already used!',
+    'DUPLICATION_NOT_POSSIBLE_IF_NO_NAME' => 'Not possible to copy the page because the new choosen name is already empty!',
+    'DUPLICATION_TROUBLE' => 'The duplication of current entry has well occured but it was not possible to retrive the link to the new entry.',
+    'DUPLICATE_OTHER_ENTRIES_CREATED' => 'Others entries were created: %{links}',
+    'DUPLICATE_PAGE_NEW_NAME' => 'Name of the new page to create',
+
     // handlers/edit
     'EDIT_ALERT_ALREADY_SAVED_BY_ANOTHER_USER' => 'ALERT : '.
         'Thispage has benn modified by another user while you were editing it.'."\n".

--- a/lang/yeswiki_es.php
+++ b/lang/yeswiki_es.php
@@ -538,7 +538,7 @@ return [
     // 'EDIT_CONFIG_HINT_PASSWORD_FOR_EDITING_MESSAGE' => 'Message informatif pour demander le mot de passe (voir doc gestion des spams)',
     // 'EDIT_CONFIG_HINT_ALLOW_DOUBLECLIC' => 'Autoriser le doubleclic pour éditer les menus et pages spéciales (true ou false)',
     // 'EDIT_CONFIG_HINT_TIMEZONE' => 'Fuseau horaire du site (ex. UTC, Europe/Paris, Europe/London)',
-    // 'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,all = autoriser tout)',
+    // 'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,duplicateiframe,all = autoriser tout)',
     // 'EDIT_CONFIG_HINT_REVISIONSCOUNT' => 'Nombre maximum de versions d\'une page affichées par le handler `/revisions`.',
     // 'EDIT_CONFIG_HINT_HTMLPURIFIERACTIVATED' => 'Activer le nettoyage HTML avant sauvegarde. Attention, modifie le contenu à la sauvegarde ! (true ou false)',
     // 'EDIT_CONFIG_HINT_FAVORITES_ACTIVATED' => 'Activer les favoris (true ou false)',

--- a/lang/yeswiki_es.php
+++ b/lang/yeswiki_es.php
@@ -566,6 +566,15 @@ return [
     // 'DELETEPAGE_PAGES_WITH_LINKS_TO' => 'Pages ayant un lien vers {tag} :',
     'DELETEPAGE_NOT_DELETED' => 'Página no eliminada.',
 
+    // handlers/DuplicationHandler.php
+    // 'DUPLICATE' => 'Dupliquer',
+    // 'DUPLICATION_IN_COURSE' => 'Vous être en train de dupliquer la page \'%{originTag}\' vers \'%{destinationTag}\' !',
+    // 'DUPLICATION_NOT_POSSIBLE_IF_EXISTING' => 'Copie de la page impossible car le nouveau nom choisi est déjà utilisé !',
+    // 'DUPLICATION_NOT_POSSIBLE_IF_NO_NAME' => 'Copie de la page impossible car le nouveau nom choisi est vide !',
+    // 'DUPLICATION_TROUBLE' => 'La duplication de la présente fiche a bien eu lieu mais il n\'a pas été possible de retrouver le lien vers la nouvelle fiche.',
+    // 'DUPLICATE_OTHER_ENTRIES_CREATED' => 'D\'autres fiches ont été créées : %{links}',
+    // 'DUPLICATE_PAGE_NEW_NAME' => 'Nom de la nouvelle page à créer',
+
     // handlers/edit
     // 'EDIT_ALERT_ALREADY_SAVED_BY_ANOTHER_USER' => 'ALERTE : '.
     //     'Cette page a &eacute;t&eacute; modifi&eacute;e par quelqu\'un d\'autre pendant que vous l\'&eacute;ditiez.'."\n".

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -583,6 +583,15 @@ return [
     'DELETEPAGE_PAGES_WITH_LINKS_TO' => 'Pages ayant un lien vers {tag} :',
     'DELETEPAGE_NOT_DELETED' => 'Page non supprimée.',
 
+    // handlers/DuplicationHandler.php
+    'DUPLICATE' => 'Dupliquer',
+    'DUPLICATION_IN_COURSE' => 'Vous être en train de dupliquer la page \'%{originTag}\' vers \'%{destinationTag}\' !',
+    'DUPLICATION_NOT_POSSIBLE_IF_EXISTING' => 'Copie de la page impossible car le nouveau nom choisi est déjà utilisé !',
+    'DUPLICATION_NOT_POSSIBLE_IF_NO_NAME' => 'Copie de la page impossible car le nouveau nom choisi est vide !',
+    'DUPLICATION_TROUBLE' => 'La duplication de la présente fiche a bien eu lieu mais il n\'a pas été possible de retrouver le lien vers la nouvelle fiche.',
+    'DUPLICATE_OTHER_ENTRIES_CREATED' => 'D\'autres fiches ont été créées : %{links}',
+    'DUPLICATE_PAGE_NEW_NAME' => 'Nom de la nouvelle page à créer',
+
     // handlers/edit
     'EDIT_ALERT_ALREADY_SAVED_BY_ANOTHER_USER' =>
         'Cette page a &eacute;t&eacute; modifi&eacute;e par quelqu\'un d\'autre pendant que vous l\'&eacute;ditiez.'."\n".

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -554,7 +554,7 @@ return [
     'EDIT_CONFIG_HINT_ALLOW_DOUBLECLIC' => 'Autoriser le doubleclic pour éditer les menus et pages spéciales (true ou false)',
     'EDIT_CONFIG_HINT_TIMEZONE' => 'Fuseau horaire du site (ex. UTC, Europe/Paris, Europe/London)',
     'EDIT_CONFIG_HINT_FAVICON' => 'Icône du site (emoji ou URL vers une image PNG)',
-    'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,all = autoriser tout)',
+    'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,duplicateiframe,all = autoriser tout)',
     'EDIT_CONFIG_HINT_REVISIONSCOUNT' => 'Nombre maximum de versions d\'une page affichées par le handler `/revisions`.',
     'EDIT_CONFIG_HINT_DEFAULT_COMMENT_AVATAR' => 'Image d\'avatar par défaut pour les commentaires (URL vers une image)',
     'EDIT_CONFIG_HINT_HTMLPURIFIERACTIVATED' => 'Activer le nettoyage HTML avant sauvegarde. Attention, modifie le contenu à la sauvegarde ! (true ou false)',

--- a/lang/yeswiki_nl.php
+++ b/lang/yeswiki_nl.php
@@ -563,6 +563,15 @@ return [
     // 'DELETEPAGE_PAGES_WITH_LINKS_TO' => 'Pages ayant un lien vers {tag} :',
     'DELETEPAGE_NOT_DELETED' => 'Pagina niet verwijderd.',
 
+    // handlers/DuplicationHandler.php
+    // 'DUPLICATE' => 'Dupliquer',
+    // 'DUPLICATION_IN_COURSE' => 'Vous être en train de dupliquer la page \'%{originTag}\' vers \'%{destinationTag}\' !',
+    // 'DUPLICATION_NOT_POSSIBLE_IF_EXISTING' => 'Copie de la page impossible car le nouveau nom choisi est déjà utilisé !',
+    // 'DUPLICATION_NOT_POSSIBLE_IF_NO_NAME' => 'Copie de la page impossible car le nouveau nom choisi est vide !',
+    // 'DUPLICATION_TROUBLE' => 'La duplication de la présente fiche a bien eu lieu mais il n\'a pas été possible de retrouver le lien vers la nouvelle fiche.',
+    // 'DUPLICATE_OTHER_ENTRIES_CREATED' => 'D\'autres fiches ont été créées : %{links}',
+    // 'DUPLICATE_PAGE_NEW_NAME' => 'Nom de la nouvelle page à créer',
+
     // handlers/edit
     // 'EDIT_ALERT_ALREADY_SAVED_BY_ANOTHER_USER' => 'ALERTE : '.
     //     'Cette page a &eacute;t&eacute; modifi&eacute;e par quelqu\'un d\'autre pendant que vous l\'&eacute;ditiez.'."\n".

--- a/lang/yeswiki_nl.php
+++ b/lang/yeswiki_nl.php
@@ -535,7 +535,7 @@ return [
     // 'EDIT_CONFIG_HINT_PASSWORD_FOR_EDITING_MESSAGE' => 'Message informatif pour demander le mot de passe (voir doc gestion des spams)',
     // 'EDIT_CONFIG_HINT_ALLOW_DOUBLECLIC' => 'Autoriser le doubleclic pour éditer les menus et pages spéciales (true ou false)',
     // 'EDIT_CONFIG_HINT_TIMEZONE' => 'Fuseau horaire du site (ex. UTC, Europe/Paris, Europe/London)',
-    // 'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,all = autoriser tout)',
+    // 'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,duplicateiframe,all = autoriser tout)',
     // 'EDIT_CONFIG_HINT_REVISIONSCOUNT' => 'Nombre maximum de versions d\'une page affichées par le handler `/revisions`.',
     // 'EDIT_CONFIG_HINT_HTMLPURIFIERACTIVATED' => 'Activer le nettoyage HTML avant sauvegarde. Attention, modifie le contenu à la sauvegarde ! (true ou false)',
     // 'EDIT_CONFIG_HINT_FAVORITES_ACTIVATED' => 'Activer les favoris (true ou false)',

--- a/lang/yeswiki_pt.php
+++ b/lang/yeswiki_pt.php
@@ -563,6 +563,15 @@ return [
     // 'DELETEPAGE_PAGES_WITH_LINKS_TO' => 'Pages ayant un lien vers {tag} :',
     'DELETEPAGE_NOT_DELETED' => 'Página não apagada.',
 
+    // handlers/DuplicationHandler.php
+    // 'DUPLICATE' => 'Dupliquer',
+    // 'DUPLICATION_IN_COURSE' => 'Vous être en train de dupliquer la page \'%{originTag}\' vers \'%{destinationTag}\' !',
+    // 'DUPLICATION_NOT_POSSIBLE_IF_EXISTING' => 'Copie de la page impossible car le nouveau nom choisi est déjà utilisé !',
+    // 'DUPLICATION_NOT_POSSIBLE_IF_NO_NAME' => 'Copie de la page impossible car le nouveau nom choisi est vide !',
+    // 'DUPLICATION_TROUBLE' => 'La duplication de la présente fiche a bien eu lieu mais il n\'a pas été possible de retrouver le lien vers la nouvelle fiche.',
+    // 'DUPLICATE_OTHER_ENTRIES_CREATED' => 'D\'autres fiches ont été créées : %{links}',
+    // 'DUPLICATE_PAGE_NEW_NAME' => 'Nom de la nouvelle page à créer',
+
     // handlers/edit
     // 'EDIT_ALERT_ALREADY_SAVED_BY_ANOTHER_USER' => 'ALERTE : '.
     //     'Cette page a &eacute;t&eacute; modifi&eacute;e par quelqu\'un d\'autre pendant que vous l\'&eacute;ditiez.'."\n".

--- a/lang/yeswiki_pt.php
+++ b/lang/yeswiki_pt.php
@@ -535,7 +535,7 @@ return [
     // 'EDIT_CONFIG_HINT_PASSWORD_FOR_EDITING_MESSAGE' => 'Message informatif pour demander le mot de passe (voir doc gestion des spams)',
     // 'EDIT_CONFIG_HINT_ALLOW_DOUBLECLIC' => 'Autoriser le doubleclic pour éditer les menus et pages spéciales (true ou false)',
     // 'EDIT_CONFIG_HINT_TIMEZONE' => 'Fuseau horaire du site (ex. UTC, Europe/Paris, Europe/London)',
-    // 'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,all = autoriser tout)',
+    // 'EDIT_CONFIG_HINT_ALLOWED_METHODS_IN_IFRAME' => 'Méthodes autorisées à être affichées dans les iframes (iframe,editiframe,bazariframe,render,duplicateiframe,all = autoriser tout)',
     // 'EDIT_CONFIG_HINT_REVISIONSCOUNT' => 'Nombre maximum de versions d\'une page affichées par le handler `/revisions`.',
     // 'EDIT_CONFIG_HINT_HTMLPURIFIERACTIVATED' => 'Activer le nettoyage HTML avant sauvegarde. Attention, modifie le contenu à la sauvegarde ! (true ou false)',
     // 'EDIT_CONFIG_HINT_FAVORITES_ACTIVATED' => 'Activer les favoris (true ou false)',

--- a/templates/duplicate-handler-ask-new-name.twig
+++ b/templates/duplicate-handler-ask-new-name.twig
@@ -1,0 +1,12 @@
+{% if message %}
+  {{ include('@templates/alert-message.twig',{type:type,message:message}) }}
+{% endif %}
+<form action="{{ url({handler:isInIframe ? 'duplicateiframe' : 'duplicate'}) }}" method="post">
+  {{ include('@bazar/inputs/text.twig',{field:{label:_t('DUPLICATE_PAGE_NEW_NAME'),type:'text',subType:'text',name:'newName',required:true,pattern:'[A-Za-z0-9_]+'}}) }}
+  <div class="form-actions form-group">
+    <div class="col-sm-9 col-sm-offset-3">
+      <button type="submit" class="btn btn-primary">{{ _t('BAZ_VALIDER') }}</button>
+      <a class="btn btn-xs btn-default" onclick="window.location={{url({handler:isInIframe ? 'iframe' : ''})|json_encode}}">{{ _t('BAZ_ANNULER') }}</a>
+    </div>
+  </div>
+</form>

--- a/tools/bazar/config.yaml
+++ b/tools/bazar/config.yaml
@@ -16,6 +16,8 @@ parameters:
   global_query: 'true'
   # authorize entry creation when wiki is not opened to create page
   bazarIgnoreAcls: true
+  # duplication could also be opened to everyone but by default not because could be a source of spam
+  canDuplicateEntryIfNotRightToWrite: false
 
   # Valeurs liees aux flux RSS
 
@@ -127,6 +129,7 @@ parameters:
       - cache_time_to_check_deletion
       - cache_time_to_refresh_forms
     - 'bazarIgnoreAcls'
+    - 'canDuplicateEntryIfNotRightToWrite'
 
 services:
   _defaults:

--- a/tools/bazar/fields/DateField.php
+++ b/tools/bazar/fields/DateField.php
@@ -78,8 +78,8 @@ class DateField extends BazarField
 
     protected function getValue($entry)
     {
-        // TODO see if it is necessary to look for $_REQUEST
         // do not take default for this field
-        return $entry[$this->propertyName] ?? null;
+        // use $_REQUEST for duplication
+        return $entry[$this->propertyName] ?? $_REQUEST[$this->propertyName] ?? null;
     }
 }

--- a/tools/bazar/lang/bazar_fr.inc.php
+++ b/tools/bazar/lang/bazar_fr.inc.php
@@ -352,6 +352,7 @@ return [
     'EDIT_CONFIG_HINT_BAZ_EXTERNAL_SERVICE[CACHE_TIME_TO_CHECK_DELETION]' => 'Temps (s) entre deux rafraîchissements du cache pour vérifier les suppresions dans les requêtes JSON',
     'EDIT_CONFIG_HINT_BAZ_EXTERNAL_SERVICE[CACHE_TIME_TO_REFRESH_FORMS]' => 'Temps (s) entre deux rafraîchissements du cache pour formulaires nécessaires aux requêtes JSON',
     'EDIT_CONFIG_HINT_BAZARIGNOREACLS' => 'Permettre la création de fiches même si le wiki est fermé en écriture (true ou false)',
+    'EDIT_CONFIG_HINT_CANDUPLICATEENTRYIFNOTRIGHTTOWRITE' => 'Permettre la duplication de fiches même si le wiki est fermé en écriture (true ou false)',
     'EDIT_CONFIG_GROUP_BAZAR' => 'Base de données',
 
     // USER FIELD

--- a/tools/bazar/templates/entries/view.twig
+++ b/tools/bazar/templates/entries/view.twig
@@ -38,6 +38,19 @@
       {% endif %}
 
       <div class="BAZ_actions_fiche">
+        {% if config.default_read_acl is not empty
+            and hasAcl(config.default_read_acl)
+            and (
+                config.canDuplicateEntryIfNotRightToWrite is same as true
+                or hasAcl(config.default_write_acl)
+                ) %}
+          <a
+            class="btn btn-entry-action btn-sm btn-default"
+            title="{{ _t('DUPLICATE') }}"
+            href="{{ url({handler:isInIframe ? 'duplicateiframe' : 'duplicate'}) }}">
+            <i class="fas fa-copy"></i>
+          </a>
+        {% endif %}
         {% if currentuser is not empty %}
           {{ include_javascript('javascripts/favorites.js') }}
           <a href="#"

--- a/tools/templates/templates/barreredaction_basic.twig
+++ b/tools/templates/templates/barreredaction_basic.twig
@@ -3,6 +3,10 @@
     <a title="{{ _t('TEMPLATE_EDIT_THIS_PAGE') ~ ' ' ~ page }}" href="{{ linkedit }}" class="link-edit">
       <i class="fa fa-pencil-alt"></i><span>{{ _t('TEMPLATE_EDIT_THIS_PAGE') }}</span>
     </a>
+    <a title="{{ _t('DUPLICATE') }}"
+      href="{{ url({handler:isInIframe ? 'duplicateiframe' : 'duplicate'}) }} ">
+      <i class="fas fa-copy"></i>
+    </a>
   {% endif %}
   {% if userIsAdminOrOwner %}
     <a title="{{ _t('TEMPLATES_SEE_ATTACHED_FILES') }}" href="{{ url({handler:'filemanager'}) }}" class="link-filemanager">


### PR DESCRIPTION
Cette PR permet de proposer une méthode pour faciliter la duplication des pages/fiches

**ce que ça fait**:
 - ajouter un bouton dans la barre d'édition pour les pages pour pouvoir dupliquer la page courante (uniquement si l'utilisateur a les droits d'écriture pour les nouvelles pages)
 - ajouter un bouton dans la partie des boutons d'actions pour les fiches pour pouvoir dupliquer la fiche courante (uniquement si l'utilisateur a les droits d'écriture pour les nouvelles pages ou si le paramètre `canDuplicateEntryIfNotRightToWrite` vaut `true`)
 - le bouton renvoie vers le nouveau handler `duplicate`
 - création d'un handler `duplicateiframe` pour fonctionner en `iframe`
 - ajout de ce nouveau handler dans la liste des handlers autorisés en `iframe`
 - ajout de la configuration du paramètre `canDuplicateEntryIfNotRightToWrite` dans la partie `bazar` dans la page `GererConfig`
 - le handler `duplicate`:
   - pour les pages : propose de choisir le nouveau nom de page puis affiche une interface de création de page avec le texte copié. L'utilisateurice peut ainsi modifier ou non le code avant de sauvegarder
   - pour les fiches : un formulaire de création d'une nouvelle fiche est affiché, pré-rempli. L'utilisateurice peut ainsi modifier ou non le contenu avant de sauvegarder

**pour tester**:
 - sur une page, en ayant les droits d'écriture pour les nouvelles pages, descendre et cliquer sur l'icône de copie puis suivre les instructions
 - sur une fiche, soit utiliser le bouton similaire aux pages, s'il est visible, soit utiliser le bouton dans la partie des bouton d'actions
 - modifier la valeur du paramètre `canDuplicateEntryIfNotRightToWrite` dans la partie `bazar` dans la page `GererConfig` et voir le changement de comportement pour un utilisateur non connecté (sans effet, si le wiki est déjà ouvert en écriture)


Bons tests