### PR TITLE
fix(DynTable): does not use crypto.randomUUID

### DIFF
--- a/tools/bazar/presentation/javascripts/components/BazarTable.js
+++ b/tools/bazar/presentation/javascripts/components/BazarTable.js
@@ -265,7 +265,7 @@ let componentParams = {
         },
         getUuid(){
             if (this.uuid === null){
-                this.uuid = crypto.randomUUID()
+                this.uuid = Date.now() + '-' + Math.round(Math.random()*10000)
             }
             return this.uuid
         },

--- a/tools/bazar/presentation/javascripts/components/DynTable.js
+++ b/tools/bazar/presentation/javascripts/components/DynTable.js
@@ -175,7 +175,7 @@ export default {
         },
         getUuid(){
             if (this.uuid === null){
-                return crypto.randomUUID()
+                return Date.now() + '-' + Math.round(Math.random()*10000)
             }
             return this.uuid
         },


### PR DESCRIPTION
**le souci**:
 - l'usage de tableau dynamique sur un site non `https` (contexte non secure) ne fonctionne pas
 - la raison est l'usage des `crypto.randomUUID()`

**ce que fait la PR**:
 - générer un UUID dont le critère d'unicité est faible mais c'est suffisant pour l'usage
