### PR TITLE
Fix issue with multiple php versions on YUNoHost

### DIFF
--- a/includes/services/ConsoleService.php
+++ b/includes/services/ConsoleService.php
@@ -37,7 +37,10 @@ class ConsoleService
      */
     public function startConsoleAsync(string $command, array $args = [], string $subfolder = "", bool $newConsole = true, int $timeoutInSec = 60): ?Process
     {
-        $phpBinaryPath = $this->phpBinaryFinder->find();
+        $phpBinaryPath = getenv('ASYNC_PHP_BINARY');
+        if(!$phpBinaryPath) {
+            $phpBinaryPath = $this->phpBinaryFinder->find();
+        }
         $newCommand = $phpBinaryPath;
         $newArgs = [self::CONSOLE_BIN,$command];
         foreach ($args as $arg) {


### PR DESCRIPTION
## Description of pull request / Description de la demande d'ajout
Get php binary for async processes from environment variable ASYC_PHP_BINARY if it exists
This variable will be defined in php-fpm pool configuration on YUNoHost side
