### PR TITLE
When you create a user in YesWiki, a password is created but you do n…

### DIFF
--- a/includes/controllers/ApiController.php
+++ b/includes/controllers/ApiController.php
@@ -176,10 +176,11 @@ class ApiController extends YesWikiController
             ];
         } else {
             try {
-                $user = $userController->create([
+                list($user, $link) = $userController->create([
                     'name' => strval($_POST['name']),
                     'email' => strval($_POST['email']),
                     'password' => $this->wiki->generateRandomString(30),
+                    'sendpassword' => !boolval($this->wiki->config['contact_disable_email_for_password'])
                 ]);
                 $code = Response::HTTP_OK;
                 $result = [
@@ -188,6 +189,7 @@ class ApiController extends YesWikiController
                         'name' => $user['name'],
                         'email' => $user['email'],
                         'signuptime' => $user['signuptime'],
+                        'link' => $link
                     ],
                 ];
             } catch (UserNameAlreadyUsedException $th) {

--- a/includes/controllers/ApiController.php
+++ b/includes/controllers/ApiController.php
@@ -176,12 +176,16 @@ class ApiController extends YesWikiController
             ];
         } else {
             try {
-                list($user, $link) = $userController->create([
+                $user = $userController->create([
                     'name' => strval($_POST['name']),
                     'email' => strval($_POST['email']),
-                    'password' => $this->wiki->generateRandomString(30),
-                    'sendpassword' => !boolval($this->wiki->config['contact_disable_email_for_password'])
+                    'password' => $this->wiki->generateRandomString(30)
                 ]);
+                if (!boolval($this->wiki->config['contact_disable_email_for_password']) && !empty($user)) {
+                    $link = $userController->sendPasswordRecoveryEmail($user);
+                } else {
+                    $link = '';
+                }
                 $code = Response::HTTP_OK;
                 $result = [
                     'created' => [$user['name']],

--- a/includes/controllers/UserController.php
+++ b/includes/controllers/UserController.php
@@ -96,7 +96,7 @@ class UserController extends YesWikiController
         if (!empty($this->userManager->create($newValues))) {
             $user = $this->userManager->getOneByName($newValues['name']);
             if (!empty($user)) {
-                return $user;
+                return array($user, $this->userManager->getUserLink());
             }
         }
         throw new Exception(_t('USER_CREATION_FAILED') . '.');

--- a/includes/controllers/UserController.php
+++ b/includes/controllers/UserController.php
@@ -96,12 +96,21 @@ class UserController extends YesWikiController
         if (!empty($this->userManager->create($newValues))) {
             $user = $this->userManager->getOneByName($newValues['name']);
             if (!empty($user)) {
-                return array($user, $this->userManager->getUserLink());
+                return $user;
             }
         }
         throw new Exception(_t('USER_CREATION_FAILED') . '.');
 
         return null;
+    }
+    
+    public function sendPasswordRecoveryEmail(User $user): string
+    {
+        if ($this->userManager->sendPasswordRecoveryEmail($user, _t('LOGIN_PASSWORD_FOR'))) {
+            return $this->userManager->getUserLink();
+        } else {
+            return "";
+        }        
     }
 
     /**

--- a/includes/services/UserManager.php
+++ b/includes/services/UserManager.php
@@ -111,7 +111,7 @@ class UserManager implements UserProviderInterface, PasswordUpgraderInterface
      *
      * @throws UserNameAlreadyUsedException|UserEmailAlreadyUsedException|Exception
      */
-    public function create($wikiNameOrUser, string $email = '', string $plainPassword = '', bool $sendpassword = false)
+    public function create($wikiNameOrUser, string $email = '', string $plainPassword = '')
     {
         $this->userlink = '';
         if ($this->securityController->isWikiHibernated()) {
@@ -132,7 +132,6 @@ class UserManager implements UserProviderInterface, PasswordUpgraderInterface
             $userAsArray['name'] = $wikiName;
             $email = $userAsArray['email'] ?? '';
             $plainPassword = $userAsArray['password'] ?? '';
-            $sendpassword = $userAsArray['sendpassword'] ?? false;
         } elseif (is_string($wikiNameOrUser)) {
             $wikiName = trim($wikiNameOrUser);
             $userAsArray = [

--- a/javascripts/users-table.js
+++ b/javascripts/users-table.js
@@ -18,6 +18,7 @@ const usersTableService = {
         success(data) {
           const userName = data.user.name
           const userEmail = data.user.email
+          const userLink = data.user.link
           const { signuptime } = data.user
           // append In Datable
           const table = $(form).siblings('.dataTables_wrapper').first()
@@ -33,6 +34,9 @@ const usersTableService = {
             '',
             ''
           ]).draw()
+          if (userLink !== '') {
+            $(`#users-table-link-change-password`).html("<br/><label>"+_t('LINK_TO_CHANGE_PASSWORD')+"</label><br/><a href='"+userLink+"' target='_blank'>"+userLink+"</a>")
+          }
           toastMessage(_t('USERSTABLE_USER_CREATED', { name: userName }), 1100, 'alert alert-success')
         },
         error(e) {

--- a/lang/yeswiki_fr.php
+++ b/lang/yeswiki_fr.php
@@ -213,6 +213,7 @@ return [
     'ERROR_ACTION_TRAIL' => 'Erreur action {{trail ...}}',
     'INDICATE_THE_PARAMETER_TOC' => 'Indiquez le nom de la page sommaire, paramètre "toc"',
     // actions/usersettings.php
+    'USER_GOTOADMIN' => 'Gestion des utilisateurices',
     'USER_SETTINGS' => 'Paramètres utilisateur',
     'USER_SIGN_UP' => 'S\'inscrire',
     'YOU_ARE_NOW_DISCONNECTED' => 'Vous êtes maintenant déconnecté',

--- a/lang/yeswikijs_en.php
+++ b/lang/yeswikijs_en.php
@@ -83,6 +83,7 @@ return [
     'MULTIDELETE_END' => 'Deletions finished',
     'MULTIDELETE_ERROR' => 'Item {itemId} has not been deleted! {error}',
     // javascripts/users-table.js
+    'LINK_TO_CHANGE_PASSWORD' => "Link to change password",    
     'USERSTABLE_USER_CREATED' => "User '{name}' created",
     'USERSTABLE_USER_NOT_CREATED' => "User '{name}' not created : {error}",
     'USERSTABLE_USER_DELETED' => 'The user "{username}" was deleted.',

--- a/lang/yeswikijs_fr.php
+++ b/lang/yeswikijs_fr.php
@@ -113,6 +113,7 @@ return [
     'MULTIDELETE_ERROR' => "L'élément {itemId} n'a pas été supprimé ! {error}",
 
     // javascripts/users-table.js
+    'LINK_TO_CHANGE_PASSWORD' => "Lien pour changer le mot de passe",
     'USERSTABLE_USER_CREATED' => "Utilisateur '{name}' créé",
     'USERSTABLE_USER_NOT_CREATED' => "Utilisateur '{name}' non créé : {error}",
     'USERSTABLE_USER_DELETED' => 'L\'utilisateur "{username}" a été supprimé.',

--- a/templates/users-table.twig
+++ b/templates/users-table.twig
@@ -28,6 +28,7 @@
       </div>
     </form>
   <div class="clearfix"></div>
+  <div id='users-table-link-change-password' class="form-row"></div>
   {% endif %}
   <table class="table table-striped" data-order='[[ {{ isAdmin ? 4 : 2 }}, "desc" ]]'>
     <thead>

--- a/tools/contact/config.yaml
+++ b/tools/contact/config.yaml
@@ -9,6 +9,7 @@ parameters:
   contact_reply_to: '' # default mail to reply to
   contact_debug: 0 # debug mode (0 pour rien, 1 pour normal, 2 pour détaillé)
   contact_passphrase: '' # passphrase pour envoyer des mail
+  contact_disable_email_for_password: false # pour désactiver l'envoie d'email pour ré-initaliser un mot de passe (ex: LDAP, SSO)
   contact_editable_config_params:
     - 'contact_use_long_wiki_urls_in_emails'
     - 'contact_mail_func'
@@ -19,3 +20,4 @@ parameters:
     - 'contact_from'
     - 'contact_reply_to'
     - 'contact_debug'
+    - 'contact_disable_email_for_password'

--- a/tools/contact/lang/contact_fr.inc.php
+++ b/tools/contact/lang/contact_fr.inc.php
@@ -154,4 +154,5 @@ return [
     'EDIT_CONFIG_HINT_CONTACT_REPLY_TO' => 'Utilisateur auquel la réponse mail sera envoyée',
     'EDIT_CONFIG_HINT_CONTACT_DEBUG' => 'Mode verbeux pour débugguer (mettre 2 pour avoir des informations)',
     'EDIT_CONFIG_GROUP_CONTACT' => 'Envoi des e-mails',
+    'EDIT_CONFIG_HINT_CONTACT_DISABLE_EMAIL_FOR_PASSWORD' => 'Désactiver l\'envoie d\'email pour ré-initaliser un mot de passe (ex: LDAP, SSO)',
 ];

--- a/tools/login/actions/LoginAction.php
+++ b/tools/login/actions/LoginAction.php
@@ -77,10 +77,9 @@ class LoginAction extends YesWikiAction
                     : $incomingurl
                 ),
 
-            'lostpasswordurl' => !empty($arg['lostpasswordurl'])
-                ? $this->wiki->generateLink($arg['lostpasswordurl'])
-                // TODO : check page name for other languages
-                : $this->wiki->Href('', 'MotDePassePerdu'),
+            'lostpasswordurl' => ! boolval($this->params->get('contact_disable_email_for_password')) ? (! empty($arg['lostpasswordurl']) ? $this->wiki->generateLink($arg['lostpasswordurl']) : 
+            // TODO : check page name for other languages
+            $this->wiki->Href('', 'MotDePassePerdu')) : '',
 
             'class' => !empty($arg['class']) ? $arg['class'] : '',
             'btnclass' => !empty($arg['btnclass']) ? $arg['btnclass'] : '',
@@ -151,7 +150,7 @@ class LoginAction extends YesWikiAction
             'email' => ((isset($user['email'])) ? $user['email'] : ((isset($_POST['email'])) ? $_POST['email'] : '')),
             'incomingurl' => $this->arguments['incomingurl'],
             'signupurl' => $this->arguments['signupurl'],
-            'lostpasswordurl' => $this->arguments['lostpasswordurl'],
+            'lostpasswordurl' => ! boolval($this->params->get('contact_disable_email_for_password')) ? $this->arguments['lostpasswordurl'] : '',
             'profileurl' => $this->arguments['profileurl'],
             'userpage' => $this->arguments['userpage'],
             'PageMenuUser' => $pageMenuUserContent,

--- a/tools/login/actions/LostPasswordAction.php
+++ b/tools/login/actions/LostPasswordAction.php
@@ -209,7 +209,7 @@ class LostPasswordAction extends YesWikiAction
         }
         $this->authController->setPassword($user, $password);
         // Was able to update password => Remove the key from triples table
-        $this->tripleStore->delete($user['name'], self::KEY_VOCABULARY, $key, '', '');
+        $this->tripleStore->delete($user['name'], UserManager::KEY_VOCABULARY, $key, '', '');
 
         return true;
     }
@@ -229,7 +229,7 @@ class LostPasswordAction extends YesWikiAction
     private function checkEmailKey(string $hash, string $user): bool
     {
         // Pas de detournement possible car utilisation de _vocabulary/key ....
-        return !is_null($this->tripleStore->exist($user, self::KEY_VOCABULARY, $hash, '', ''));
+        return !is_null($this->tripleStore->exist($user, UserManager::KEY_VOCABULARY, $hash, '', ''));
     }
     /* End of Password recovery process (AKA reset password)   */
 }

--- a/tools/login/actions/UserSettingsAction.php
+++ b/tools/login/actions/UserSettingsAction.php
@@ -61,7 +61,7 @@ class UserSettingsAction extends YesWikiAction
         $this->errorPasswordChange = '';
         $this->referrer = '';
         $user = $this->getUser($_GET ?? []);
-        if (! boolval($this->wiki->config['contact_disable_email_for_password'])) {
+        if (!boolval($this->wiki->config['contact_disable_email_for_password']) && !empty($user)) {
             $this->userlink = $this->userManager->getLastUserLink($user);
         } else {
             $this->userlink = '';
@@ -235,7 +235,7 @@ class UserSettingsAction extends YesWikiAction
                     $sanitizedPost
                 );
                 $this->userlink = '';
-                if (! boolval($this->wiki->config['contact_disable_email_for_password'])) {
+                if (!boolval($this->wiki->config['contact_disable_email_for_password'])) {
                     if ($this->userManager->sendPasswordRecoveryEmail($user, _t('LOGIN_PASSWORD_FOR'))) {
                         $this->userlink = $this->userManager->getUserLink();
                     }
@@ -291,7 +291,7 @@ class UserSettingsAction extends YesWikiAction
                     $this->wiki->Redirect($this->wiki->href());
                 } catch (TokenNotFoundException $th) {
                     $this->errorPasswordChange = _t('USERSETTINGS_PASSWORD_NOT_CHANGED') . ' ' . $th->getMessage();
-                } catch (BadFormatPasswordException|Throwable $ex) {
+                } catch (BadFormatPasswordException | Throwable $ex) {
                     // Something when wrong when updating the user in DB
                     $this->errorPasswordChange = _t('USERSETTINGS_PASSWORD_NOT_CHANGED') . ' ' . $ex->getMessage();
                 }
@@ -317,8 +317,10 @@ class UserSettingsAction extends YesWikiAction
                 $password = isset($post['password']) && is_string($post['password']) ? $post['password'] : '';
                 if (!empty($emptyInputsParametersNames)) {
                     $this->error = str_replace('{parameters}', implode(',', $emptyInputsParametersNames), _t('USERSETTINGS_SIGNUP_MISSING_INPUT'));
-                } elseif ($this->authController->checkPasswordValidateRequirements($password) &&
-                    $post['confpassword'] !== $password) {
+                } elseif (
+                    $this->authController->checkPasswordValidateRequirements($password) &&
+                    $post['confpassword'] !== $password
+                ) {
                     $this->error = _t('USER_PASSWORDS_NOT_IDENTICAL') . '.';
                 } else { // Password is correct
                     $_POST['submit'] = SecurityController::EDIT_PAGE_SUBMIT_VALUE;

--- a/tools/login/lang/login_en.inc.php
+++ b/tools/login/lang/login_en.inc.php
@@ -37,7 +37,9 @@ return [
     'LOGIN_DEAR' => 'Dear',
     'LOGIN_CLICK_FOLLOWING_LINK' => 'Click on the link below to reset your password',
     'LOGIN_THE_TEAM' => 'The team from',
+    'LOGIN_PASSWORD_FOR' => 'Password for',
     'LOGIN_PASSWORD_LOST_FOR' => 'Lost password for',
+    'LAST_LINK_TO_CHANGE_PASSWORD' => 'Last link to change password',
     // 'LOGIN_NO_SIGNUP_IN_THIS_PERIOD' => 'Il n\'y a pas d\'inscription pour cette période.',
     // actions/login.php
     // 'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',

--- a/tools/login/lang/login_fr.inc.php
+++ b/tools/login/lang/login_fr.inc.php
@@ -37,10 +37,12 @@ return [
     'LOGIN_DEAR' => 'Cher',
     'LOGIN_CLICK_FOLLOWING_LINK' => 'Cliquez sur le lien suivant pour ré-initialiser votre mot de passe',
     'LOGIN_THE_TEAM' => 'L\'équipe de',
+    'LOGIN_PASSWORD_FOR' => 'Mot de passe pour',
     'LOGIN_PASSWORD_LOST_FOR' => 'Mot de passe perdu pour',
     'LOGIN_NO_SIGNUP_IN_THIS_PERIOD' => 'Il n\'y a pas d\'inscription pour cette période.',
     'LOGIN_MY_OPTIONS' => 'Mes options',
     'LOGIN_MY_CONTENTS' => 'Mes contenus',
+    'LAST_LINK_TO_CHANGE_PASSWORD' => 'Dernier lien pour changer le mot de passe',
 
     // actions/login.php
     'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',

--- a/tools/login/lang/login_fr.inc.php
+++ b/tools/login/lang/login_fr.inc.php
@@ -42,7 +42,7 @@ return [
     'LOGIN_NO_SIGNUP_IN_THIS_PERIOD' => 'Il n\'y a pas d\'inscription pour cette période.',
     'LOGIN_MY_OPTIONS' => 'Mes options',
     'LOGIN_MY_CONTENTS' => 'Mes contenus',
-    'LAST_LINK_TO_CHANGE_PASSWORD' => 'Dernier lien pour changer le mot de passe',
+    'LINK_TO_CHANGE_PASSWORD' => 'Lien pour changer le mot de passe',
 
     // actions/login.php
     'LOGIN_COOKIES_ERROR' => 'Vous devez accepter les cookies pour pouvoir vous connecter.',

--- a/tools/login/templates/usersettings.twig
+++ b/tools/login/templates/usersettings.twig
@@ -28,7 +28,7 @@
 {% if userlink is not empty %}
   <div class="control-group form-group">
   	<div class="controls col-sm-9">
-  		<label>{{ _t('LAST_LINK_TO_CHANGE_PASSWORD') }}</label><br/>
+  		<label>{{ _t('LINK_TO_CHANGE_PASSWORD') }}</label><br/>
   		<a href='{{ userlink }}' target='_blank'>{{ userlink }}</a>
   	</div>
   </div>

--- a/tools/login/templates/usersettings.twig
+++ b/tools/login/templates/usersettings.twig
@@ -1,4 +1,5 @@
-<h2>{{ _t('USER_SETTINGS') }}{{ adminIsActing ? ' — ' ~ user.name : ''}}</h2>
+{% if adminIsActing %} <a href="{{ url({tag: 'GererUtilisateurs'}) }}" class="btn btn-primary pull-right"><i class="fa fa-arrow-left"></i> {{ _t('USER_GOTOADMIN')}}</a>{% endif %}
+<h2>{{ _t('USER_SETTINGS') }}{% if adminIsActing %} — {{user.name}}{% endif %}</h2>
 
 {% if errorUpdate is not empty %}
   <div class="alert alert-danger">{{ errorUpdate }}</div>

--- a/tools/login/templates/usersettings.twig
+++ b/tools/login/templates/usersettings.twig
@@ -25,6 +25,14 @@
       <input class="form-control" name="revisioncount" value="{{ user.revisioncount|e('html_attr') }}" size="40" />
     </div>
   </div> #}
+{% if userlink is not empty %}
+  <div class="control-group form-group">
+  	<div class="controls col-sm-9">
+  		<label>{{ _t('LAST_LINK_TO_CHANGE_PASSWORD') }}</label><br/>
+  		<a href='{{ userlink }}' target='_blank'>{{ userlink }}</a>
+  	</div>
+  </div>
+{% endif %}  
   <div class="control-group form-group">
 		<div class="controls col-sm-9 col-sm-offset-3">
       <input type="hidden" name="csrf-token-update" value="{{ csrfToken({id:'main',refresh:false}) }}">


### PR DESCRIPTION
…ot have the means to simply notify the user.

- send reset password email (with link) when admin create user
- show reset password link to admin after created
- if modify user, admin show last reset password link
- if change email of old user, new reset password email is sent (reset link is update)
- new param 'contact_disable_email_for_password' to disabled reset password email (case of LDAP, SSO, ...)

## Description of pull request / Description de la demande d'ajout

Implement issue #1177
