### PR TITLE
Add multiple form ids support to the rss handler

### DIFF
--- a/tools/bazar/handlers/RssHandler.php
+++ b/tools/bazar/handlers/RssHandler.php
@@ -11,26 +11,45 @@ class RssHandler extends YesWikiHandler
 {
     public function run()
     {
-        if (!$this->wiki->HasAccess('read') || !$this->wiki->page) {
+    try 
+    {
+        if (!$this->wiki->HasAccess('read') || !$this->wiki->page) {  	return "tote";
             return null;
         }
 
-        $urlrss = $this->wiki->href('rss');
+        // urlrss is never used : $urlrss = $this->wiki->href('rss');
+
         $securityController = $this->getService(SecurityController::class);
+
         if (isset($_GET['id'])) {
-            $id = $securityController->filterInput(INPUT_GET, 'id', FILTER_DEFAULT, true);
+            $id = $securityController->filterInput(INPUT_GET, 'id', FILTER_DEFAULT, true, "string", [ "flags" => FILTER_FORCE_ARRAY ]);
         } elseif (isset($_GET['id_typeannonce'])) {
-            $id = $securityController->filterInput(INPUT_GET, 'id_typeannonce', FILTER_DEFAULT, true);
-        }
-        if (!empty($id) && strval($id) == strval(intval($id))) {
-            $urlrss .= '&amp;id=' . $id;
-        } else {
-            $id = '';
+            $id = $securityController->filterInput(INPUT_GET, 'id_typeannonce', FILTER_DEFAULT, true, "string", [ "flags" => FILTER_FORCE_ARRAY ]);
         }
 
+		if ($id == null)
+		{
+			$id = '';
+		}
+		else
+		{
+			foreach ($id as $vID)
+			{
+				if (strval($vID) == strval(intval($vID)))
+				{
+		            // urlrss is never used : $urlrss .= '&amp;id=' . $vID;
+		        }
+		        else
+		        {
+		            $id = '';
+		            break;
+		        }	
+			}
+		}
+        
         if (isset($_GET['nbitem'])) {
             $nbitem = $_GET['nbitem'];
-            $urlrss .= '&amp;nbitem=' . $nbitem;
+            // urlrss is never used : $urlrss .= '&amp;nbitem=' . $nbitem;
         } else {
             $nbitem = $this->wiki->config['BAZ_NB_ENTREES_FLUX_RSS'];
         }
@@ -46,12 +65,12 @@ class RssHandler extends YesWikiHandler
         $q = '';
         if (isset($_GET['q']) and !empty($_GET['q'])) {
             $q = $_GET['q'];
-            $urlrss .= '&amp;q=' . $q;
+            //$urlrss .= '&amp;q=' . $q;
         }
 
         if (isset($_GET['query'])) {
             $query = $_GET['query'];
-            $urlrss .= '&amp;query=' . $query;
+            // urlrss is never used : $urlrss .= '&amp;query=' . $query;
             $tabquery = [];
             $tableau = [];
             $tab = explode('|', $query); //découpe la requete autour des |
@@ -64,6 +83,24 @@ class RssHandler extends YesWikiHandler
             $query = '';
         }
 
+		// ordre
+        $ordre = '';
+        if (isset($_GET['ordre']) and !empty($_GET['ordre'])) {
+            $ordre = $_GET['ordre'];
+            //$urlrss .= '&amp;q=' . $ordre;
+        }
+        else $ordre = "desc";
+        
+        
+        // champ
+        $champ = '';
+        if (isset($_GET['champ']) and !empty($_GET['champ'])) {
+            $champ = $_GET['champ'];
+            //$urlrss .= '&amp;q=' . $champ;
+        }
+        else
+	        $champ = 'date_creation_fiche';
+
         $tableau_flux_rss = $this->getService(EntryManager::class)->search(
             [
                 'queries' => $query,
@@ -75,8 +112,8 @@ class RssHandler extends YesWikiHandler
             true  // use Guard
         );
 
-        $GLOBALS['ordre'] = 'desc';
-        $GLOBALS['champ'] = 'date_creation_fiche';
+        $GLOBALS['ordre'] = $ordre;
+        $GLOBALS['champ'] = $champ;
         usort($tableau_flux_rss, 'champCompare');
 
         // Limite le nombre de résultat au nombre de fiches demandées
@@ -183,6 +220,12 @@ class RssHandler extends YesWikiHandler
             . '" rel="self" type="application/rss+xml" />',
             $this->sanitize($xml, ENT_QUOTES, 'UTF-8')
         );
+        
+      }
+      catch (Exception $e) {
+   			return  'Caught exception: ' .  $e->getMessage() . "\n";
+		} 	
+       
     }
 
     private function sanitize($string)

--- a/tools/bazar/handlers/RssHandler.php
+++ b/tools/bazar/handlers/RssHandler.php
@@ -17,8 +17,6 @@ class RssHandler extends YesWikiHandler
             return null;
         }
 
-        // urlrss is never used : $urlrss = $this->wiki->href('rss');
-
         $securityController = $this->getService(SecurityController::class);
 
         if (isset($_GET['id'])) {
@@ -35,12 +33,8 @@ class RssHandler extends YesWikiHandler
 		{
 			foreach ($id as $vID)
 			{
-				if (strval($vID) == strval(intval($vID)))
-				{
-		            // urlrss is never used : $urlrss .= '&amp;id=' . $vID;
-		        }
-		        else
-		        {
+				if (strval($vID) != strval(intval($vID)))
+				{		            
 		            $id = '';
 		            break;
 		        }	
@@ -48,15 +42,13 @@ class RssHandler extends YesWikiHandler
 		}
         
         if (isset($_GET['nbitem'])) {
-            $nbitem = $_GET['nbitem'];
-            // urlrss is never used : $urlrss .= '&amp;nbitem=' . $nbitem;
+            $nbitem = $_GET['nbitem'];            
         } else {
             $nbitem = $this->wiki->config['BAZ_NB_ENTREES_FLUX_RSS'];
         }
 
         if (isset($_GET['utilisateur'])) {
-            $utilisateur = $_GET['utilisateur'];
-            $urlrss .= '&amp;utilisateur=' . $utilisateur;
+            $utilisateur = $_GET['utilisateur'];            
         } else {
             $utilisateur = '';
         }
@@ -64,13 +56,11 @@ class RssHandler extends YesWikiHandler
         // chaine de recherche
         $q = '';
         if (isset($_GET['q']) and !empty($_GET['q'])) {
-            $q = $_GET['q'];
-            //$urlrss .= '&amp;q=' . $q;
+            $q = $_GET['q'];            
         }
 
         if (isset($_GET['query'])) {
-            $query = $_GET['query'];
-            // urlrss is never used : $urlrss .= '&amp;query=' . $query;
+            $query = $_GET['query'];            
             $tabquery = [];
             $tableau = [];
             $tab = explode('|', $query); //découpe la requete autour des |
@@ -84,22 +74,10 @@ class RssHandler extends YesWikiHandler
         }
 
 		// ordre
-        $ordre = '';
-        if (isset($_GET['ordre']) and !empty($_GET['ordre'])) {
-            $ordre = $_GET['ordre'];
-            //$urlrss .= '&amp;q=' . $ordre;
-        }
-        else $ordre = "desc";
-        
-        
+        $ordre = "desc";
+    
         // champ
-        $champ = '';
-        if (isset($_GET['champ']) and !empty($_GET['champ'])) {
-            $champ = $_GET['champ'];
-            //$urlrss .= '&amp;q=' . $champ;
-        }
-        else
-	        $champ = 'date_creation_fiche';
+        $champ = 'date_creation_fiche';
 
         $tableau_flux_rss = $this->getService(EntryManager::class)->search(
             [

--- a/tools/security/controllers/SecurityController.php
+++ b/tools/security/controllers/SecurityController.php
@@ -8,55 +8,6 @@ use YesWiki\Core\Service\TemplateEngine;
 use YesWiki\Core\YesWikiController;
 use YesWiki\Security\Controller\CaptchaController;
 
-if (!function_exists('security_sanitize'))
-{
-	function security_sanitize ($pRawInputFiltered, $pSanitizedFormat)
-	{         	
-
-		/**
-		 * @var mixed $result
-		 */
-			
-		$result = null;
-		switch ($pSanitizedFormat) {
-		    case 'string':
-		        $result = (
-		            in_array($pRawInputFiltered, [false, null], true)
-		            || !is_scalar($pRawInputFiltered)
-		        )
-		            ? ''
-		            : (
-		                $emulateFilterSanitizeString
-		                ? htmlspecialchars(strip_tags(strval($pRawInputFiltered)))
-		                : strval($pRawInputFiltered)
-		            );
-		        break;
-		    case 'int':
-		        $result = (
-		            in_array($pRawInputFiltered, [false, null], true)
-		            || !is_scalar($pRawInputFiltered)
-		        )
-		            ? 0
-		            : intval($pRawInputFiltered);
-		        break;
-		    case 'bool':
-		        $result = in_array($pRawInputFiltered, [false, null, 0, 'false', '0'], true)
-		            ? false
-		            : (
-		                in_array($pRawInputFiltered, [true, 'true', 1], true)
-		                ? true
-		                : boolval($pRawInputFiltered)
-		            );
-		        break;
-		    default:
-		        $result = $pRawInputFiltered;
-		        break;
-		}
-
-		return $result;
-	}
-}
-
 class SecurityController extends YesWikiController
 {
     // this value cannot be changed because use by extensions
@@ -233,6 +184,60 @@ class SecurityController extends YesWikiController
         return $champsCaptcha;
     }
 
+	/**
+     * Sanitize raw input values 
+     * @$pRawInputFiltered : the original value returned by PHP filter input
+     * @$pSanitizedFormat : the format to check
+     * supported format string, int, bool
+     * if the format is not specified, the function return the original $pRawInputFiltered
+     */
+
+	private function sanitize ($pRawInputFiltered, $pSanitizedFormat)
+	{         	
+
+		/**
+		 * @var mixed $result
+		 */
+			
+		$result = null;
+		switch ($pSanitizedFormat) {
+		    case 'string':
+		        $result = (
+		            in_array($pRawInputFiltered, [false, null], true)
+		            || !is_scalar($pRawInputFiltered)
+		        )
+		            ? ''
+		            : (
+		                $emulateFilterSanitizeString
+		                ? htmlspecialchars(strip_tags(strval($pRawInputFiltered)))
+		                : strval($pRawInputFiltered)
+		            );
+		        break;
+		    case 'int':
+		        $result = (
+		            in_array($pRawInputFiltered, [false, null], true)
+		            || !is_scalar($pRawInputFiltered)
+		        )
+		            ? 0
+		            : intval($pRawInputFiltered);
+		        break;
+		    case 'bool':
+		        $result = in_array($pRawInputFiltered, [false, null, 0, 'false', '0'], true)
+		            ? false
+		            : (
+		                in_array($pRawInputFiltered, [true, 'true', 1], true)
+		                ? true
+		                : boolval($pRawInputFiltered)
+		            );
+		        break;
+		    default:
+		        $result = $pRawInputFiltered;
+		        break;
+		}
+
+		return $result;
+	}
+
     /**
      * retrieve input using filter to prevent injection from other php script
      * emulate $filter = FILTER_SANITIZE_STRING because deprecated since php8.1.
@@ -276,14 +281,14 @@ class SecurityController extends YesWikiController
  	
 			foreach ($rawInputFiltered as $vKey => $vValue)
 			{
-				$vSanitizedArray [$vKey] = security_sanitize ($vValue, $sanitizedFormat);
+				$vSanitizedArray [$vKey] = $this->sanitize ($vValue, $sanitizedFormat);
 			}
 			
 			return $vSanitizedArray;
 		}
 		else
 		{			
-			return security_sanitize ($rawInputFiltered, $sanitizedFormat);
+			return $this->sanitize ($rawInputFiltered, $sanitizedFormat);
 		}		
     }
 }

--- a/tools/security/controllers/SecurityController.php
+++ b/tools/security/controllers/SecurityController.php
@@ -6,6 +6,56 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use YesWiki\Core\Controller\AuthController;
 use YesWiki\Core\Service\TemplateEngine;
 use YesWiki\Core\YesWikiController;
+use YesWiki\Security\Controller\CaptchaController;
+
+if (!function_exists('security_sanitize'))
+{
+	function security_sanitize ($pRawInputFiltered, $pSanitizedFormat)
+	{         	
+
+		/**
+		 * @var mixed $result
+		 */
+			
+		$result = null;
+		switch ($pSanitizedFormat) {
+		    case 'string':
+		        $result = (
+		            in_array($pRawInputFiltered, [false, null], true)
+		            || !is_scalar($pRawInputFiltered)
+		        )
+		            ? ''
+		            : (
+		                $emulateFilterSanitizeString
+		                ? htmlspecialchars(strip_tags(strval($pRawInputFiltered)))
+		                : strval($pRawInputFiltered)
+		            );
+		        break;
+		    case 'int':
+		        $result = (
+		            in_array($pRawInputFiltered, [false, null], true)
+		            || !is_scalar($pRawInputFiltered)
+		        )
+		            ? 0
+		            : intval($pRawInputFiltered);
+		        break;
+		    case 'bool':
+		        $result = in_array($pRawInputFiltered, [false, null, 0, 'false', '0'], true)
+		            ? false
+		            : (
+		                in_array($pRawInputFiltered, [true, 'true', 1], true)
+		                ? true
+		                : boolval($pRawInputFiltered)
+		            );
+		        break;
+		    default:
+		        $result = $pRawInputFiltered;
+		        break;
+		}
+
+		return $result;
+	}
+}
 
 class SecurityController extends YesWikiController
 {
@@ -215,52 +265,6 @@ class SecurityController extends YesWikiController
 		*/
 		$rawInputFiltered = filter_input($type, $varName, $filter, $options);
  
-		function sanitize ($pRawInputFiltered, $pSanitizedFormat)
-		{         	
-		
-			/**
-		     * @var mixed $result
-		     */
-				
-		    $result = null;
-		    switch ($pSanitizedFormat) {
-		        case 'string':
-		            $result = (
-		                in_array($pRawInputFiltered, [false, null], true)
-		                || !is_scalar($pRawInputFiltered)
-		            )
-		                ? ''
-		                : (
-		                    $emulateFilterSanitizeString
-		                    ? htmlspecialchars(strip_tags(strval($pRawInputFiltered)))
-		                    : strval($pRawInputFiltered)
-		                );
-		            break;
-		        case 'int':
-		            $result = (
-		                in_array($pRawInputFiltered, [false, null], true)
-		                || !is_scalar($pRawInputFiltered)
-		            )
-		                ? 0
-		                : intval($pRawInputFiltered);
-		            break;
-		        case 'bool':
-		            $result = in_array($pRawInputFiltered, [false, null, 0, 'false', '0'], true)
-		                ? false
-		                : (
-		                    in_array($pRawInputFiltered, [true, 'true', 1], true)
-		                    ? true
-		                    : boolval($pRawInputFiltered)
-		                );
-		            break;
-		        default:
-		            $result = $pRawInputFiltered;
-		            break;
-		    }
-
-		    return $result;
-		}
-		
         if ($options["flags"] & FILTER_REQUIRE_ARRAY || $options["flags"] & FILTER_FORCE_ARRAY)
 		{			
 			$vSanitizedArray = [];
@@ -272,14 +276,14 @@ class SecurityController extends YesWikiController
  	
 			foreach ($rawInputFiltered as $vKey => $vValue)
 			{
-				$vSanitizedArray [$vKey] = sanitize ($vValue, $sanitizedFormat);
+				$vSanitizedArray [$vKey] = security_sanitize ($vValue, $sanitizedFormat);
 			}
 			
 			return $vSanitizedArray;
 		}
 		else
 		{			
-			return sanitize ($rawInputFiltered, $sanitizedFormat);
+			return security_sanitize ($rawInputFiltered, $sanitizedFormat);
 		}		
     }
 }

--- a/tools/security/controllers/SecurityController.php
+++ b/tools/security/controllers/SecurityController.php
@@ -209,50 +209,77 @@ class SecurityController extends YesWikiController
          * @var string $sanitizedFormat
          */
         $sanitizedFormat = $emulateFilterSanitizeString ? 'string' : $format;
+         
         /**
-         * @var mixed $rawInputFiltered
-         */
-        $rawInputFiltered = filter_input($type, $varName, $filter, $options);
+		* @var mixed $rawInputFiltered
+		*/
+		$rawInputFiltered = filter_input($type, $varName, $filter, $options);
+ 
+		function sanitize ($pRawInputFiltered, $pSanitizedFormat)
+		{         	
+		
+			/**
+		     * @var mixed $result
+		     */
+				
+		    $result = null;
+		    switch ($pSanitizedFormat) {
+		        case 'string':
+		            $result = (
+		                in_array($pRawInputFiltered, [false, null], true)
+		                || !is_scalar($pRawInputFiltered)
+		            )
+		                ? ''
+		                : (
+		                    $emulateFilterSanitizeString
+		                    ? htmlspecialchars(strip_tags(strval($pRawInputFiltered)))
+		                    : strval($pRawInputFiltered)
+		                );
+		            break;
+		        case 'int':
+		            $result = (
+		                in_array($pRawInputFiltered, [false, null], true)
+		                || !is_scalar($pRawInputFiltered)
+		            )
+		                ? 0
+		                : intval($pRawInputFiltered);
+		            break;
+		        case 'bool':
+		            $result = in_array($pRawInputFiltered, [false, null, 0, 'false', '0'], true)
+		                ? false
+		                : (
+		                    in_array($pRawInputFiltered, [true, 'true', 1], true)
+		                    ? true
+		                    : boolval($pRawInputFiltered)
+		                );
+		            break;
+		        default:
+		            $result = $pRawInputFiltered;
+		            break;
+		    }
 
-        /**
-         * @var mixed $result
-         */
-        $result = null;
-        switch ($sanitizedFormat) {
-            case 'string':
-                $result = (
-                    in_array($rawInputFiltered, [false, null], true)
-                    || !is_scalar($rawInputFiltered)
-                )
-                    ? ''
-                    : (
-                        $emulateFilterSanitizeString
-                        ? htmlspecialchars(strip_tags(strval($rawInputFiltered)))
-                        : strval($rawInputFiltered)
-                    );
-                break;
-            case 'int':
-                $result = (
-                    in_array($rawInputFiltered, [false, null], true)
-                    || !is_scalar($rawInputFiltered)
-                )
-                    ? 0
-                    : intval($rawInputFiltered);
-                break;
-            case 'bool':
-                $result = in_array($rawInputFiltered, [false, null, 0, 'false', '0'], true)
-                    ? false
-                    : (
-                        in_array($rawInputFiltered, [true, 'true', 1], true)
-                        ? true
-                        : boolval($rawInputFiltered)
-                    );
-                break;
-            default:
-                $result = $rawInputFiltered;
-                break;
-        }
-
-        return $result;
+		    return $result;
+		}
+		
+        if ($options["flags"] & FILTER_REQUIRE_ARRAY || $options["flags"] & FILTER_FORCE_ARRAY)
+		{			
+			$vSanitizedArray = [];
+		
+			if ($rawInputFiltered === false || $rawInputFiltered === null)
+	 		{
+	 			return null;
+	 		}
+ 	
+			foreach ($rawInputFiltered as $vKey => $vValue)
+			{
+				$vSanitizedArray [$vKey] = sanitize ($vValue, $sanitizedFormat);
+			}
+			
+			return $vSanitizedArray;
+		}
+		else
+		{			
+			return sanitize ($rawInputFiltered, $sanitizedFormat);
+		}		
     }
 }


### PR DESCRIPTION
RSS handler didn't accept array of ids while export_buttons did.

RSS handler support now arrays of ids as parameters :

Additionaly, it supports now champ and ordre hash parameters.

 /?example/rss&id[0]=12&id[1]=13#champ=bf_nom&ordre="asc"


