### PR TITLE
Fix/page forms cache improve

### DIFF
--- a/includes/services/PageManager.php
+++ b/includes/services/PageManager.php
@@ -199,7 +199,7 @@ class PageManager
                 return $pages;
             }
         } else {
-            $limit = (int)$limit;
+            $limit = (int) $limit;
             $limit = ($limit < 1) ? 50 : $limit;
             if ($pages = $this->dbService->loadAll('select id, tag, time, user, owner from' . $this->dbService->prefixTable('pages') . "where latest = 'Y' and comment_on = '' order by time desc limit $limit")) {
                 //foreach ($pages as $page) {
@@ -281,7 +281,7 @@ class PageManager
         $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('pages')} WHERE tag='{$this->dbService->escape($tag)}' OR comment_on='{$this->dbService->escape($tag)}'");
         $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('links')} WHERE from_tag='{$this->dbService->escape($tag)}' ");
         $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('acls')} WHERE page_tag='{$this->dbService->escape($tag)}' ");
-        $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('triples')} WHERE `resource`='{$this->dbService->escape($tag)}' and `property`='".TripleStore::TYPE_URI."' and `value`='".EntryManager::TRIPLES_ENTRY_ID."'");
+        $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('triples')} WHERE `resource`='{$this->dbService->escape($tag)}' and `property`='" . TripleStore::TYPE_URI . "' and `value`='" . EntryManager::TRIPLES_ENTRY_ID . "'");
         $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('triples')} WHERE `resource`='{$this->dbService->escape($tag)}' and `property`='http://outils-reseaux.org/_vocabulary/metadata'");
         $this->dbService->query("DELETE FROM {$this->dbService->prefixTable('referrers')} WHERE page_tag='{$this->dbService->escape($tag)}' ");
         $this->tagsManager->deleteAll($tag);
@@ -390,8 +390,8 @@ class PageManager
             } else {
                 $timeQuery = $time ? "time = '{$this->dbService->escape($time)}'" : "latest = 'Y'";
                 $page = $this->dbService->loadSingle(
-                    "SELECT `owner` FROM {$this->dbService->prefixTable('pages')} ".
-                    "WHERE tag = '{$this->dbService->escape($tag)}' AND {$timeQuery} ".
+                    "SELECT `owner` FROM {$this->dbService->prefixTable('pages')} " .
+                    "WHERE tag = '{$this->dbService->escape($tag)}' AND {$timeQuery} " .
                     "LIMIT 1"
                 );
                 $this->ownersCache[$tag] = $page['owner'] ?? null;

--- a/includes/services/PageManager.php
+++ b/includes/services/PageManager.php
@@ -227,9 +227,6 @@ class PageManager
      */
     public function getReadablePageTags(): array
     {
-        /**
-         * @var string $sqlRequest
-         */
         $sqlRequest = <<<SQL
             SELECT tag,owner FROM {$this->dbService->prefixTable('pages')} WHERE LATEST = 'Y' ORDER BY tag
         SQL;
@@ -239,9 +236,6 @@ class PageManager
         if (!$this->wiki->UserIsAdmin()) {
             $sqlRequest .= $this->aclService->updateRequestWithACL();
         }
-        /**
-         * @var array $pages  - list of pages ['tag' => string,'owner' => string]
-         */
         $pages = $this->dbService->loadAll($sqlRequest);
         return array_map(function ($page) {
             // cache page's owner to prevent reload of page from sql or infinite loop in some case

--- a/tools/bazar/services/FormManager.php
+++ b/tools/bazar/services/FormManager.php
@@ -78,9 +78,6 @@ class FormManager
     public function getAll(): array
     {
         if (!$this->cacheValidatedForAll) {
-            /**
-             * @var array $forms - forms extracted from database
-             */
             $forms = $this->dbService->loadAll("SELECT * FROM {$this->dbService->prefixTable('nature')} ORDER BY bn_label_nature ASC");
             foreach ($forms as $form) {
                 if (!empty($form['bn_id_nature'])) {


### PR DESCRIPTION
**contexte**:
 - j'ai remarqué sur les sites avec plusieurs milliers de pages en temps de chargement lent dû
   - au chargement systématique des acls de toutes les pages à chaque édition d'une page
   - au rechargement systématique de la liste des formulaires dans `FormManager` depuis la base SQL

**propositions**:
 - ne faire plus qu'une seule requête SQL pour récupérer la liste des pages avec les bons droits de lecture dans `PageManager`
 - utiliser le cache dans `FormManager::getAll` pour éviter de multiplier les requêtes SQL identiques