### PR TITLE
fix(BazarListeService): ensure external forms return an array

### DIFF
--- a/tools/bazar/services/BazarListService.php
+++ b/tools/bazar/services/BazarListService.php
@@ -42,27 +42,30 @@ class BazarListService
             return $this->formManager->getAll();
         }
     }
-    
-    private function replaceDefaultImage($options, $forms, $entries): array {
+
+    private function replaceDefaultImage($options, $forms, $entries): array
+    {
         if (! class_exists('attach')) {
-            include ('tools/attach/libs/attach.lib.php');
+            include('tools/attach/libs/attach.lib.php');
         }
         $attach = new attach($this->wiki);
         $basePath = $attach->GetUploadPath();
         $basePath = $basePath . (substr($basePath, - 1) != "/" ? "/" : "");
-        
+
         foreach($options['idtypeannonce'] as $idtypeannonce) {
-            $template = $forms[(int)$idtypeannonce]['template'];
-            $image_names = array_map(function($item) {return $item[1];},
-            array_filter($template,
-                function($item) { return $item[0] == 'image'; }
+            $template = $forms[(int) $idtypeannonce]['template'] ?? [];
+            $image_names = array_map(
+                function ($item) {return $item[1];},
+                array_filter(
+                    $template,
+                    function ($item) { return $item[0] == 'image'; }
                 )
             );
             foreach($image_names as $image_name) {
                 $default_image_filename = "defaultimage{$idtypeannonce}_{$image_name}.jpg";
-                if (file_exists($basePath.$default_image_filename)) {
-                    $image_key = 'image'.$image_name;
-                    foreach($entries as $key=>$entry) {
+                if (file_exists($basePath . $default_image_filename)) {
+                    $image_key = 'image' . $image_name;
+                    foreach($entries as $key => $entry) {
                         if (array_key_exists($image_key, $entry) && ($entry[$image_key] == null)) {
                             $entry[$image_key] = $default_image_filename;
                         }
@@ -163,7 +166,7 @@ class BazarListService
                 $field = $this->findFieldByName($forms, $facettable['source']);
                 if (!($field instanceof BazarField)) {
                     if ($this->debug) {
-                        trigger_error("Waiting field instanceof BazarField from findFieldByName, ".
+                        trigger_error("Waiting field instanceof BazarField from findFieldByName, " .
                             (
                                 (is_null($field)) ? 'null' : (
                                     (gettype($field) == "object") ? get_class($field) : gettype($field)
@@ -219,7 +222,7 @@ class BazarListService
             }));
 
             $filters[$idkey]['icon'] = !empty($options['groupicons'][$i]) ?
-                    '<i class="'.$options['groupicons'][$i].'"></i> ' : '';
+                    '<i class="' . $options['groupicons'][$i] . '"></i> ' : '';
 
             $filters[$idkey]['title'] = !empty($options['titles'][$i]) ?
                     $options['titles'][$i] : $list['titre_liste'];
@@ -233,7 +236,7 @@ class BazarListService
             foreach ($list['label'] as $listkey => $label) {
                 if (!empty($facettables[$id][$listkey])) {
                     $filters[$idkey]['list'][] = [
-                        'id' => $idkey.$listkey,
+                        'id' => $idkey . $listkey,
                         'name' => $idkey,
                         'value' => htmlspecialchars($listkey),
                         'label' => $label,


### PR DESCRIPTION
Les nouveautés concernant les images par défaut dans les formulaires ne testent pas si `$form['template']` est de type `array`.
Ceci pose souci lors de l'usage de formulaires externes : il y a génération d'une erreur php de type warning car `null` est fourni à `array_filter`

Je propose un correctif qui empêche cette erreur (ligne 56)