### PR TITLE
fix(login/modal): position of text in dropdown

### DIFF
--- a/tools/login/templates/modal.twig
+++ b/tools/login/templates/modal.twig
@@ -30,7 +30,7 @@
 {% block formTitle %}{% endblock %}
 
 {% block notConnected %}
-    <a href="#LoginModal" role="button" class="btn-icon navbar-btn {{ not nobtn ? 'btn btn-default ' ~ btnclass : '' }}" data-toggle="modal" data-placement="bottom" title="{{ _t('LOGIN_LOGIN') }}" data-tooltip="tooltip">
+    <a href="#LoginModal" role="button" class="navbar-btn {{ not nobtn ? 'btn btn-default ' ~ btnclass : '' }}" data-toggle="modal" data-placement="bottom" title="{{ _t('LOGIN_LOGIN') }}" data-tooltip="tooltip">
         <i class="fa fa-sign-in-alt"></i><span class="login-text"> {{ _t('LOGIN_LOGIN') }}</span>
     </a>
     <div class="modal fade" id="LoginModal" tabindex="-1" role="dialog" aria-labelledby="LoginModalLabel" aria-hidden="true">


### PR DESCRIPTION
**contexte**:
les dernières modification du fichier 
[tools/login/templates/modal.twig](https://github.com/YesWiki/yeswiki/blob/doryphore-dev/tools/login/templates/modal.twig) ont ajouter un bouton plus joli pour se connecter MAIS pour les sites qui ont conservé le bouton de connexion dans le menu dropdown, l'affichage du bouton "se connecter" est décalé.

**correctif**:
 - je propose juste de retirer la classe `btn-icon` qui est la classe qui pose problème dans l'affichage `dropdown`
 - ceci ajouter un très léger décalage du bouton dans l'affichage en dehors du `dropdown` qui est à peine perceptible à l'oeil nul

**pour tester**:
 - mettre `{{login template="modal.tpl.html"}}` dans le menu dropdown de `PageRapideHaut`
 - afficher une page avec le thème margot sans être connecté
 - cliquer sur la roue crantée
 - le bouton de connexion devrait être maintenant positionné comme les autres