### PR TITLE
Add enhanced regexp handling for field filtering in query

### DIFF
--- a/tools/bazar/services/BazarListService.php
+++ b/tools/bazar/services/BazarListService.php
@@ -93,6 +93,7 @@ class BazarListService
         } else {
             $entries = $this->entryManager->search(
                 [
+                    "regexp" => $options["regexp"]??"0", 
                     'queries' => $options['query'] ?? '',
                     'formsIds' => $options['idtypeannonce'] ?? [],
                     'keywords' => $_REQUEST['q'] ?? '',

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -333,9 +333,17 @@ class EntryManager
                                 $requeteSQL .= ' NOT ';
                                 $nom = substr($nom, 0, -1);
                             }
-                            $requeteSQL .= '(body REGEXP \'"' . $nom . '":("' . $rawCriteron .
+
+                            if (($params["regexp"]??"0") == "1")
+                            {
+                            	$requeteSQL .= 'JSON_VALID(body) AND JSON_EXTRACT(body, "$.' . $nom . '") REGEXP "' . $val . '"';                                                      	
+	                        }
+	                        else
+	                        {                                
+                                $requeteSQL .= '(body REGEXP \'"' . $nom . '":("' . $rawCriteron .
                                 '"|"[^"]*,' . $rawCriteron . '"|"' . $rawCriteron . ',[^"]*"|"[^"]*,'
                                 . $rawCriteron . ',[^"]*")\')';
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
We can specify a new parameter in getentries to use an enhanced method for field filtering in query.
This method use the JSON_VALID and JSON_EXTRACT methods available since MySQL 5.7.8 and MariaDB 10.2.3
We can then specify normal REGEXP in field filtering in bazarliste
ex :
{{ bazarliste query="bf_myfield=start.\*end|bf_mysecondfield=a\*b?" }}
