### PR TITLE
Allows route like /api/forms/1, 2/entries/...

### DIFF
--- a/tools/bazar/controllers/ApiController.php
+++ b/tools/bazar/controllers/ApiController.php
@@ -50,7 +50,7 @@ class ApiController extends YesWikiController
     public function getAllFormEntries($formId, $output = null, $selectedEntries = null)
     {
         $entries = $this->getService(EntryManager::class)->search([
-            'formsIds' => $formId,
+            'formsIds' => (is_array ($formId)?$formId:array_map ('trim', explode (",", $formId))), // allows route like /api/forms/1, 2/entries/...
             'queries' => $this->getService(EntryController::class)
                 ->formatQuery(!empty($selectedEntries) ? ['query' => ['id_fiche' => $selectedEntries]] : [], $_GET),
             'minDate' => $_GET['dateMin'] ?? '',


### PR DESCRIPTION
Allows route like /api/forms/{formId1}, {formId2} , {formId3}/entries/... which will return entries from several forms 
Note : it will be used for JSON export buttons since the export can be associated with several forms ids.

## Description of pull request / Description de la demande d'ajout

Describe what it does / Expliquer ce que cela fait
Issue references (if exists)/ Demande associée (si elle existe)
