### PR TITLE
Correct bug not displaying filters for values with special chars like…

### DIFF
--- a/tools/bazar/presentation/javascripts/entries-index-dynamic.js
+++ b/tools/bazar/presentation/javascripts/entries-index-dynamic.js
@@ -197,7 +197,20 @@ const load = (domElement) => {
               let entryValues = entry[filter.propName]
               if (!entryValues || typeof entryValues != 'string') return
               entryValues = entryValues.split(',')
-              return entryValues.some((value) => value == node.value)
+              return entryValues.some(function (value)
+              {
+              	if (typeof (value) == "string")
+              	{
+              		return (value
+            	  	.replace(/&/g, '&amp;')
+				          .replace(/</g, '&lt;')
+				          .replace(/>/g, '&gt;')
+				          .replace(/"/g, '&quot;')
+				          .replace(/'/g, '&#039;') == node.value);
+              	}
+              	else              	
+	               return (value == node.value);
+              });
             }).length
           })
         })


### PR DESCRIPTION
When displaying filters for text values (ie : neither radio, checkbox, etc..), filters are not displayed for values containing special characters like quote.

Ex : "Figuier goutte d'or"

Ceci est du au fait que lors de la préparation du noeud dans BazarListService.php la valeur du noeud est transformée avec htmlspecialchars :

private function createFilterNode($value, $label)
    {
        return [
            'value' => **htmlspecialchars**($value),
            'label' => $label,
            'children' => [],
        ];
    }
    
 Dans le traitement coté client, la comparaison utilise la valeur non transformée.
 
 calculateFiltersCount() {
        this.filters.forEach((filter) => {
          filter.flattenNodes.forEach((node) => {
            node.count = this.searchedEntries.filter((entry) => {
              let entryValues = entry[filter.propName]
              if (!entryValues || typeof entryValues != 'string') return
              entryValues = entryValues.split(',')
              return entryValues.some((value) => **value == node.value**)
            }).length
          })
        })
      },
      
      
  Le bug est corrigé en remplacant également les caractères spéciaux avant de faire le test : 
             return entryValues.some(function (value)
              {
              	**if (typeof (value) == "string")
              	{
              		return (value
            	  	.replace(/&/g, '&amp;')
				    .replace(/</g, '&lt;')
				    .replace(/>/g, '&gt;')
				    .replace(/"/g, '&quot;')
				    .replace(/'/g, '&#039;') == node.value);
              	}
              	else**              	
	               return (value == node.value);
              });