### PR TITLE
Fix/edit handler save metadata

### DIFF
--- a/includes/services.yaml
+++ b/includes/services.yaml
@@ -26,3 +26,6 @@ services:
   YesWiki\Core\Service\CommentService:
     tags:
       - { name: yeswiki.event_subscriber }
+  YesWiki\Core\Service\ThemeManager:
+    tags:
+      - { name: yeswiki.event_subscriber }

--- a/includes/services/PageManager.php
+++ b/includes/services/PageManager.php
@@ -282,6 +282,7 @@ class PageManager
         $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('links')} WHERE from_tag='{$this->dbService->escape($tag)}' ");
         $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('acls')} WHERE page_tag='{$this->dbService->escape($tag)}' ");
         $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('triples')} WHERE `resource`='{$this->dbService->escape($tag)}' and `property`='".TripleStore::TYPE_URI."' and `value`='".EntryManager::TRIPLES_ENTRY_ID."'");
+        $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('triples')} WHERE `resource`='{$this->dbService->escape($tag)}' and `property`='http://outils-reseaux.org/_vocabulary/metadata'");
         $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('referrers')} WHERE page_tag='{$this->dbService->escape($tag)}' ");
         $this->tagsManager->deleteAll($tag);
         

--- a/templates/handlers/edit.twig
+++ b/templates/handlers/edit.twig
@@ -25,6 +25,27 @@
     {{ renderAction('aceditor', { saveButton: true, name: 'body', value: body })|raw }}
   {% endif %}
 
+  {% if request.newpage is same as '1' and request.theme is not empty %}
+    <input type="hidden" name="newpage" value="1"/>
+    {% for key in [
+          'theme',
+          'style',
+          'squelette',
+          'bgimg',
+          'PageFooter',
+          'PageHeader',
+          'PageTitre',
+          'PageRapideHaut',
+          'PageMenuHaut',
+          'PageMenu',
+          'favorite_preset'
+          ] %}
+      {% if request[key] is not empty %}
+          <input type="hidden" name="{{key}}" value="{{request[key]}}"/>
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+
   {# Filled by tools/tags/handles/page/edit__ #}
   {# TODO: stop using all those edit__, and put directly the code here #}
   <div class="tags-container"></div>

--- a/tools/templates/handlers/page/__edit.php
+++ b/tools/templates/handlers/page/__edit.php
@@ -6,22 +6,6 @@ if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
 }
 
-// Sauvegarde des metas
-if (isset($_GET["newpage"]) && $_GET["newpage"]==1 && isset($_GET["theme"]) && !isset($this->page['metadatas']['theme'])) {
-    $metadata = [
-        'theme' => $_GET["theme"],
-        'style' => $_GET["style"] ?? CSS_PAR_DEFAUT ,
-        'squelette' => $_GET["squelette"] ?? SQUELETTE_PAR_DEFAUT ,
-        'bgimg' => $_GET["bgimg"] ?? null
-    ];
-    foreach (ThemeManager::SPECIAL_METADATA as $metadataName) {
-        if (!empty($_GET[$metadataName])) {
-            $metadata[$metadataName] = $_GET[$metadataName];
-        }
-    }
-    $this->SaveMetaDatas($this->GetPageTag(), $metadata);
-}
-
 // Si une valeur de body est passee en paramétre GET (et pas POST) on l'ajoute en titre dans la nouvelle page vierge
 if (isset($_GET["body"]) && !isset($_POST["body"])) {
     $_POST["body"] = '======'.$_GET["body"].'======';


### PR DESCRIPTION
**le souci**:
 - l'usage du handler `/edit`avec dans l'url `newpage=1&theme=...` contourne la gestion des `acls`
 - en effet, lors de la rédaction du contenu d'une fiche ou d'une page, si un ChatMot est détecté, il y a alors création automatique d'un lien contenant ce qui est évoqué ci-dessous. L'objectif est de permettre la conservation du thème et de ses réglages lors de la création d'une nouvelle page (ceci ne concerne pas les fiches)
 - Le hic est qu'actuellement le pre-handler `__edit.php` enregistre les métadonnées associées avant la création de la page et avant la vérification de l'autorisation de créer la page
 - Il y a donc une surcharge de `triples` inutilisés en base de données (il m'est arrivé d'avoir 4000 lignes concernées sur 9000 lignes dans la table des `triples`)
 
**ce que ça fait**:
 - retirer l'enregistrement des métadonnées depuis le handlers `__edit`
 - nettoyer automatiquement les métadonnées associées à une page lors de sa suppression dans `PageManager`
 - enregistrer les nouvelles métadonnées à l'aide de `ThemeManager` et uniquement après la création d'une page et si les données sont nouvelles (le critère d'enregistrement des données reste le même)
 - modifier le template `handler/edit.twig` pour que le formulaire de modification de fiche conserve les données du thème et les transmette lors de la création de la fiche

**Pour tester**:
 - créer le contenu d'une page avec un ChatMot qui correspond au nom du nouvelle page
 - cliquer sur le lien ainsi créé
 - enregistré la nouvelle page
 - vérifier l'existence des métadonnées (soit en base SQL, soit avec le handler `/loadmetadatas`
