### PR TITLE
Correct wrong searchfields handling

### DIFF
--- a/tools/bazar/controllers/ApiController.php
+++ b/tools/bazar/controllers/ApiController.php
@@ -247,9 +247,9 @@ class ApiController extends YesWikiController
             return ($value === 'true') ? true : (($value === 'false') ? false : $value);
         }, $_GET);
 
-        // format search field
-        $searchfields = isset($GET['search']) && $_GET['search'] == 'dynamic' ? $_GET['searchfields'] ?? [] : [];
-        $searchfields = (empty($searchfields) || !is_string($searchfields) || !is_array($searchfields))
+        $searchfields = isset($_GET['search']) && $_GET['search'] == 'dynamic' ? $_GET['searchfields'] ?? [] : [];
+       
+        $searchfields = (empty($searchfields) || (!is_string($searchfields) && !is_array($searchfields)))
             ? ['bf_titre']
             : (
                 is_string($searchfields)


### PR DESCRIPTION
Quelques petites erreurs dans le code ($GET au lieu de $_GET, et une condition incorrecte), éliminaient les searchfields de la requête ce qui produisait qu'on ne pouvait pas chercher sur ces champs.

## Description of pull request / Description de la demande d'ajout

Describe what it does / Expliquer ce que cela fait
Issue references (if exists)/ Demande associée (si elle existe)
