### PR TITLE
Convert relative URLs contained in entries provided by rss handler to absolute URLs

### DIFF
--- a/includes/urlutils.inc.php
+++ b/includes/urlutils.inc.php
@@ -123,3 +123,95 @@ function testRefererUrlInIframe()
 
     return $iframe ? 'iframe' : '';
 }
+
+/**
+ * Test si une URL est locale
+ *
+ * @param string $pURL l'url à tester.
+ * 
+ * @return boolean true if URL is local, false otherwise
+ */
+
+function isLocalUrl ($pURL)
+{
+	$vParsed = parse_url($pURL);
+
+	if ($vParsed === false) return true;
+	else
+	if ($vParsed["scheme"] . "://" . $vParsed["host"] . ":" . $vParsed["port"] == getRootUrl())
+		return true;
+	else
+		return false;
+}
+
+/**
+ * Résout une URL en une URL absolue en se basant sur une URL de référence.
+ *
+ * @param string $pPageAbsoluteURL L'URL absolue du document contenant le lien (ex: "https://exemple.com/chemin/page.html")
+ * @param string $pLink Le href trouvé dans le fichier (ex: "../img/photo.jpg" ou "/css/style.css" ou "https://autre.com/")
+ * @return string L'URL absolue résolue.
+ */
+function getAbsoluteURLForLinkInAPage ($pPageAbsoluteURL, $pLink)
+{
+    // Si $pLink est déjà absolu, on le retourne tel quel.
+    if (parse_url($pLink, PHP_URL_SCHEME) !== null) {
+        return $pLink;
+    }
+
+    // Parse l'url absolue de la page
+    $vPageParts = parse_url($pPageAbsoluteURL);
+    if ($vPageParts === false || !isset($vPageParts['scheme'], $vPageParts['host'])) {
+        throw new InvalidArgumentException("URL de base invalide : $pPageAbsoluteURL");
+    }
+
+    // Construction du chemin de base
+    $vBasePath = $vPageParts['vPath'] ?? '/';
+    // Si la base finit par un fichier, on enlève tout après le dernier '/'
+    if (substr($vBasePath, -1) !== '/') {
+        $vBasePath = substr($vBasePath, 0, strrpos($vBasePath, '/') + 1);
+    }
+
+    // Si le relatif commence par '/', c'est à partir du root
+    if (str_starts_with($pLink, '/')) {
+        $vPath = $pLink;
+    } else {
+        $vPath = $vBasePath . $pLink;
+    }
+
+    // Normalisation des vSegments (./, ../)
+    $vSegments = explode('/', $vPath);
+    $vResolved = [];
+    foreach ($vSegments as $vSegment) {
+        if ($vSegment === '' || $vSegment === '.') {
+            // ignore
+            if ($vSegment === '' && empty($vResolved)) {
+                // conserver les premières slashs pour les cas comme "/foo"
+                $vResolved[] = '';
+            }
+            continue;
+        }
+        if ($vSegment === '..') {
+            if (count($vResolved) > 1 || (count($vResolved) === 1 && $vResolved[0] !== '')) {
+                array_pop($vResolved);
+            }
+            continue;
+        }
+        $vResolved[] = $vSegment;
+    }
+
+    $vNormalizedPath = implode('/', $vResolved);
+    // Gérer le cas où on veut un slash final si le dernier vSegment était vide
+    if (str_ends_with($vPath, '/') && !str_ends_with($vNormalizedPath, '/')) {
+        $vNormalizedPath .= '/';
+    }
+
+    // Reconstruire l'URL
+    $vAbsolutePath = $vPageParts['scheme'] . '://' . $vPageParts['host'];
+    if (isset($vPageParts['port'])) {
+        $vAbsolutePath .= ':' . $vPageParts['port'];
+    }
+    
+    $vAbsolutePath .= $vNormalizedPath;
+
+    return $vAbsolutePath;
+}

--- a/tools/bazar/handlers/RssHandler.php
+++ b/tools/bazar/handlers/RssHandler.php
@@ -155,7 +155,7 @@ class RssHandler extends YesWikiHandler
                         '<![CDATA[' . preg_replace(
                         '/data-id=".*"/Ui',
                         '',
-                        $this->sanitize($this->getService(EntryController::class)->view($ligne))
+                        $this->sanitize($this->updateRelativeLinks ($this->getService(EntryController::class)->view($ligne), $this->wiki->href('', $ligne['id_fiche'])))
                     ) . ']]>'
                     );
                     $xml .= "\r\n        ";
@@ -205,4 +205,21 @@ class RssHandler extends YesWikiHandler
 
         return $string;
     }
+
+    private function updateRelativeLinks ($pBody, $pPageURL)
+    {
+    	$vBody = $pBody;
+
+    	$pattern = '~(<a[[:blank:]]*[^>]*[[:blank:]]*href[[:blank:]]*=[[:blank:]]*)(["\'])(.*?)(\2)([^>]*>)~m';
+
+    	if (preg_match_all($pattern, $vBody, $matches)) { 
+
+		    foreach ($matches[3] as $vKey => $vURL) {        	       
+				$vAbsoluteURL = getAbsoluteURLForLinkInAPage ($pPageURL, $vURL);
+				$vBody = str_replace($matches[0][$vKey], $matches[1][$vKey] . $matches[2][$vKey] . $vAbsoluteURL . $matches[2][$vKey] . $matches[5][$vKey], $vBody);
+		    }        
+	    }
+
+    	return $vBody;
+    }    
 }


### PR DESCRIPTION
Ensure all HREF in entries are absolute by replacing relative URL relatively to the parent entry URL