### PR TITLE
Make filters sorting insensitive to case and accent

### DIFF
--- a/tools/bazar/services/BazarListService.php
+++ b/tools/bazar/services/BazarListService.php
@@ -210,7 +210,12 @@ class BazarListService
                 $filter['title'] = $propName == 'owner' ? _t('BAZ_CREATOR') : $propName;
                 // We collect all values
                 $uniqValues = array_unique(array_column($entries, $propName));
-                sort($uniqValues);
+
+                usort($uniqValues, function($a, $b)
+				{
+				    return strcmp(strtolower(iconv('UTF-8', 'ASCII//TRANSLIT', $a)), strtolower(iconv('UTF-8', 'ASCII//TRANSLIT', $b)));
+				});
+                
                 foreach ($uniqValues as $value) {
                     $filter['nodes'][] = $this->createFilterNode($value, $value);
                 }


### PR DESCRIPTION
When displaying filters of text field (for example) in bazarlist, use a natural sorting method :
ex : Afficher 
Amélanchier 1
amélanchier 2
Tilleul à grandes feuilles
Tilleul argenté
Tilleul de Henry

Plutot que : 

Amélanchier 1
Tilleul argenté
Tilleul de Henry
**Tilleul à grandes feuilles**
**amélanchier 2**

