### PR TITLE
refactor(FILTER_SANITIZE_STRING): use new arg for SecurityController::filterInput and make the update work

### DIFF
--- a/includes/controllers/ApiController.php
+++ b/includes/controllers/ApiController.php
@@ -802,11 +802,11 @@ class ApiController extends YesWikiController
                 Response::HTTP_BAD_REQUEST
             );
         } else {
-            $property = $this->getService(SecurityController::class)->filterInput($method, 'property', FILTER_SANITIZE_STRING);
+            $property = $this->getService(SecurityController::class)->filterInput($method, 'property', FILTER_DEFAULT, true);
             if (empty($property)) {
                 $property = null;
             }
-            $username = $this->getService(SecurityController::class)->filterInput($method, 'user', FILTER_SANITIZE_STRING);
+            $username = $this->getService(SecurityController::class)->filterInput($method, 'user', FILTER_DEFAULT, true);
             if (empty($username)) {
                 if (!$this->wiki->UserIsAdmin()) {
                     $username = $this->getService(AuthController::class)->getLoggedUser()['name'];

--- a/includes/controllers/ArchiveController.php
+++ b/includes/controllers/ArchiveController.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 use YesWiki\Core\ApiResponse;
 use YesWiki\Core\Service\ArchiveService;
 use YesWiki\Core\YesWikiController;
-use YesWiki\Security\Service\SecurityController;
+use YesWiki\Security\Controller\SecurityController;
 
 class ArchiveController extends YesWikiController
 {
@@ -64,7 +64,7 @@ class ArchiveController extends YesWikiController
 
     public function manageArchiveAction(?string $id = null)
     {
-        $action = $this->getService(SecurityController::class)->filterInput(INPUT_POST, 'action', FILTER_SANITIZE_STRING);
+        $action = $this->getService(SecurityController::class)->filterInput(INPUT_POST, 'action', FILTER_DEFAULT, true);
         switch ($action) {
             case 'delete':
                 if (!empty($id)) {

--- a/includes/controllers/CsrfTokenController.php
+++ b/includes/controllers/CsrfTokenController.php
@@ -38,10 +38,10 @@ class CsrfTokenController extends YesWikiController
         }
         switch ($inputType) {
             case 'GET':
-                $inputToken = $this->getService(SecurityController::class)->filterInput(INPUT_GET, $inputKey, FILTER_SANITIZE_STRING);
+                $inputToken = $this->getService(SecurityController::class)->filterInput(INPUT_GET, $inputKey, FILTER_DEFAULT, true);
                 break;
             case 'POST':
-                $inputToken = $this->getService(SecurityController::class)->filterInput(INPUT_POST, $inputKey, FILTER_SANITIZE_STRING);
+                $inputToken = $this->getService(SecurityController::class)->filterInput(INPUT_POST, $inputKey, FILTER_DEFAULT, true);
                 break;
 
             default:

--- a/includes/migrations/20240425000000_CercopitequePostInstall.php
+++ b/includes/migrations/20240425000000_CercopitequePostInstall.php
@@ -3,13 +3,13 @@
 use YesWiki\AutoUpdate\Service\AutoUpdateService;
 use YesWiki\Core\Service\ConfigurationService;
 use YesWiki\Core\YesWikiMigration;
-use YesWiki\Security\Service\SecurityController;
+use YesWiki\Security\Controller\SecurityController;
 
 class CercopitequePostInstall extends YesWikiMigration
 {
     public function run()
     {
-        $previousVersion = $this->getService(SecurityController::class)->filterInput(INPUT_GET, 'previous_version', FILTER_SANITIZE_STRING);
+        $previousVersion = $this->getService(SecurityController::class)->filterInput(INPUT_GET, 'previous_version', FILTER_DEFAULT, true);
         if ($previousVersion === 'cercopitheque') {
 
             $config = $this->getService(ConfigurationService::class)->getConfiguration('wakka.config.php');

--- a/tools/attach/libs/attach.lib.php
+++ b/tools/attach/libs/attach.lib.php
@@ -963,7 +963,7 @@ if (!class_exists('attach')) {
         {
             $path = $this->GetUploadPath();
             $rawFileName = empty($rawFileName)
-                ? $this->wiki->services->get(SecurityController::class)->filterInput(INPUT_GET, 'file', FILTER_SANITIZE_FULL_SPECIAL_CHARS, string)
+                ? $this->wiki->services->get(SecurityController::class)->filterInput(INPUT_GET, 'file', FILTER_SANITIZE_FULL_SPECIAL_CHARS, false, 'string')
                 : $rawFileName;
             $filename = $path . '/' . basename($rawFileName);
             if (!empty($rawFileName) && file_exists($filename)) {

--- a/tools/autoupdate/actions/UpdateAction.php
+++ b/tools/autoupdate/actions/UpdateAction.php
@@ -25,7 +25,7 @@ class UpdateAction extends YesWikiAction
             return $this->render("@autoupdate/norepo.twig", []);
         }
 
-        $action = $securityController->filterInput(INPUT_GET, 'action', FILTER_SANITIZE_STRING);
+        $action = $securityController->filterInput(INPUT_GET, 'action', FILTER_DEFAULT, true);
         if (empty($action) || !$this->wiki->UserIsAdmin() || $this->isWikiHibernated()) {
             // Base action, display current status of software, extension and themes
             return $this->render("@autoupdate/status.twig", [
@@ -44,12 +44,12 @@ class UpdateAction extends YesWikiAction
 
         // Handle upgrade and delete actions
         // package can be 'yeswiki' for core upgrade, or extension name, or theme name
-        $packageName = $securityController->filterInput(INPUT_GET, 'package', FILTER_SANITIZE_STRING);
+        $packageName = $securityController->filterInput(INPUT_GET, 'package', FILTER_DEFAULT, true);
 
         switch ($action) {
             case 'upgrade':
                 // Ensure a backup is made before the upgrade (or force upgrade)
-                $forcedUpdateToken = $securityController->filterInput(INPUT_GET, 'forcedUpdateToken', FILTER_SANITIZE_STRING);
+                $forcedUpdateToken = $securityController->filterInput(INPUT_GET, 'forcedUpdateToken', FILTER_DEFAULT, true);
                 if (!$this->getService(ArchiveService::class)->hasValidatedBackup($forcedUpdateToken)) {
                     return $this->render("@core/preupdate-backup.twig", [
                         'packageName' => $packageName
@@ -67,7 +67,7 @@ class UpdateAction extends YesWikiAction
                 ], false));
                 break;
             case 'post_install':
-                $rawMessages = $securityController->filterInput(INPUT_GET, 'messages', FILTER_UNSAFE_RAW, 'string');
+                $rawMessages = $securityController->filterInput(INPUT_GET, 'messages', FILTER_UNSAFE_RAW, false, 'string');
                 $messages = empty($rawMessages) ? [] : json_decode($rawMessages, true);
                 if (!is_array($messages)) {
                     $messages = [];

--- a/tools/autoupdate/actions/UpdateAction.php
+++ b/tools/autoupdate/actions/UpdateAction.php
@@ -5,7 +5,7 @@ use YesWiki\AutoUpdate\Service\MigrationService;
 use YesWiki\AutoUpdate\Service\UpdateAdminPagesService;
 use YesWiki\Core\Service\ArchiveService;
 use YesWiki\Core\YesWikiAction;
-use YesWiki\Controller\Service\SecurityController;
+use YesWiki\Security\Controller\SecurityController;
 
 class UpdateAction extends YesWikiAction
 {

--- a/tools/autoupdate/actions/UpdateAction.php
+++ b/tools/autoupdate/actions/UpdateAction.php
@@ -82,6 +82,9 @@ class UpdateAction extends YesWikiAction
             case 'delete':
                 $messages = $updateService->delete($packageName);
                 break;
+            default:
+                $messages = [];
+                break;
         }
 
         // Display result of action, with a list of success/error messages

--- a/tools/bazar/fields/FileField.php
+++ b/tools/bazar/fields/FileField.php
@@ -65,7 +65,7 @@ class FileField extends BazarField
                 if ($this->isAllowedToDeleteFile($entry, $value)) {
                     if (substr($value, 0, strlen($this->defineFilePrefix($entry))) == $this->defineFilePrefix($entry)) {
                         $attach = $this->getAttach();
-                        $rawFileName = $this->getService(SecurityController::class)->filterInput(INPUT_GET, 'delete_file', FILTER_SANITIZE_FULL_SPECIAL_CHARS, 'string');
+                        $rawFileName = $this->getService(SecurityController::class)->filterInput(INPUT_GET, 'delete_file', FILTER_SANITIZE_FULL_SPECIAL_CHARS, false, 'string');
                         if (!empty($rawFileName)) {
                             $attach->fmDelete($rawFileName);
                         }

--- a/tools/bazar/handlers/RssHandler.php
+++ b/tools/bazar/handlers/RssHandler.php
@@ -18,9 +18,9 @@ class RssHandler extends YesWikiHandler
         $urlrss = $this->wiki->href('rss');
         $securityController = $this->getService(SecurityController::class);
         if (isset($_GET['id'])) {
-            $id = $securityController->filterInput(INPUT_GET, 'id', FILTER_SANITIZE_STRING);
+            $id = $securityController->filterInput(INPUT_GET, 'id', FILTER_DEFAULT, true);
         } elseif (isset($_GET['id_typeannonce'])) {
-            $id = $securityController->filterInput(INPUT_GET, 'id_typeannonce', FILTER_SANITIZE_STRING);
+            $id = $securityController->filterInput(INPUT_GET, 'id_typeannonce', FILTER_DEFAULT, true);
         }
         if (!empty($id) && strval($id) == strval(intval($id))) {
             $urlrss .= '&amp;id=' . $id;

--- a/tools/login/actions/LoginAction.php
+++ b/tools/login/actions/LoginAction.php
@@ -168,13 +168,13 @@ class LoginAction extends YesWikiAction
 
     private function login()
     {
-        $incomingurl = $this->securityController->filterInput(INPUT_POST, 'incomingurl', FILTER_SANITIZE_URL, 'string');
+        $incomingurl = $this->securityController->filterInput(INPUT_POST, 'incomingurl', FILTER_SANITIZE_URL, false, 'string');
         if (empty($incomingurl)) {
             $incomingurl = $this->arguments['incomingurl'];
         }
         try {
             if (!empty($_POST["name"])) {
-                $name = $this->securityController->filterInput(INPUT_POST, 'name', FILTER_SANITIZE_STRING);
+                $name = $this->securityController->filterInput(INPUT_POST, 'name', FILTER_DEFAULT, true);
                 if (empty($name)) {
                     throw new LoginException(_t('LOGIN_WRONG_USER'));
                 }
@@ -188,7 +188,7 @@ class LoginAction extends YesWikiAction
                 if (empty($_POST["email"])) {
                     throw new LoginException(_t('LOGIN_WRONG_USER'));
                 }
-                $email = $this->securityController->filterInput(INPUT_POST, 'email', FILTER_SANITIZE_STRING);
+                $email = $this->securityController->filterInput(INPUT_POST, 'email', FILTER_DEFAULT, true);
                 if (empty($email)) {
                     throw new LoginException(_t('LOGIN_WRONG_USER'));
                 }
@@ -197,11 +197,11 @@ class LoginAction extends YesWikiAction
             if (empty($user)) {
                 throw new LoginException(_t('LOGIN_WRONG_USER'));
             }
-            $password = $this->securityController->filterInput(INPUT_POST, 'password', FILTER_UNSAFE_RAW, 'string');
+            $password = $this->securityController->filterInput(INPUT_POST, 'password', FILTER_UNSAFE_RAW, false, 'string');
             if (!$this->authController->checkPassword($password, $user)) {
                 throw new LoginException(_t('LOGIN_WRONG_PASSWORD'));
             }
-            $remember = $this->securityController->filterInput(INPUT_POST, 'remember', FILTER_VALIDATE_BOOL, 'bool');
+            $remember = $this->securityController->filterInput(INPUT_POST, 'remember', FILTER_VALIDATE_BOOL, false, 'bool');
             $this->authController->login($user, $remember);
 
             // si l'on veut utiliser la page d'accueil correspondant au nom d'utilisateur

--- a/tools/login/actions/LostPasswordAction.php
+++ b/tools/login/actions/LostPasswordAction.php
@@ -42,7 +42,7 @@ class LostPasswordAction extends YesWikiAction
         if (isset($_POST['subStep']) && !isset($_GET['a'])) {
             try {
                 $user = $this->manageSubStep(
-                    $this->securityController->filterInput(INPUT_POST, 'subStep', FILTER_SANITIZE_NUMBER_INT, 'int')
+                    $this->securityController->filterInput(INPUT_POST, 'subStep', FILTER_SANITIZE_NUMBER_INT, false, 'int')
                 );
             } catch (Exception $ex) {
                 $this->typeOfRendering = 'directDangerMessage';
@@ -52,8 +52,8 @@ class LostPasswordAction extends YesWikiAction
         } elseif (isset($_GET['a']) && $_GET['a'] === 'recover' && !empty($_GET['email'])) {
             $this->typeOfRendering = 'directDangerMessage';
             $message = _t('LOGIN_INVALID_KEY');
-            $hash = $this->securityController->filterInput(INPUT_GET, 'email', FILTER_SANITIZE_STRING);
-            $encodedUser = $this->securityController->filterInput(INPUT_GET, 'u', FILTER_SANITIZE_STRING);
+            $hash = $this->securityController->filterInput(INPUT_GET, 'email', FILTER_DEFAULT, true);
+            $encodedUser = $this->securityController->filterInput(INPUT_GET, 'u', FILTER_DEFAULT, true);
             if (empty($hash)) {
                 $this->errorType = 'invalidKey';
             } elseif ($this->checkEmailKey($hash, base64_decode($encodedUser))) {
@@ -92,7 +92,7 @@ class LostPasswordAction extends YesWikiAction
                 if (isset($hash)) {
                     $key = $hash;
                 } else {
-                    $key = $this->securityController->filterInput(INPUT_POST, 'key', FILTER_SANITIZE_STRING);
+                    $key = $this->securityController->filterInput(INPUT_POST, 'key', FILTER_DEFAULT, true);
                 }
                 return $this->render("@login/lost-password-recover-form.twig", [
                     'errorType' => $this->errorType,
@@ -127,7 +127,7 @@ class LostPasswordAction extends YesWikiAction
         switch ($subStep) {
             case 1:
                 // we just submitted an email or username for verification
-                $email = $this->securityController->filterInput(INPUT_POST, 'email', FILTER_SANITIZE_STRING);
+                $email = $this->securityController->filterInput(INPUT_POST, 'email', FILTER_DEFAULT, true);
                 if (empty($email)) {
                     $this->errorType = 'emptyEmail';
                     $this->typeOfRendering = 'emailForm';
@@ -147,7 +147,7 @@ class LostPasswordAction extends YesWikiAction
                 if (empty($_POST['userID']) || empty($_POST['key'])) {
                     $this->wiki->Redirect($this->wiki->Href("", $this->params->get('root_page')));
                 }
-                $userName = $this->securityController->filterInput(INPUT_POST, 'userID', FILTER_SANITIZE_STRING);
+                $userName = $this->securityController->filterInput(INPUT_POST, 'userID', FILTER_DEFAULT, true);
                 $user = $this->userManager->getOneByName($userName);
                 $this->typeOfRendering = 'recoverForm';
                 if (empty($_POST['pw0']) || empty($_POST['pw1']) || (strcmp($_POST['pw0'], $_POST['pw1']) != 0) || (trim($_POST['pw0']) == '')) {
@@ -156,8 +156,8 @@ class LostPasswordAction extends YesWikiAction
                 } else {
                     if (!empty($user)) {
                         try {
-                            $key = $this->securityController->filterInput(INPUT_POST, 'key', FILTER_SANITIZE_STRING);
-                            $pw0 = $this->securityController->filterInput(INPUT_POST, 'pw0', FILTER_SANITIZE_STRING);
+                            $key = $this->securityController->filterInput(INPUT_POST, 'key', FILTER_DEFAULT, true);
+                            $pw0 = $this->securityController->filterInput(INPUT_POST, 'pw0', FILTER_DEFAULT, true);
                             $this->resetPassword(
                                 $user['name'],
                                 $key,

--- a/tools/security/controllers/SecurityController.php
+++ b/tools/security/controllers/SecurityController.php
@@ -187,6 +187,7 @@ class SecurityController extends YesWikiController
      * @param int $type
      * @param string $varName
      * @param int $filter same as filter_input
+     * @param bool $emulateFilterSanitizeString
      * @param string $format 'string', 'int', 'bool', 'array', '' (empty = not formatted)
      * @param array|int $options same as filter_input
      * @return mixed
@@ -195,17 +196,18 @@ class SecurityController extends YesWikiController
         int $type,
         string $varName,
         int $filter = FILTER_DEFAULT,
+        bool $emulateFilterSanitizeString = false,
         string $format = '',
         $options = 0
     ) {
         /**
          * @var int $sanitizedFilter
          */
-        $sanitizedFilter = ($filter === FILTER_SANITIZE_STRING) ? FILTER_UNSAFE_RAW : $filter;
+        $sanitizedFilter = $emulateFilterSanitizeString ? FILTER_UNSAFE_RAW : $filter;
         /**
          * @var string $sanitizedFormat
          */
-        $sanitizedFormat = ($filter === FILTER_SANITIZE_STRING) ? 'string' : $format;
+        $sanitizedFormat = $emulateFilterSanitizeString ? 'string' : $format;
         /**
          * @var mixed $rawInputFiltered
          */
@@ -223,7 +225,7 @@ class SecurityController extends YesWikiController
                 )
                     ? ''
                     : (
-                        $filter === FILTER_SANITIZE_STRING
+                        $emulateFilterSanitizeString
                         ? htmlspecialchars(strip_tags(strval($rawInputFiltered)))
                         : strval($rawInputFiltered)
                     );


### PR DESCRIPTION
**Contexte**:
 - je me rends compte qu'avec `php 8.3` et peut-être d'autres versions plus anciennes, l'utilisation de la constante : `FILTER_SANITIZE_STRING` crée un warning intempestif.

**Propositionn**:
 - ~~définition d'une nouvelle constante `FILTER_SANITIZE_STRING_BKUP` de même valeur~~
 - ajout d'un argument à la méthode `SecurityController::filterInput` pour émuler le comportement de cette option
 - corrections de 2 bugs qui étaient présents dans la définition des noms de classes