### PR TITLE
fix(ApiController): remove specific weird code for subtitle properties

### DIFF
--- a/tools/bazar/controllers/ApiController.php
+++ b/tools/bazar/controllers/ApiController.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
+use YesWiki\Bazar\Field\TextareaField;
 use YesWiki\Bazar\Service\BazarListService;
 use YesWiki\Bazar\Service\EntryExtraFieldsService;
 use YesWiki\Bazar\Service\EntryManager;
@@ -328,19 +329,20 @@ class ApiController extends YesWikiController
         // Reduce the size of the data sent by transforming entries object into array
         // we use the $fieldMapping to transform back the data when receiving data in the front end
         $entryFieldsService = $this->getService(EntryExtraFieldsService::class);
-        $entries = array_map(function ($entry) use ($fieldList, $entryFieldsService) {
+        $entries = array_map(function ($entry) use ($fieldList, $entryFieldsService, $forms) {
             $entryFieldsService->setEntryId($entry['id_fiche']);
             $result = [];
-            foreach ($fieldList as $field) {
-                // Format subtitle (why?)
-                if (!empty($entry[$field]) && !empty($_GET['displayfields']['subtitle']) && $_GET['displayfields']['subtitle'] == $field) {
-                    $entry[$field] = $this->wiki->Format($entry[$field]);
+            foreach ($fieldList as $fieldName) {
+                // when the field is a TextareaField with the SYNTAX_WIKI syntax, transform the field value into HTML
+                $field = $this->getService(FormManager::class)->findFieldFromNameOrPropertyName($fieldName,$entry['id_typeannonce']);
+                if ($field && $field->getType() == 'textelong' && $field->getSyntax() == TextareaField::SYNTAX_WIKI){
+                    $entry[$fieldName] = $this->wiki->Format($entry[$fieldName]);
                 }
                 // handle specific fields like comments, reactions
-                if (empty($entry[$field])) {
-                    $entry[$field] = $entryFieldsService->get($field);
+                if (empty($entry[$fieldName])) {
+                    $entry[$fieldName] = $entryFieldsService->get($fieldName);
                 }
-                $result[] = $entry[$field] ?? null;
+                $result[] = $entry[$fieldName] ?? null;
             }
 
             return $result;


### PR DESCRIPTION
Ma PR concerne un bout de code dans `ApiController.php` de BazaR qui avait déjà été repéré sans savoir à quoi il sert (cf le commentaire) :

```
// Format subtitle (why?)
if (!empty($entry[$field]) && !empty($_GET['displayfields']['subtitle']) && $_GET['displayfields']['subtitle'] == $field) {
    $entry[$field] = $this->wiki->Format($entry[$field]);
}
```

Dans la plupart des cas, ce bout de code est inoffensif mais j'ai trouvé un cas où j'ai mis super longtemps pour comprendre pourquoi j'avais un bug.
Notamment, si le subtitle demandé est un checkbox entry field, si l'ID en question comporte 2 majuscules, le `$this->wiki->Format` vient modifier la chaîne de caractère pour la remplacer par un lien html. Cela empêche ensuite le champ subtitle de s'afficher dans l'affichage d'une liste sous la forme de blocs.

Je propose de supprimer ce code pour que ce type de cas ne se reproduise plus. Toutefois si vous avez une explication plausible de pourquoi ce code très spécifique a été mis là, je suis preneur :smile: 