### PR TITLE
Fix/panel button not collapsible

### DIFF
--- a/tools/templates/actions/panel.php
+++ b/tools/templates/actions/panel.php
@@ -66,9 +66,10 @@ if ($GLOBALS['check_' . $pagetag]['panel']) {
         }
     }
 
+    $headerTagName = $collapsible ? 'button' : 'div';
     $result = '<!-- start of panel -->'
         . "<div class=\"panel $class\" $data>
-      <button class=\"panel-heading" . ($collapsed ? " collapsed" : '') . '"';
+      <$headerTagName class=\"panel-heading" . ($collapsed ? ' collapsed' : '') . '"';
     if ($collapsible) {
         $result .= " id=\"$headingID\"" . ' data-toggle="collapse"' . (!empty($accordionID) ? " data-parent=\"#$accordionID\"" : '')
             . " href=\"#$collapseID\" aria-expanded=\"" . ($collapsed ? 'false' : 'true') . "\" aria-controls=\"$collapseID\"";
@@ -77,7 +78,7 @@ if ($GLOBALS['check_' . $pagetag]['panel']) {
           <h4 class=\"panel-title\">
            $title
           </h4>
-      </button>
+      </$headerTagName>
       
       <div id=\"$collapseID\"";
     if ($collapsible) {

--- a/tools/templates/actions/panel.php
+++ b/tools/templates/actions/panel.php
@@ -30,7 +30,7 @@ $collapsible = ($type == 'collapsed' || $type == 'collapsible');
 $collapsed = ($type == 'collapsed');
 
 // data attributes
-$data = $this->services->get(\YesWiki\Templates\Service\Utils::class)->getDataParameter();
+$data = $this->services->get(YesWiki\Templates\Service\Utils::class)->getDataParameter();
 
 $pagetag = $this->GetPageTag();
 
@@ -39,7 +39,7 @@ if (!isset($GLOBALS['check_' . $pagetag])) {
     $GLOBALS['check_' . $pagetag] = [];
 }
 if (!isset($GLOBALS['check_' . $pagetag]['panel'])) {
-    $GLOBALS['check_' . $pagetag]['panel'] = $this->services->get(\YesWiki\Templates\Service\Utils::class)->checkGraphicalElements('panel', $pagetag, $this->page['body'] ?? '');
+    $GLOBALS['check_' . $pagetag]['panel'] = $this->services->get(YesWiki\Templates\Service\Utils::class)->checkGraphicalElements('panel', $pagetag, $this->page['body'] ?? '');
 }
 
 if ($GLOBALS['check_' . $pagetag]['panel']) {


### PR DESCRIPTION
Pour faire suite aux discussions de post fusion de #1159 j'ai mené une inspection plus fine de l'impact de l'usage de `<button />` à la place de `<div />` pour les éléments de type `collapsible`.

Pour les thèmes utilisant `bootstrap 3` (ce qui est le cas du thème officiel), il n'y a pas d'impact. Pour les thèmes n'utilisant pas `bootstrap 3`, il faudra que chaque thème fasse attention à utiliser `event.preventDefault()`.

Toutefois, j'ai noté que dans le cas d'un `panel` non `collapsible`, la modification de @ppom0 utilise toujours `button` ce qui peut induire en erreur l'usager car l'élément n'est pas cliquable. 

Je propose donc cette PR pour utiliser `div` dans le cas précis des `panel` non `collapsible`

**A noter**:
 - la PR possède 2 commits : 
   - 1 commit d'autoformat PSR
   - 1 commit avec la proposition