### PR TITLE
fix(TabsField): lazy loading

### DIFF
--- a/tools/bazar/fields/TabsField.php
+++ b/tools/bazar/fields/TabsField.php
@@ -36,8 +36,9 @@ class TabsField extends LabelField
         $this->btnClass = (in_array($values[self::FIELD_BTN_COLOR], ["btn-primary","btn-secondary-1","btn-secondary-2"], true) ? $values[self::FIELD_BTN_COLOR] : "btn-primary") .
           ($values[self::FIELD_BTN_SIZE] === "btn-xs" ? " btn-xs" : "") ;
         $this->tabsController = $this->getService(TabsController::class);
-        $this->formText = $this->prepareText('form');
-        $this->viewText = $this->prepareText('view');
+        // does not call prepareText in constuct only in render (lazy loading)
+        $this->formText = '';
+        $this->viewText = '';
     }
 
     protected function sanitizeTitles(?string $input): ?array


### PR DESCRIPTION
prevent rendering of tabs when loading form in SelectEntryField

fix <https://forum.yeswiki.net/t/formulaire-a-onglets-dans-formulaire-a-onglets/1318>

**context**:
 - lors de l'utilisation de formulaire avec un `SelectEntryField` vers un formulaire ayant lui-même des onglets, ceci casse le fonctionnement des onglets

**solution**
 - retrait du chargement des titres des onglets dans le constructeur de `TabsField`

**comment tester**:
 - créer un formulaire avec des onglets
 - y ajouter des fiches
 - créer un second formulaire avec des onglets et ajouter un `listefiche` vers le premier formulaire (si possible dans le premier onglet)
 - essayer de créer une fiche et constater que le souci disparaît avec le correctif
