### PR TITLE
Auto update migrations use filter input

### DIFF
--- a/includes/YesWikiMigration.php
+++ b/includes/YesWikiMigration.php
@@ -7,16 +7,26 @@ use YesWiki\Wiki;
 
 abstract class YesWikiMigration
 {
-  protected $wiki;
-  protected $dbService;
+    protected $wiki;
+    protected $dbService;
 
-  public function setWiki(Wiki $wiki): void
-  {
-    $this->wiki = $wiki;
-  }
+    public function setWiki(Wiki $wiki): void
+    {
+        $this->wiki = $wiki;
+    }
 
-  public function setDbService(DbService $dbService): void
-  {
-    $this->dbService = $dbService;
-  }
+    public function setDbService(DbService $dbService): void
+    {
+        $this->dbService = $dbService;
+    }
+
+    /**
+     * give service from name
+     * @param string $className
+     * @return mixed
+     */
+    protected function getService(string $className)
+    {
+        return $this->wiki->services->get($className);
+    }
 }

--- a/includes/controllers/ApiController.php
+++ b/includes/controllers/ApiController.php
@@ -28,6 +28,7 @@ use YesWiki\Core\Service\CommentService;
 use YesWiki\Core\Service\ReactionManager;
 use YesWiki\Core\Service\TripleStore;
 use YesWiki\Core\YesWikiController;
+use YesWiki\Security\Controller\SecurityController;
 
 class ApiController extends YesWikiController
 {
@@ -801,14 +802,11 @@ class ApiController extends YesWikiController
                 Response::HTTP_BAD_REQUEST
             );
         } else {
-            $property = filter_input($method, 'property', FILTER_UNSAFE_RAW);
-            $property = in_array($property, [false,null], true) ? "" : htmlspecialchars(strip_tags($property));
+            $property = $this->getService(SecurityController::class)->filterInput($method, 'property', FILTER_SANITIZE_STRING);
             if (empty($property)) {
                 $property = null;
             }
-
-            $username = filter_input($method, 'user', FILTER_UNSAFE_RAW);
-            $username = in_array($username, [false,null], true) ? "" : htmlspecialchars(strip_tags($username));
+            $username = $this->getService(SecurityController::class)->filterInput($method, 'user', FILTER_SANITIZE_STRING);
             if (empty($username)) {
                 if (!$this->wiki->UserIsAdmin()) {
                     $username = $this->getService(AuthController::class)->getLoggedUser()['name'];

--- a/includes/controllers/ApiController.php
+++ b/includes/controllers/ApiController.php
@@ -39,34 +39,34 @@ class ApiController extends YesWikiController
         $output = '<h1>YesWiki API</h1>';
 
         $urlUser = $this->wiki->Href('', 'api/users');
-        $output .= '<h2>'._t('USERS').'</h2>'."\n".
-            '<p><code>GET '.$urlUser.'</code></p>';
+        $output .= '<h2>' . _t('USERS') . '</h2>' . "\n" .
+            '<p><code>GET ' . $urlUser . '</code></p>';
 
         $urlGroup = $this->wiki->Href('', 'api/groups');
-        $output .= '<h2>'._t('GROUPS').'</h2>'."\n".
-            '<p><code>GET '.$urlGroup.'</code></p>';
+        $output .= '<h2>' . _t('GROUPS') . '</h2>' . "\n" .
+            '<p><code>GET ' . $urlGroup . '</code></p>';
 
         $urlPages = $this->wiki->Href('', 'api/pages');
-        $output .= '<h2>'._t('PAGES').'</h2>'."\n".
-            '<p><code>GET '.$urlPages.'</code></p>';
+        $output .= '<h2>' . _t('PAGES') . '</h2>' . "\n" .
+            '<p><code>GET ' . $urlPages . '</code></p>';
         $urlPagesComments = $this->wiki->Href('', 'api/pages/{pageTag}/comments');
-        $output .= '<p><code>GET '.$urlPagesComments.'</code></p>';
+        $output .= '<p><code>GET ' . $urlPagesComments . '</code></p>';
 
         $urlComments = $this->wiki->Href('', 'api/comments');
-        $output .= '<h2>'._t('COMMENTS').'</h2>'."\n".
-            '<p><code>GET '.$urlComments.'</code></p>';
+        $output .= '<h2>' . _t('COMMENTS') . '</h2>' . "\n" .
+            '<p><code>GET ' . $urlComments . '</code></p>';
 
         $urlTriples = $this->wiki->Href('', 'api/triples/{resource}', ['property' => 'http://outils-reseaux.org/_vocabulary/type', 'user' => 'username'], false);
-        $output .= '<h2>'._t('TRIPLES').'</h2>'."\n".
-            '<p><code>GET '.$urlTriples.'</code></p>';
+        $output .= '<h2>' . _t('TRIPLES') . '</h2>' . "\n" .
+            '<p><code>GET ' . $urlTriples . '</code></p>';
 
         $urlArchives = $this->wiki->Href('', 'api/archives');
-        $output .= '<h2>'._t('ARCHIVES').'</h2>'."\n".
-            '<p>'._t('ONLY_FOR_ADMINS').'</p>'.
-            '<p><code>GET '.$urlArchives.'</code></p>'.
-            '<p><code>GET '.$urlArchives.'/{id}</code></p>'.
-            '<p><code>POST '.$urlArchives.'</code></p>'.
-            '<p><code>POST '.$urlArchives.'/{id}</code></p>';
+        $output .= '<h2>' . _t('ARCHIVES') . '</h2>' . "\n" .
+            '<p>' . _t('ONLY_FOR_ADMINS') . '</p>' .
+            '<p><code>GET ' . $urlArchives . '</code></p>' .
+            '<p><code>GET ' . $urlArchives . '/{id}</code></p>' .
+            '<p><code>POST ' . $urlArchives . '</code></p>' .
+            '<p><code>POST ' . $urlArchives . '/{id}</code></p>';
 
         // TODO use annotations to document the API endpoints
         $extensions = $this->wiki->extensions;
@@ -86,7 +86,7 @@ class ApiController extends YesWikiController
                 }
             }
             if (empty($response)) {
-                $func = 'documentation'.ucfirst(strtolower($extension));
+                $func = 'documentation' . ucfirst(strtolower($extension));
                 if (function_exists($func)) {
                     $output .= $func();
                 }
@@ -95,7 +95,7 @@ class ApiController extends YesWikiController
             }
         }
 
-        $output = $this->wiki->Header().'<div class="api-container">'.$output.'</div>'.$this->wiki->Footer();
+        $output = $this->wiki->Header() . '<div class="api-container">' . $output . '</div>' . $this->wiki->Footer();
 
         return new Response($output);
     }
@@ -553,7 +553,7 @@ class ApiController extends YesWikiController
                                 // test if limits wherer put
                                 if (!empty($params['maxreaction']) && count($userReactions) >= $params['maxreaction']) {
                                     return new ApiResponse(
-                                        ['error' => 'Seulement '.$params['maxreaction'].' réaction(s) possible(s). Vous pouvez désélectionner une de vos réactions pour changer.'],
+                                        ['error' => 'Seulement ' . $params['maxreaction'] . ' réaction(s) possible(s). Vous pouvez désélectionner une de vos réactions pour changer.'],
                                         Response::HTTP_UNAUTHORIZED
                                     );
                                 } else {
@@ -581,7 +581,7 @@ class ApiController extends YesWikiController
                             }
                         }
                         return new ApiResponse(
-                            ['error' => "'".strval($_POST['reactionid']) . "' n'est pas une réaction déclarée sur la page '".strval($_POST['pagetag'])."'"],
+                            ['error' => "'" . strval($_POST['reactionid']) . "' n'est pas une réaction déclarée sur la page '" . strval($_POST['pagetag']) . "'"],
                             Response::HTTP_INTERNAL_SERVER_ERROR
                         );
                     } else {

--- a/includes/controllers/ArchiveController.php
+++ b/includes/controllers/ArchiveController.php
@@ -26,7 +26,7 @@ class ArchiveController extends YesWikiController
         $filePath = $this->archiveService->getFilePath($id);
         if (empty($filePath)) {
             return new ApiResponse(
-                ['error' => "Not existing file ".htmlspecialchars($id)],
+                ['error' => "Not existing file " . htmlspecialchars($id)],
                 Response::HTTP_BAD_REQUEST
             );
         } else {

--- a/includes/controllers/ArchiveController.php
+++ b/includes/controllers/ArchiveController.php
@@ -7,6 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 use YesWiki\Core\ApiResponse;
 use YesWiki\Core\Service\ArchiveService;
 use YesWiki\Core\YesWikiController;
+use YesWiki\Security\Service\SecurityController;
 
 class ArchiveController extends YesWikiController
 {
@@ -63,8 +64,7 @@ class ArchiveController extends YesWikiController
 
     public function manageArchiveAction(?string $id = null)
     {
-        $action = filter_input(INPUT_POST, 'action', FILTER_UNSAFE_RAW);
-        $action = in_array($action, [false,null], true) ? "" : htmlspecialchars(strip_tags($action));
+        $action = $this->getService(SecurityController::class)->filterInput(INPUT_POST, 'action', FILTER_SANITIZE_STRING);
         switch ($action) {
             case 'delete':
                 if (!empty($id)) {

--- a/includes/controllers/CsrfTokenController.php
+++ b/includes/controllers/CsrfTokenController.php
@@ -7,6 +7,7 @@ use Symfony\Component\Security\Csrf\Exception\TokenNotFoundException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use YesWiki\Core\YesWikiController;
+use YesWiki\Security\Controller\SecurityController;
 
 class CsrfTokenController extends YesWikiController
 {
@@ -37,13 +38,10 @@ class CsrfTokenController extends YesWikiController
         }
         switch ($inputType) {
             case 'GET':
-                $inputToken = filter_input(INPUT_GET, $inputKey, FILTER_UNSAFE_RAW);
-                $inputToken = in_array($inputToken, [false,null], true) ? $inputToken : htmlspecialchars(strip_tags($inputToken));
+                $inputToken = $this->getService(SecurityController::class)->filterInput(INPUT_GET, $inputKey, FILTER_SANITIZE_STRING);
                 break;
-
             case 'POST':
-                $inputToken = filter_input(INPUT_POST, $inputKey, FILTER_UNSAFE_RAW);
-                $inputToken = in_array($inputToken, [false,null], true) ? $inputToken : htmlspecialchars(strip_tags($inputToken));
+                $inputToken = $this->getService(SecurityController::class)->filterInput(INPUT_POST, $inputKey, FILTER_SANITIZE_STRING);
                 break;
 
             default:

--- a/includes/migrations/20240425000000_CercopitequePostInstall.php
+++ b/includes/migrations/20240425000000_CercopitequePostInstall.php
@@ -3,12 +3,14 @@
 use YesWiki\AutoUpdate\Service\AutoUpdateService;
 use YesWiki\Core\Service\ConfigurationService;
 use YesWiki\Core\YesWikiMigration;
+use YesWiki\Security\Service\SecurityController;
 
 class CercopitequePostInstall extends YesWikiMigration
 {
     public function run()
     {
-        if (isset($_GET['previous_version']) && $_GET['previous_version'] == 'cercopitheque') {
+        $previousVersion = $this->getService(SecurityController::class)->filterInput(INPUT_GET, 'previous_version', FILTER_SANITIZE_STRING);
+        if ($previousVersion === 'cercopitheque') {
 
             $config = $this->getService(ConfigurationService::class)->getConfiguration('wakka.config.php');
             $config->load();

--- a/includes/migrations/20240425000000_CercopitequePostInstall.php
+++ b/includes/migrations/20240425000000_CercopitequePostInstall.php
@@ -1,4 +1,5 @@
 <?php
+
 use YesWiki\AutoUpdate\Service\AutoUpdateService;
 use YesWiki\Core\Service\ConfigurationService;
 use YesWiki\Core\YesWikiMigration;
@@ -9,14 +10,14 @@ class CercopitequePostInstall extends YesWikiMigration
     {
         if (isset($_GET['previous_version']) && $_GET['previous_version'] == 'cercopitheque') {
 
-            $config = $this->wiki->services->get(ConfigurationService::class)->getConfiguration('wakka.config.php');
+            $config = $this->getService(ConfigurationService::class)->getConfiguration('wakka.config.php');
             $config->load();
 
             // check favorite_theme
             // If default theme was used, install new yeswikicerco extension to keep same look and feel
             $favoriteThemefromFile = $config['favorite_theme'] ?? '';
             if (empty($favoriteThemefromFile) || $favoriteThemefromFile == 'yeswiki') {
-                $this->wiki->services->get(AutoUpdateService::class)->upgrade('yeswikicerco');
+                $this->getService(AutoUpdateService::class)->upgrade('yeswikicerco');
 
                 $config['favorite_theme'] = 'yeswikicerco';
                 $config['favorite_style'] = $config['favorite_style'] ?? 'gray.css';

--- a/tools/attach/libs/attach.lib.php
+++ b/tools/attach/libs/attach.lib.php
@@ -5,6 +5,7 @@
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use YesWiki\Core\Service\LinkTracker;
 use YesWiki\Core\Service\HtmlPurifierService;
+use YesWiki\Security\Controller\SecurityController;
 
 if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
@@ -959,7 +960,9 @@ if (!class_exists('attach')) {
         public function fmDelete(string $rawFileName = "")
         {
             $path = $this->GetUploadPath();
-            $rawFileName = empty($rawFileName) ? filter_input(INPUT_GET, 'file', FILTER_SANITIZE_FULL_SPECIAL_CHARS) : $rawFileName;
+            $rawFileName = empty($rawFileName)
+                ? $this->wiki->services->get(SecurityController::class)->filterInput(INPUT_GET, 'file', FILTER_SANITIZE_FULL_SPECIAL_CHARS, string)
+                : $rawFileName;
             $filename = $path . '/' . basename($rawFileName);
             if (!empty($rawFileName) && file_exists($filename)) {
                 $trash = $filename . 'trash' . $this->getDate();

--- a/tools/attach/libs/attach.lib.php
+++ b/tools/attach/libs/attach.lib.php
@@ -107,7 +107,7 @@ if (!class_exists('attach')) {
          */
         public function GetScriptPath()
         {
-            return $this->wiki->getBaseUrl().'/';
+            return $this->wiki->getBaseUrl() . '/';
             // if (preg_match("/.(php)$/i", $_SERVER["PHP_SELF"])) {
             //     $a = explode('/', $_SERVER["PHP_SELF"]);
             //     $a[count($a) - 1] = '';
@@ -501,10 +501,10 @@ if (!class_exists('attach')) {
                 if ($linkParts) {
                     $this->wiki->services->get(LinkTracker::class)->forceAddIfNotIncluded($linkParts['tag']);
                 }
-                $link = '<a href="'.$this->wiki->generateLink($this->link).'"'.$classDataForLinks.'>';
+                $link = '<a href="' . $this->wiki->generateLink($this->link) . '"' . $classDataForLinks . '>';
             } else {
                 if (empty($this->nofullimagelink) or !$this->nofullimagelink) {
-                    $link = '<a href="' . $this->GetScriptPath() . $fullFilename . '"'.$classDataForLinks.'>';
+                    $link = '<a href="' . $this->GetScriptPath() . $fullFilename . '"' . $classDataForLinks . '>';
                 }
             }
             $caption = '';
@@ -518,12 +518,12 @@ if (!class_exists('attach')) {
             $data = '';
             if (is_array($this->data)) {
                 foreach ($this->data as $key => $value) {
-                    $data .= ' data-'.$key.'="'.$value.'"';
+                    $data .= ' data-' . $key . '="' . $value . '"';
                 }
             }
 
             $notAligned = (strpos($this->classes, 'left') === false && strpos($this->classes, 'right') == false  && strpos($this->classes, 'center') == false);
-            $output = ($notAligned ? '<div>' : '').(isset($link) ? $link : '')."<figure class=\"$this->classes\" $data>$img$caption$legend</figure>".(isset($link) ? '</a>' : '').($notAligned ? '</div>' : '');
+            $output = ($notAligned ? '<div>' : '') . (isset($link) ? $link : '') . "<figure class=\"$this->classes\" $data>$img$caption$legend</figure>" . (isset($link) ? '</a>' : '') . ($notAligned ? '</div>' : '');
 
             echo $output;
             //$this->showUpdateLink();
@@ -541,9 +541,9 @@ if (!class_exists('attach')) {
         public function showAsVideo($fullFilename)
         {
             $output = $this->wiki->format(
-                '{{player url="'.$this->wiki->getBaseUrl().'/'.$fullFilename.'" type="video" '.
-                'height="'.(!empty($height) ? $height : '300px').'" '.
-                'width="'.(!empty($width) ? $width : '400px').'"}}'
+                '{{player url="' . $this->wiki->getBaseUrl() . '/' . $fullFilename . '" type="video" ' .
+                'height="' . (!empty($height) ? $height : '300px') . '" ' .
+                'width="' . (!empty($width) ? $width : '400px') . '"}}'
             );
             echo $output;
             $this->showUpdateLink();
@@ -551,7 +551,7 @@ if (!class_exists('attach')) {
         // Affiche le fichier liee comme un fichier audio
         public function showAsAudio($fullFilename)
         {
-            $output = $this->wiki->format('{{player url="'.$this->wiki->getBaseUrl().'/'.$fullFilename.'" type="audio"}}');
+            $output = $this->wiki->format('{{player url="' . $this->wiki->getBaseUrl() . '/' . $fullFilename . '" type="audio"}}');
             echo $output;
             $this->showUpdateLink();
         }
@@ -560,7 +560,7 @@ if (!class_exists('attach')) {
         public function showAsFreeMindMindMap($fullFilename)
         {
             $output = $this->wiki->format(
-                '{{player url="'.$this->wiki->getBaseUrl().'/'.$fullFilename.'" '.
+                '{{player url="' . $this->wiki->getBaseUrl() . '/' . $fullFilename . '" ' .
                 'height="' . (!empty($height) ? $height : '650px') . '" ' .
                 'width="' . (!empty($width) ? $width : '100%') . '"}}'
             );
@@ -569,9 +569,7 @@ if (!class_exists('attach')) {
         }
 
         // Affiche le fichier liee comme un fichier mind map  freemind
-        public function showAsWma($fullFilename)
-        {
-        }
+        public function showAsWma($fullFilename) {}
 
         // End Paste
 
@@ -752,10 +750,10 @@ if (!class_exists('attach')) {
                 case 5:
                     $t = array();
                     foreach ($this->wiki->config['authorized-extensions'] as $ext => $des) {
-                        $t[] = $ext.' ('.$des.')';
+                        $t[] = $ext . ' (' . $des . ')';
                     }
                     $these = implode(', ', $t);
-                    echo "<div class=\"alert alert-error alert-danger\">". _t('ERROR_NOT_AUTHORIZED_EXTENSION'). $these . '.</div>';
+                    echo "<div class=\"alert alert-error alert-danger\">" . _t('ERROR_NOT_AUTHORIZED_EXTENSION') . $these . '.</div>';
                     break;
             }
             echo $this->wiki->Format(_t('ATTACH_BACK_TO_PAGE') . " " . $this->wiki->GetPageTag());
@@ -789,7 +787,7 @@ if (!class_exists('attach')) {
                 header('Content-Type: application/octet-stream; name="' . $dlFilename . '"'); //This should work for the rest
                 header('Content-Type: application/octetstream; name="' . $dlFilename . '"'); //This should work for IE & Opera
                 if (in_array(preg_replace("/^.*\.([^.]+$)/", "$1", $dlFilename), ['txt','md','png','svg','jpeg','jpg','mp3'])) {
-                    header('Content-Type: '.mime_content_type($fullFilename).'; name="' . $dlFilename . '"');
+                    header('Content-Type: ' . mime_content_type($fullFilename) . '; name="' . $dlFilename . '"');
                 }
                 header('Content-Disposition: attachment; filename="' . $dlFilename . '"');
                 header("Content-Description: File Transfer");
@@ -982,18 +980,18 @@ if (!class_exists('attach')) {
                 $filenamesToDelete[] = $this->getResizedFilename($filename, "[0-9][0-9][0-9]", "[0-9][0-9][0-9][0-9]", "crop");
                 $filenamesToDelete[] = $this->getResizedFilename($filename, "[0-9][0-9][0-9][0-9]", "[0-9][0-9][0-9][0-9]", "crop");
                 // old Image Field
-                $filenamesToDelete[] = $cachePath."/vignette_".basename($filename);
-                $filenamesToDelete[] = $cachePath."/image_".basename($filename);
+                $filenamesToDelete[] = $cachePath . "/vignette_" . basename($filename);
+                $filenamesToDelete[] = $cachePath . "/image_" . basename($filename);
                 // old agenda.tpl.html|blog.tpl.html|damier.tpl.html|materiel-card.tpl.html|news.tpl.html|photobox.tpl.html|trombinoscope.tpl.html
-                $filenamesToDelete[] = $cachePath."/image_[0-9][0-9][0-9][x_][0-9][0-9][0-9]_".basename($filename);
-                $filenamesToDelete[] = $cachePath."/image_[0-9][0-9][0-9][x_][0-9][0-9][0-9][0-9]_".basename($filename);
-                $filenamesToDelete[] = $cachePath."/image_[0-9][0-9][0-9][0-9][x_][0-9][0-9][0-9]_".basename($filename);
-                $filenamesToDelete[] = $cachePath."/image_[0-9][0-9][0-9][0-9][x_][0-9][0-9][0-9][0-9]_".basename($filename);
+                $filenamesToDelete[] = $cachePath . "/image_[0-9][0-9][0-9][x_][0-9][0-9][0-9]_" . basename($filename);
+                $filenamesToDelete[] = $cachePath . "/image_[0-9][0-9][0-9][x_][0-9][0-9][0-9][0-9]_" . basename($filename);
+                $filenamesToDelete[] = $cachePath . "/image_[0-9][0-9][0-9][0-9][x_][0-9][0-9][0-9]_" . basename($filename);
+                $filenamesToDelete[] = $cachePath . "/image_[0-9][0-9][0-9][0-9][x_][0-9][0-9][0-9][0-9]_" . basename($filename);
                 // old templates.functions.php getImageFromBody
-                $filenamesToDelete[] = $cachePath."/[0-9][0-9][0-9]x[0-9][0-9][0-9]-".basename($filename);
-                $filenamesToDelete[] = $cachePath."/[0-9][0-9][0-9][0-9]x[0-9][0-9][0-9]-".basename($filename);
-                $filenamesToDelete[] = $cachePath."/[0-9][0-9][0-9]x[0-9]0-9][0-9][0-9]-".basename($filename);
-                $filenamesToDelete[] = $cachePath."/[0-9][0-9][0-9][0-9]x[0-9]0-9][0-9][0-9]-".basename($filename);
+                $filenamesToDelete[] = $cachePath . "/[0-9][0-9][0-9]x[0-9][0-9][0-9]-" . basename($filename);
+                $filenamesToDelete[] = $cachePath . "/[0-9][0-9][0-9][0-9]x[0-9][0-9][0-9]-" . basename($filename);
+                $filenamesToDelete[] = $cachePath . "/[0-9][0-9][0-9]x[0-9]0-9][0-9][0-9]-" . basename($filename);
+                $filenamesToDelete[] = $cachePath . "/[0-9][0-9][0-9][0-9]x[0-9]0-9][0-9][0-9]-" . basename($filename);
                 foreach ($filenamesToDelete as $path) {
                     array_map('unlink', glob($path));
                 }
@@ -1039,14 +1037,14 @@ if (!class_exists('attach')) {
             if (!empty($file['name'])) {
                 if ($this->isSafeMode) {
                     $currentTag = $this->wiki->GetPageTag();
-                    $prefixFileName = substr($file['realname'], 0, strlen($currentTag)) == $currentTag ? $currentTag."_" : "";
+                    $prefixFileName = substr($file['realname'], 0, strlen($currentTag)) == $currentTag ? $currentTag . "_" : "";
                     $file_vignette = $file['path'] . '/' . $prefixFileName . $file['name'] . "_vignette_" . $width . '_' . $height . '_' . $file['datepage'] . '_' . $file['dateupload'] . '.' . $file['ext'];
                 } else {
                     $file_vignette = $file['path'] . '/' . $file['name'] . "_vignette_" . $width . '_' . $height . '_' . $file['datepage'] . '_' . $file['dateupload'] . '.' . $file['ext'];
                 }
             } else {
                 $pathInfo = pathinfo($fullFilename);
-                $file_vignette = "{$file['path']}/{$pathInfo['filename']}_vignette_{$width}_{$height}".(isset($pathInfo['extension']) ? ".{$pathInfo['extension']}" : '');
+                $file_vignette = "{$file['path']}/{$pathInfo['filename']}_vignette_{$width}_{$height}" . (isset($pathInfo['extension']) ? ".{$pathInfo['extension']}" : '');
             }
 
             return $file_vignette;
@@ -1109,7 +1107,7 @@ if (!class_exists('attach')) {
                     $ext = pathinfo($image_src)['extension'];
                     do {
                         $tempFile = tmpfile();
-                        $tempFileName = stream_get_meta_data($tempFile)['uri'].".$ext";
+                        $tempFileName = stream_get_meta_data($tempFile)['uri'] . ".$ext";
                         unlink(stream_get_meta_data($tempFile)['uri']);
                     } while (file_exists($tempFileName));
                     $imgTrans->target_path = $tempFileName;

--- a/tools/bazar/fields/FileField.php
+++ b/tools/bazar/fields/FileField.php
@@ -64,8 +64,10 @@ class FileField extends BazarField
                 if ($this->isAllowedToDeleteFile($entry, $value)) {
                     if (substr($value, 0, strlen($this->defineFilePrefix($entry))) == $this->defineFilePrefix($entry)) {
                         $attach = $this->getAttach();
-                        $rawFileName = filter_input(INPUT_GET, 'delete_file', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-                        $attach->fmDelete($rawFileName);
+                        $rawFileName = $this->getService(SecurityController::class)->filterInput(INPUT_GET, 'delete_file', FILTER_SANITIZE_FULL_SPECIAL_CHARS, 'string');
+                        if (!empty($rawFileName)) {
+                            $attach->fmDelete($rawFileName);
+                        }
                     } else {
                         // do not delete file if not same entry name (only remove from this entry)
                         $deletedFile = true;

--- a/tools/bazar/fields/FileField.php
+++ b/tools/bazar/fields/FileField.php
@@ -77,14 +77,14 @@ class FileField extends BazarField
             }
         }
         return ($alertMessage ?? '') . $this->render('@bazar/inputs/file.twig', (
-            empty($value) ||  !file_exists($this->getBasePath().  $value) || $deletedFile
+            empty($value) ||  !file_exists($this->getBasePath() . $value) || $deletedFile
             ? [
                 'maxSize' => $this->maxSize
             ]
             : [
                 'value' => $value,
                 'shortFileName' => $this->getShortFileName($value),
-                'fileUrl' => $this->getBasePath().  $value,
+                'fileUrl' => $this->getBasePath() . $value,
                 'deleteUrl' => empty($entry) ? '' : $this->getWiki()->href('edit', $entry['id_fiche'], ['delete_file' => $value], false),
                 'isAllowedToDeleteFile' => empty($entry) ? false : $this->isAllowedToDeleteFile($entry, $value)
             ]
@@ -114,17 +114,17 @@ class FileField extends BazarField
                     move_uploaded_file($_FILES[$this->propertyName]['tmp_name'], $filePath);
                     chmod($filePath, 0755);
                 } else {
-                    echo _t('BAZ_FILE_ALREADY_EXISTING').'<br />';
+                    echo _t('BAZ_FILE_ALREADY_EXISTING') . '<br />';
                 }
             } else {
-                echo _t('BAZ_NOT_AUTHORIZED_FILE').'<br />';
+                echo _t('BAZ_NOT_AUTHORIZED_FILE') . '<br />';
 
                 return [$this->propertyName => ''];
             }
 
             return [$this->propertyName => basename($filePath)];
         } elseif (!empty($value)) {
-            return [$this->propertyName => file_exists($this->getBasePath(). $value) ? $value : ''];
+            return [$this->propertyName => file_exists($this->getBasePath() . $value) ? $value : ''];
         } else {
             return [$this->propertyName => ''];
         }
@@ -135,13 +135,13 @@ class FileField extends BazarField
         $value = $this->getValue($entry);
 
         $basePath = $this->getBasePath() ;
-        if (!empty($value) && file_exists($basePath.$value)) {
+        if (!empty($value) && file_exists($basePath . $value)) {
             $shortFileName = $this->getShortFileName($value);
             return $this->render('@bazar/fields/file.twig', [
                 'value' => $value,
                 'fileUrl' => ($shortFileName == $value)
-                    ? $this->getWiki()->getBaseUrl().'/'.$basePath . $value
-                    : $this->getWiki()->Href('download', $entry['id_fiche']."_".$this->getPropertyName(), ['file' => $value], false),
+                    ? $this->getWiki()->getBaseUrl() . '/' . $basePath . $value
+                    : $this->getWiki()->Href('download', $entry['id_fiche'] . "_" . $this->getPropertyName(), ['file' => $value], false),
                 'shortFileName' => $shortFileName,
             ]);
         }
@@ -168,7 +168,7 @@ class FileField extends BazarField
      */
     protected function defineFilePrefix(array $entry)
     {
-        return $entry['id_fiche'].'_'.$this->getPropertyName().'_';
+        return $entry['id_fiche'] . '_' . $this->getPropertyName() . '_';
     }
 
     /**

--- a/tools/bazar/handlers/RssHandler.php
+++ b/tools/bazar/handlers/RssHandler.php
@@ -23,21 +23,21 @@ class RssHandler extends YesWikiHandler
             $id = in_array($id, [false,null], true) ? "" : htmlspecialchars(strip_tags($id));
         }
         if (!empty($id) && strval($id) == strval(intval($id))) {
-            $urlrss .= '&amp;id='.$id;
+            $urlrss .= '&amp;id=' . $id;
         } else {
             $id = '';
         }
 
         if (isset($_GET['nbitem'])) {
             $nbitem = $_GET['nbitem'];
-            $urlrss .= '&amp;nbitem='.$nbitem;
+            $urlrss .= '&amp;nbitem=' . $nbitem;
         } else {
             $nbitem = $this->wiki->config['BAZ_NB_ENTREES_FLUX_RSS'];
         }
 
         if (isset($_GET['utilisateur'])) {
             $utilisateur = $_GET['utilisateur'];
-            $urlrss .= '&amp;utilisateur='.$utilisateur;
+            $urlrss .= '&amp;utilisateur=' . $utilisateur;
         } else {
             $utilisateur = '';
         }
@@ -46,12 +46,12 @@ class RssHandler extends YesWikiHandler
         $q = '';
         if (isset($_GET['q']) and !empty($_GET['q'])) {
             $q = $_GET['q'];
-            $urlrss .= '&amp;q='.$q;
+            $urlrss .= '&amp;q=' . $q;
         }
 
         if (isset($_GET['query'])) {
             $query = $_GET['query'];
-            $urlrss .= '&amp;query='.$query;
+            $urlrss .= '&amp;query=' . $query;
             $tabquery = array();
             $tableau = array();
             $tab = explode('|', $query); //découpe la requete autour des |
@@ -100,7 +100,7 @@ class RssHandler extends YesWikiHandler
         $xml .= "\r\n      ";
         $xml .= XML_Util::createTag('language', null, 'fr-FR');
         $xml .= "\r\n      ";
-        $xml .= XML_Util::createTag('copyright', null, 'Copyright (c) '.date('Y').' '. htmlentities(removeAccents($this->wiki->config['BAZ_RSS_NOMSITE'])));
+        $xml .= XML_Util::createTag('copyright', null, 'Copyright (c) ' . date('Y') . ' ' . htmlentities(removeAccents($this->wiki->config['BAZ_RSS_NOMSITE'])));
         $xml .= "\r\n      ";
         $xml .= XML_Util::createTag('lastBuildDate', null, date('r'));
         $xml .= "\r\n      ";
@@ -141,11 +141,11 @@ class RssHandler extends YesWikiHandler
                 $xml .= XML_Util::createTag(
                     'description',
                     null,
-                    '<![CDATA['.preg_replace(
+                    '<![CDATA[' . preg_replace(
                         '/data-id=".*"/Ui',
                         '',
                         $this->sanitize($this->getService(EntryController::class)->view($ligne))
-                    ).']]>'
+                    ) . ']]>'
                 );
                 $xml .= "\r\n        ";
                 $xml .= XML_Util::createTag('pubDate', null, date('r', strtotime($ligne['date_creation_fiche'])));
@@ -159,9 +159,9 @@ class RssHandler extends YesWikiHandler
             $xml .= "\r\n          ";
             $xml .= XML_Util::createTag('title', null, $this->sanitize(_t('BAZ_PAS_DE_FICHES')));
             $xml .= "\r\n          ";
-            $xml .= XML_Util::createTag('link', null, '<![CDATA['.$this->wiki->config['base_url'].$this->wiki->config['root_page'].']]>');
+            $xml .= XML_Util::createTag('link', null, '<![CDATA[' . $this->wiki->config['base_url'] . $this->wiki->config['root_page'] . ']]>');
             $xml .= "\r\n          ";
-            $xml .= XML_Util::createTag('guid', null, '<![CDATA['.$this->wiki->config['base_url'].$this->wiki->config['root_page'].']]>');
+            $xml .= XML_Util::createTag('guid', null, '<![CDATA[' . $this->wiki->config['base_url'] . $this->wiki->config['root_page'] . ']]>');
             $xml .= "\r\n          ";
             $xml .= XML_Util::createTag('description', null, $this->sanitize(_t('BAZ_PAS_DE_FICHES')));
             $xml .= "\r\n          ";
@@ -178,9 +178,9 @@ class RssHandler extends YesWikiHandler
 
         return str_replace(
             '</image>',
-            '</image>'."\n"
-            .'    <atom:link href="'. htmlentities((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . '://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'])
-            .'" rel="self" type="application/rss+xml" />',
+            '</image>' . "\n"
+            . '    <atom:link href="' . htmlentities((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'])
+            . '" rel="self" type="application/rss+xml" />',
             $this->sanitize($xml, ENT_QUOTES, 'UTF-8')
         );
     }

--- a/tools/bazar/handlers/RssHandler.php
+++ b/tools/bazar/handlers/RssHandler.php
@@ -3,6 +3,7 @@
 use YesWiki\Bazar\Controller\EntryController;
 use YesWiki\Bazar\Service\EntryManager;
 use YesWiki\Core\YesWikiHandler;
+use YesWiki\Security\Controller\SecurityController;
 
 // TODO use Symfony XmlEncoder instead
 // https://symfony.com/doc/current/components/serializer.html#the-xmlencoder
@@ -15,12 +16,11 @@ class RssHandler extends YesWikiHandler
         }
 
         $urlrss = $this->wiki->href('rss');
+        $securityController = $this->getService(SecurityController::class);
         if (isset($_GET['id'])) {
-            $id = filter_input(INPUT_GET, 'id', FILTER_UNSAFE_RAW);
-            $id = in_array($id, [false,null], true) ? "" : htmlspecialchars(strip_tags($id));
+            $id = $securityController->filterInput(INPUT_GET, 'id', FILTER_SANITIZE_STRING);
         } elseif (isset($_GET['id_typeannonce'])) {
-            $id = filter_input(INPUT_GET, 'id_typeannonce', FILTER_UNSAFE_RAW);
-            $id = in_array($id, [false,null], true) ? "" : htmlspecialchars(strip_tags($id));
+            $id = $securityController->filterInput(INPUT_GET, 'id_typeannonce', FILTER_SANITIZE_STRING);
         }
         if (!empty($id) && strval($id) == strval(intval($id))) {
             $urlrss .= '&amp;id=' . $id;

--- a/tools/login/actions/LoginAction.php
+++ b/tools/login/actions/LoginAction.php
@@ -85,7 +85,7 @@ class LoginAction extends YesWikiAction
             'nobtn' => $this->formatBoolean($arg, false, 'nobtn'),
             'template' => (empty($arg['template']) ||
                 empty(basename($arg['template'])) ||
-                !$this->templateEngine->hasTemplate("@login/".basename($arg['template'])))
+                !$this->templateEngine->hasTemplate("@login/" . basename($arg['template'])))
                 ? 'default.twig'
                 : basename($arg['template']),
         ];
@@ -117,9 +117,9 @@ class LoginAction extends YesWikiAction
     private function getIncomingUrlFromServer(array $server): string
     {
         $url = explode('?', $server['REQUEST_URI']);
-        $d = dirname($url[0].'?');
+        $d = dirname($url[0] . '?');
         $t = ($d != '/' ? str_replace($d, '', $server['REQUEST_URI']) : $server['REQUEST_URI']);
-        return $this->wiki->getBaseUrl().$t;
+        return $this->wiki->getBaseUrl() . $t;
     }
 
     private function renderForm(string $action): string

--- a/tools/login/actions/LostPasswordAction.php
+++ b/tools/login/actions/LostPasswordAction.php
@@ -41,7 +41,9 @@ class LostPasswordAction extends YesWikiAction
 
         if (isset($_POST['subStep']) && !isset($_GET['a'])) {
             try {
-                $user = $this->manageSubStep(filter_input(INPUT_POST, 'subStep', FILTER_SANITIZE_NUMBER_INT));
+                $user = $this->manageSubStep(
+                    $this->securityController->filterInput(INPUT_POST, 'subStep', FILTER_SANITIZE_NUMBER_INT, 'int')
+                );
             } catch (Exception $ex) {
                 $this->typeOfRendering = 'directDangerMessage';
                 $this->errorType = 'exception';
@@ -50,10 +52,8 @@ class LostPasswordAction extends YesWikiAction
         } elseif (isset($_GET['a']) && $_GET['a'] === 'recover' && !empty($_GET['email'])) {
             $this->typeOfRendering = 'directDangerMessage';
             $message = _t('LOGIN_INVALID_KEY');
-            $hash = filter_input(INPUT_GET, 'email', FILTER_UNSAFE_RAW);
-            $hash = in_array($hash, [false,null], true) ? "" : htmlspecialchars(strip_tags($hash));
-            $encodedUser = filter_input(INPUT_GET, 'u', FILTER_UNSAFE_RAW);
-            $encodedUser = in_array($encodedUser, [false,null], true) ? "" : htmlspecialchars(strip_tags($encodedUser));
+            $hash = $this->securityController->filterInput(INPUT_GET, 'email', FILTER_SANITIZE_STRING);
+            $encodedUser = $this->securityController->filterInput(INPUT_GET, 'u', FILTER_SANITIZE_STRING);
             if (empty($hash)) {
                 $this->errorType = 'invalidKey';
             } elseif ($this->checkEmailKey($hash, base64_decode($encodedUser))) {
@@ -92,8 +92,7 @@ class LostPasswordAction extends YesWikiAction
                 if (isset($hash)) {
                     $key = $hash;
                 } else {
-                    $key = filter_input(INPUT_POST, 'key', FILTER_UNSAFE_RAW);
-                    $key = in_array($key, [false,null], true) ? "" : htmlspecialchars(strip_tags($key));
+                    $key = $this->securityController->filterInput(INPUT_POST, 'key', FILTER_SANITIZE_STRING);
                 }
                 return $this->render("@login/lost-password-recover-form.twig", [
                     'errorType' => $this->errorType,
@@ -128,8 +127,7 @@ class LostPasswordAction extends YesWikiAction
         switch ($subStep) {
             case 1:
                 // we just submitted an email or username for verification
-                $email = filter_input(INPUT_POST, 'email', FILTER_UNSAFE_RAW);
-                $email = in_array($email, [false,null], true) ? "" : htmlspecialchars(strip_tags($email));
+                $email = $this->securityController->filterInput(INPUT_POST, 'email', FILTER_SANITIZE_STRING);
                 if (empty($email)) {
                     $this->errorType = 'emptyEmail';
                     $this->typeOfRendering = 'emailForm';
@@ -149,8 +147,7 @@ class LostPasswordAction extends YesWikiAction
                 if (empty($_POST['userID']) || empty($_POST['key'])) {
                     $this->wiki->Redirect($this->wiki->Href("", $this->params->get('root_page')));
                 }
-                $userName = filter_input(INPUT_POST, 'userID', FILTER_UNSAFE_RAW);
-                $userName = in_array($userName, [false,null], true) ? "" : htmlspecialchars(strip_tags($userName));
+                $userName = $this->securityController->filterInput(INPUT_POST, 'userID', FILTER_SANITIZE_STRING);
                 $user = $this->userManager->getOneByName($userName);
                 $this->typeOfRendering = 'recoverForm';
                 if (empty($_POST['pw0']) || empty($_POST['pw1']) || (strcmp($_POST['pw0'], $_POST['pw1']) != 0) || (trim($_POST['pw0']) == '')) {
@@ -159,10 +156,8 @@ class LostPasswordAction extends YesWikiAction
                 } else {
                     if (!empty($user)) {
                         try {
-                            $key = filter_input(INPUT_POST, 'key', FILTER_UNSAFE_RAW);
-                            $key = in_array($key, [false,null], true) ? "" : htmlspecialchars(strip_tags($key));
-                            $pw0 = filter_input(INPUT_POST, 'pw0', FILTER_UNSAFE_RAW);
-                            $pw0 = in_array($pw0, [false,null], true) ? "" : $pw0;
+                            $key = $this->securityController->filterInput(INPUT_POST, 'key', FILTER_SANITIZE_STRING);
+                            $pw0 = $this->securityController->filterInput(INPUT_POST, 'pw0', FILTER_SANITIZE_STRING);
                             $this->resetPassword(
                                 $user['name'],
                                 $key,

--- a/tools/login/actions/LostPasswordAction.php
+++ b/tools/login/actions/LostPasswordAction.php
@@ -68,22 +68,22 @@ class LostPasswordAction extends YesWikiAction
                 $this->errorType = 'invalidKey';
             }
         }
-        $renderedTitle = '<h2>'._t('LOGIN_CHANGE_PASSWORD').'</h2>';
+        $renderedTitle = '<h2>' . _t('LOGIN_CHANGE_PASSWORD') . '</h2>';
         switch ($this->typeOfRendering) {
             case 'userNotFound':
-                return $renderedTitle.$this->render("@templates/alert-message-with-back.twig", [
+                return $renderedTitle . $this->render("@templates/alert-message-with-back.twig", [
                     'type' => 'danger',
                     'message' => _t('LOGIN_UNKNOWN_USER')
                 ]);
                 break;
             case 'successPage':
-                return $renderedTitle.$this->render("@templates/alert-message.twig", [
+                return $renderedTitle . $this->render("@templates/alert-message.twig", [
                     'type' => 'success',
                     'message' => _t('LOGIN_MESSAGE_SENT')
                 ]);
                 break;
             case 'recoverSuccess':
-                return $renderedTitle.$this->render("@templates/alert-message.twig", [
+                return $renderedTitle . $this->render("@templates/alert-message.twig", [
                     'type' => 'success',
                     'message' => _t('LOGIN_PASSWORD_WAS_RESET')
                 ]);
@@ -104,7 +104,7 @@ class LostPasswordAction extends YesWikiAction
                 ]);
                 break;
             case 'directDangerMessage':
-                return $renderedTitle.$this->render("@templates/alert-message.twig", [
+                return $renderedTitle . $this->render("@templates/alert-message.twig", [
                     'type' => 'danger',
                     'message' => $message,
                 ]);
@@ -221,14 +221,14 @@ class LostPasswordAction extends YesWikiAction
         $pieces = parse_url($this->params->get('base_url'));
         $domain = isset($pieces['host']) ? $pieces['host'] : '';
 
-        $message = _t('LOGIN_DEAR').' ' . $user['name'] . ",\n";
-        $message .= _t('LOGIN_CLICK_FOLLOWING_LINK').' :' . "\n";
+        $message = _t('LOGIN_DEAR') . ' ' . $user['name'] . ",\n";
+        $message .= _t('LOGIN_CLICK_FOLLOWING_LINK') . ' :' . "\n";
         $message .= '-----------------------' . "\n";
         $message .= $passwordLink . "\n";
         $message .= '-----------------------' . "\n";
-        $message .= _t('LOGIN_THE_TEAM').' ' . $domain . "\n";
+        $message .= _t('LOGIN_THE_TEAM') . ' ' . $domain . "\n";
 
-        $subject = _t('LOGIN_PASSWORD_LOST_FOR').' ' . $domain;
+        $subject = _t('LOGIN_PASSWORD_LOST_FOR') . ' ' . $domain;
         // Send the email
         return send_mail($this->params->get('BAZ_ADRESSE_MAIL_ADMIN'), $this->params->get('BAZ_ADRESSE_MAIL_ADMIN'), $user['email'], $subject, $message);
     }
@@ -252,7 +252,7 @@ class LostPasswordAction extends YesWikiAction
             throw new Exception(_t('WIKI_IN_HIBERNATION'));
         }
         if ($this->checkEmailKey($key, $userName) === false) { // The password recovery key does not match
-            throw new Exception(_t('USER_INCORRECT_PASSWORD_KEY').'.');
+            throw new Exception(_t('USER_INCORRECT_PASSWORD_KEY') . '.');
         }
 
         $user = $this->userManager->getOneByName($userName);


### PR DESCRIPTION
@seballot comme convenu, je te propose cette PR.
Elle est en plusieurs commits
 - création d'une méthode `SecurityController::filterInput`
 - refactor du code existant pour utiliser cette méthode et éviter la duplication du code (car `FILTER_SANITIZE_STRING` est dépréciée à partir de `php 8.1`)
 - au passage, auto format `PSR2`
 - puis je remplace les appels de `$_GET` dans `autoupdate` par un appel de `filterInput`
 - l'idée est de s'assurer que c'est bien une chaîne de caractère qui provient de `$_GET` et qu'aucun script ou extension ne pirate le contenu de `$_GET` dans l'idée de déjouer les sécurités
 - au passage, j'introduis `YesWikiMigration::getService` pour faciliter les choses

Qu'en penses-tu ?