### PR TITLE
fix(DbService): escape column

### DIFF
--- a/includes/services/DbService.php
+++ b/includes/services/DbService.php
@@ -143,13 +143,13 @@ class DbService
 
     public function columnExists($table, $column)
     {
-        return $this->count("SHOW COLUMNS FROM {$this->prefixTable($table)} LIKE '{$column}';") > 0;
+        return $this->count("SHOW COLUMNS FROM {$this->prefixTable($table)} LIKE '{$this->escape($column)}';") > 0;
     }
 
     public function dropColumn($table, $column)
     {
         if ($this->columnExists($table, $column)) {
-            $this->query("ALTER TABLE {$this->prefixTable($table)} DROP `{$column}`;");
+            $this->query("ALTER TABLE {$this->prefixTable($table)} DROP `{$this->escape($column)}`;");
         }
     }
 


### PR DESCRIPTION
@seballot petite proposition de bonne pratique, toujours utiliser `escape` pour les requêtes SQL (en l'occurrence, aucun souci pour le moment, mais c'est pour éviter les soucis plus tard si on oublie une injection SQL en utilisant `dropColumn`)
