### PR TITLE
fix(ConsoleServiceTest): wait 1 second more to wait the result to test

### DIFF
--- a/tests/includes/services/ConsoleServiceTest.php
+++ b/tests/includes/services/ConsoleServiceTest.php
@@ -138,7 +138,7 @@ class ConsoleServiceTest extends YesWikiTestCase
             "-w",1,
         ]);
         $process->wait();
-        sleep(2);
+        sleep(3);
 
         $content = file_get_contents($tmp_path);
         unlink($tmp_path);


### PR DESCRIPTION
Petit correctif pour ajuster le temps d'attente de résultat pour les tests de `ConsoleService` sinon ça peut donner un faux négatif
