### PR TITLE
fix(conditionschecking): work for checkboxfiche

### DIFF
--- a/tools/bazar/presentation/javascripts/bazar-fields/conditionschecking.js
+++ b/tools/bazar/presentation/javascripts/bazar-fields/conditionschecking.js
@@ -527,7 +527,7 @@ const ConditionsChecking = {
     if (result.type != '') {
       return result
     }
-    const node = $(`div[class*="group-checkbox-"][class*="${fieldName}"]`).filter(
+    const node = $(`div[class*="group-checkbox-"][class*="${fieldName}"],ul[class*="group-checkbox-"][class*="${fieldName}"]`).filter(
       function(index) {
         const classes = $(this).attr('class').split(' ')
         return classes.filter((className) => className.slice(-fieldName.length) == fieldName).length > 0


### PR DESCRIPTION
fix #1132

effectivement, pour `checkboxfiche`, il y a utilisation de l'élément html `<ul>` au lieu de `<div>` et ça n'était pas attrapé par le code `js` de `conditionschecking`. Je propose de corriger ceci.