### PR TITLE
[fix] htmlspecialchars(): Passing null to parameter is deprecated

### DIFF
--- a/formatters/wakka.php
+++ b/formatters/wakka.php
@@ -416,8 +416,8 @@ if (!class_exists('\YesWiki\WikiniFormatter')) {
                     // markdown images compatibility
                     elseif (preg_match('/^\!\[([^\]]*)\]\(([^\) ]+)(?: "(.*)")?\)$/sm', $thing, $matches)) {
                         $src = $matches[2];
-                        $alt = htmlspecialchars($matches[1]);
-                        $title = htmlspecialchars($matches[3]);
+                        $alt = htmlspecialchars($matches[1] ?? '');
+                        $title = htmlspecialchars($matches[3] ?? '');
 
                         return '<img loading="lazy" class="img-responsive" src="' . $src . '" alt="' . $alt . '" ' . (empty($title) ? '' : 'title="' . $title . '"') . ' />';
                     }


### PR DESCRIPTION
## Description of pull request / Description de la demande d'ajout

I had this error due to an image without alt text on a php8.3 setup:
```
Warning: Undefined array key 3 in /var/www/html/formatters/wakka.php on line 420

Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/formatters/wakka.php on line 420
```

With this in the template
```
![](https://www.chatons.org//sites/default/files/uploads/engrenage_jaune.svg)
```

Sometimes it's legitimate to have no alt text configured (for some icons with a label for example) or image decorative with no need of description.

This PR fix this deprecated message.

