### PR TITLE
fix(extension): allow import class from extension with dash in folder

### DIFF
--- a/includes/services/Performer.php
+++ b/includes/services/Performer.php
@@ -125,7 +125,7 @@ class Performer
         /* extract extension name from path to allow namespace */
         if (preg_match('/(?:tools[\\\\\\/]([A-Za-z0-9_\\-]+)|(custom))[\\\\\/][a-zA-Z0-9_\\\\\/\\-]+.php$/', $object['filePath'], $matches)) {
             $extensionName = empty($matches[1]) ? $matches[2]:$matches[1];
-            $classNameWithNamespace = "YesWiki\\".ucfirst(strtolower($extensionName))."\\".$object['baseName'];
+            $classNameWithNamespace = "YesWiki\\".StringUtilService::folderToNamespace($extensionName)."\\".$object['baseName'];
             if (class_exists($classNameWithNamespace)) {
                 $className = $classNameWithNamespace;
             }

--- a/includes/services/StringUtilService.php
+++ b/includes/services/StringUtilService.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace YesWiki\Core\Service;
+
+class StringUtilService
+{
+    public static function folderToNamespace(string $folder): string
+    {
+        if(preg_match_all('/[a-zA-Z0-9]+/', $folder, $matches) === false) {
+            return '';
+        }
+        return implode('', array_map(function ($input) {return ucfirst(strtolower($input));}, $matches[0]));
+    }
+}

--- a/tests/includes/services/StringUtilServiceTest.php
+++ b/tests/includes/services/StringUtilServiceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace YesWiki\Test\Core\Service;
+
+use PHPUnit\Framework\TestCase;
+use YesWiki\Core\Service\StringUtilService;
+
+require_once 'includes/services/StringUtilService.php';
+
+class StringUtilServiceTest extends TestCase
+{
+    /**
+     * @dataProvider folderToNamespaceProvider
+     */
+    public function testFolderToNamespace(string $input, string $expected)
+    {
+        $this->assertEquals(
+            $expected,
+            StringUtilService::folderToNamespace($input),
+            'Unable to convert : ' . $input
+        );
+    }
+
+    public function folderToNamespaceProvider()
+    {
+        return [
+            ['', ''],
+            ['.', ''],
+            ['foo', 'Foo'],
+            ['Foo', 'Foo'],
+            ['foo1', 'Foo1'],
+            ['foO', 'Foo'],
+            ['foo.bar', 'FooBar'],
+            ['foo-bar', 'FooBar'],
+            ['foo_bar', 'FooBar'],
+            ['foo~bar', 'FooBar'],
+        ];
+    }
+}


### PR DESCRIPTION
Yeswiki is unable to autoload load class from extension with dash or other namespaces invalid characters in his folder. The `createPerformable` function does not convert some caracters which are valid in folder name but not in namespace.

The fix use a regexp to extract alphanumeric characters from folder name and create a pascal case string without separators

