### PR TITLE
fix(pdf.twig): does not use jQuery to hide throbber

### DIFF
--- a/tools/attach/templates/actions/pdf.twig
+++ b/tools/attach/templates/actions/pdf.twig
@@ -5,7 +5,7 @@
   <iframe
     src="javascripts/vendor/pdfjs-dist/web/pdf-viewer.php?file={{ url|e('url') }}"
     class="embed-responsive-item" frameborder="0" allowfullscreen
-    onload="$(this).siblings('.pdf-block-loading').hide();"
+    onload="event.target.parentNode.querySelector('.pdf-block-loading').style.display='none';"
     >
     </iframe>
 {% endblock %}


### PR DESCRIPTION
Small proposal of change when displaying pdf in viewer (iframe). 
 - Does not use jQuery but Vanilla