### PR TITLE
Add a support for ARM64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
 
     db:
         image: mysql:5.6
+        platform: linux/amd64
         container_name: db
         volumes:
             - ./.db:/var/lib/mysql


### PR DESCRIPTION
## Description of pull request 
The former Docker-compose image doesnt support ARM64 system (in my case, a M1 Mac). A support of this kind of system have been added then.
