### PR TITLE
fix(PdfViewer): force mjs to be javascript

### DIFF
--- a/javascripts/vendor/pdfjs-dist/.htaccess
+++ b/javascripts/vendor/pdfjs-dist/.htaccess
@@ -1,0 +1,3 @@
+<IfModule mod_mime.c>
+  AddType text/javascript .mjs
+</IfModule>


### PR DESCRIPTION
**Problème**
 - sur certains hébergements, l'extension `mjs` n'est pas reconnue comme `text/javascript`
 - ceci empêche le fonctionnement du lecteur embarqué `pdf` en raison des contraintes CORS

**Proposition**
 - ajout du fichier `.htaccess` pour définir ce type
 - attention particulière à remettre le fichier lors de la mise à jour des fichiers `pdfjs-dist`
 - correction de `ComposerScriptHelper` pour que la détection de la nouvelle version fonctionne

**Astuce**:
 - après fusion, peut-être faire un `composer update` pour faire une mise à jour des fichiers de `pdfjs-dist` et pousser les nouveaux fichiers