### PR TITLE
Refactor fields format values before save

### DIFF
--- a/tools/bazar/fields/AclField.php
+++ b/tools/bazar/fields/AclField.php
@@ -123,8 +123,8 @@ class AclField extends BazarField
             return (!empty($this->propertyName))
             ? [
                 'fields-to-remove' => [
-                    $this->propertyName,
-                ],
+                    $this->propertyName
+                ]
             ]
             : [];
         }

--- a/tools/bazar/fields/BazarField.php
+++ b/tools/bazar/fields/BazarField.php
@@ -115,25 +115,42 @@ abstract class BazarField implements \JsonSerializable
     public function renderInputIfPermitted($entry)
     {
         // Safety checks, must be run before every renderInput
-        if (!$this->canEdit($entry, !$entry)) {
+        if (!$this->canEdit($entry)) {
             return '';
         }
 
         return $this->renderInput($entry);
     }
 
-    public function formatValuesBeforeSaveIfEditable($entry, bool $isCreation = false)
+    public function formatValuesBeforeSaveIfEditable($entry)
     {
-        // this method is defined to check $this->canEdit with $isCreation
-        // without changing signature of formatValuesBeforeSave()
-        return $this->formatValuesBeforeSave($entry);
+        // Let's prevent creation of empty keys
+    
+    	if (empty($this->propertyName)) return [];
+    
+    	// Let's check if we are authorized to set or modify the field
+    	
+    	if ($this->canEdit ($entry))
+    	{
+    		// We can : let's return the formatted given value
+    	
+	    	return $this->formatValuesBeforeSave($entry);
+    	}    	
+    	else
+	{
+		// We cannot : let's return the default value
+		            
+		return [ $this->propertyName => $this->default ];
+	}        	
     }
 
     // Format input values before save
     public function formatValuesBeforeSave($entry)
     {
-        // to prevent creation of empty keys
-        return empty($this->propertyName) ? [] : [$this->propertyName => $this->getValue($entry)];
+	    // By default, let's return the value 
+	    // NOTE : The emptiness test is already done in formatValuesBeforeSaveIfEditable. Let's keep it for safety reason.
+    
+        return empty($this->propertyName) ? [] : [$this->propertyName => $this->getValue($entry)]; 
     }
 
     // Render the show view of the field
@@ -185,10 +202,12 @@ abstract class BazarField implements \JsonSerializable
         return empty($readAcl) || $this->getService(AclService::class)->check($readAcl, $userNameForRendering, true, $isCreation ? '' : $entry['id_fiche']);
     }
 
-    /* Return true if we are if editing is allowed for the field */
-    public function canEdit($entry, bool $isCreation = false)
+    /* Return true if editing is allowed for the field */
+    public function canEdit($entry)
     {
         $writeAcl = empty($this->writeAccess) ? '' : $this->writeAccess;
+
+		$isCreation = !$entry;
 
         return empty($writeAcl) || $this->getService(AclService::class)->check($writeAcl, null, true, $isCreation ? '' : $entry['id_fiche'], $isCreation ? 'creation' : 'edit');
     }

--- a/tools/bazar/fields/CheckboxField.php
+++ b/tools/bazar/fields/CheckboxField.php
@@ -94,33 +94,16 @@ abstract class CheckboxField extends EnumField
     }
 
     public function formatValuesBeforeSave($entry)
-    {
-        return $this->formatValuesBeforeSaveIfEditable($entry, false);
-    }
-
-    public function formatValuesBeforeSaveIfEditable($entry, bool $isCreation = false)
-    {
-        if ($this->canEdit($entry, $isCreation)) {
-            // get value
-            $checkboxField = $entry[$this->propertyName] ?? null;
-            // detect if from Form to check if clean field
-            if (isset($entry[$this->propertyName . self::FROM_FORM_ID])) {
-                $oldValue = $entry[$this->propertyName . self::FROM_FORM_ID];
-                $oldValue = ($oldValue == "''") ? '' : $oldValue;
-                if (!is_array($checkboxField) && ($checkboxField == $oldValue)) {
-                    $checkboxField = '';
-                }
-            }
-
-            // format value
-            $entry[$this->propertyName] = $this->sanitizeValues($checkboxField, 'string');
+    {       
+    	// Get the value
+    
+		$checkboxField = $this->getValue($entry);
+		
+		if ($checkboxField === null) return [];
+		else        
+        {
+        	return [ $this->propertyName => $this->sanitizeValues($checkboxField, 'string') ];
         }
-
-        return [$this->propertyName => $this->getValue($entry),
-            'fields-to-remove' => [
-                $this->propertyName . self::FROM_FORM_ID,
-                $this->propertyName,
-            ], ];
     }
 
     /**

--- a/tools/bazar/fields/MapField.php
+++ b/tools/bazar/fields/MapField.php
@@ -170,41 +170,16 @@ class MapField extends BazarField
 
     public function formatValuesBeforeSave($entry)
     {
-        return $this->formatValuesBeforeSaveIfEditable($entry, false);
-    }
-
-    public function formatValuesBeforeSaveIfEditable($entry, bool $isCreation = false)
-    {
-        if (!$this->canEdit($entry, $isCreation)) {
-            // retrieve value from value because redefined with right value
-
-            $values = $this->getValue($entry);
-
-            if (empty($values)) {
-                if (isset($entry[$this->getLatitudeField()])) {
-                    unset($entry[$this->getLatitudeField()]);
-                }
-                if (isset($entry[$this->getLongitudeField()])) {
-                    unset($entry[$this->getLongitudeField()]);
-                }
-            } else {
-                $entry[$this->getPropertyName()] = $values;
-                $entry[$this->getLatitudeField()] = $values[$this->getLatitudeField()];
-                $entry[$this->getLongitudeField()] = $values[$this->getLatitudeField()];
-            }
-        }
-
-        if (!empty($entry[$this->getLatitudeField()]) && !empty($entry[$this->getLongitudeField()])) {
-            $entry[$this->getPropertyName()] = [
+        $vValue = $this->getValue ($entry);
+        
+        if ($vValue && !empty($vValue[$this->getLatitudeField()]) && !empty($vValue[$this->getLongitudeField()]))
+		{
+            return
+            [
+                $this->getPropertyName() => $entry[$this->getPropertyName()],
                 $this->getLatitudeField() => $entry[$this->getLatitudeField()],
                 $this->getLongitudeField() => $entry[$this->getLongitudeField()],
-            ];
-
-            return [
-                $this->getPropertyName() => $entry[$this->getPropertyName()],
-                /*$this->getLatitudeField() => $entry[$this->getLatitudeField()],
-                $this->getLongitudeField() => $entry[$this->getLongitudeField()],*/
-                'fields-to-remove' => [$this->getLatitudeField(), $this->getLongitudeField(), 'carte_google'],
+                'fields-to-remove' => ['carte_google']
             ];
         } else {
             return [
@@ -212,7 +187,7 @@ class MapField extends BazarField
                     $this->getPropertyName(),
                     $this->getLatitudeField(),
                     $this->getLongitudeField(),
-                    'carte_google',
+                    'carte_google'
                 ],
             ];
         }

--- a/tools/bazar/fields/PasswordField.php
+++ b/tools/bazar/fields/PasswordField.php
@@ -22,26 +22,24 @@ class PasswordField extends BazarField
 
     public function formatValuesBeforeSave($entry)
     {
-        return $this->formatValuesBeforeSaveIfEditable($entry, false);
-    }
-
-    public function formatValuesBeforeSaveIfEditable($entry, bool $isCreation = false)
-    {
         $value = $this->getValue($entry);
-        if ($this->canEdit($entry, $isCreation)) {
-            if (!empty($value)) {
-                // If a new password has been set, encode it
-                return [$this->propertyName => md5($value),
-                    'fields-to-remove' => [$this->propertyName . '-previous'], ];
-            } else {
-                // If no new password was set, keep the old encoded one
-                return [$this->propertyName => $entry[$this->propertyName . '-previous'] ?? null,
-                    'fields-to-remove' => [$this->propertyName . '-previous'], ];
-            }
-        } else {
-            return [$this->propertyName => $value ?? null,
-                'fields-to-remove' => [$this->propertyName . '-previous'], ];
+
+        if (!empty($value))
+        {
+			// If a new password has been set, encode it
+            return [
+            			$this->propertyName => md5($value),
+                    	'fields-to-remove' => [$this->propertyName . '-previous' ]
+                   ];
         }
+        else
+        {
+			// If no new password was set, keep the old encoded one
+            return [
+            			$this->propertyName => $entry[$this->propertyName . '-previous'] ?? null,
+	                   'fields-to-remove' => [$this->propertyName . '-previous']
+	               ];         
+        }        
     }
 
     protected function renderStatic($entry)

--- a/tools/bazar/fields/TitleField.php
+++ b/tools/bazar/fields/TitleField.php
@@ -35,7 +35,9 @@ class TitleField extends BazarField
 
     public function formatValuesBeforeSave($entry)
     {
-        $dirtyHtml = $this->getValue($entry);
+
+        $dirtyHtml = $this->titleTemplate;//$this->getValue($entry);
+        
         $value = $this->getService(HtmlPurifierService::class)->cleanHTML($dirtyHtml);
         $formManager = $this->getService(FormManager::class);
 
@@ -49,7 +51,7 @@ class TitleField extends BazarField
                     $fieldValue = $field->getValue($entry);
                     if ($field instanceof CheckboxField) {
                         // get first value instead of keys
-                        $formattedValue = $field->formatValuesBeforeSaveIfEditable($entry)[$field->getPropertyName()];
+                        $formattedValue = $field->formatValuesBeforeSave($entry)[$field->getPropertyName()];
                         $fieldValues = $field->getValues([$field->getPropertyName() => $formattedValue]);
                         $replacement = $field->getOptions()[$fieldValues[0] ?? null] ?? '';
                     } elseif ($field instanceof TagsField) {

--- a/tools/bazar/services/EntryManager.php
+++ b/tools/bazar/services/EntryManager.php
@@ -36,6 +36,11 @@ class EntryManager
 
     public const TRIPLES_ENTRY_ID = 'fiche_bazar';
 
+	public const VALIDATE_FLAG_ANTISPAM = 		1 << 0;
+	public const VALIDATE_FLAG_BF_TITRE = 		1 << 1;	
+	public const VALIDATE_FLAG_ID_TYPEANNONCE =	1 << 2;
+	public const VALIDATE_FLAG_ALL =			self::VALIDATE_FLAG_ANTISPAM | self::VALIDATE_FLAG_BF_TITRE | self::VALIDATE_FLAG_ID_TYPEANNONCE;
+
     public function __construct(
         Wiki $wiki,
         Mailer $mailer,
@@ -206,21 +211,31 @@ class EntryManager
      *
      * @throws Exception
      */
-    public function validate($data)
+    public function validate($data, $pFlags = self::VALIDATE_FLAG_ALL)
     {
-        if (!isset($data['antispam']) or !$data['antispam'] == 1) {
-            throw new Exception(_t('BAZ_PROTECTION_ANTISPAM'));
-        }
+    	if ($pFlags & self::VALIDATE_FLAG_ANTISPAM)
+    	{    
+	        if (!isset($data['antispam']) or !$data['antispam'] == 1) {
+	            throw new Exception(_t('BAZ_PROTECTION_ANTISPAM'));
+	        }
+	    }
 
         // On teste le titre car ça peut bugguer sérieusement sans
-        if (!isset($data['bf_titre'])) {
-            throw new Exception(_t('BAZ_FICHE_NON_SAUVEE_PAS_DE_TITRE'));
-        }
+        
+        if ($pFlags & self::VALIDATE_FLAG_BF_TITRE)
+    	{            
+	        if (!isset($data['bf_titre'])) {
+	            throw new Exception(_t('BAZ_FICHE_NON_SAUVEE_PAS_DE_TITRE'));
+	        }
+	    }
 
-        // form metadata
-        if (!isset($data['id_typeannonce'])) {
-            throw new Exception(_t('BAZ_NO_FORMS_FOUND'));
-        }
+        if ($pFlags & self::VALIDATE_FLAG_ID_TYPEANNONCE)
+    	{            
+	        // form metadata
+	        if (!isset($data['id_typeannonce'])) {
+	            throw new Exception(_t('BAZ_NO_FORMS_FOUND'));
+	        }
+	    }
     }
 
     /**
@@ -240,16 +255,25 @@ class EntryManager
         if ($this->securityController->isWikiHibernated()) {
             throw new \Exception(_t('WIKI_IN_HIBERNATION'));
         }
+
         $data['id_typeannonce'] = "$formId"; // Must be a string
 
         if ($semantic) {
             $data = $this->semanticTransformer->convertFromSemanticData($formId, $data);
         }
 
-        $this->validate($data);
+		// We need to check antispam before if it is removed from data
+
+        $this->validate($data, self::VALIDATE_FLAG_ANTISPAM);
+
+		// Let's format the data
 
         $data = $this->formatDataBeforeSave($data, true);
-
+        
+        // We need to check bf_titre and id_typeannonce once the data are formated
+        
+        $this->validate($data, self::VALIDATE_FLAG_BF_TITRE | self::VALIDATE_FLAG_ID_TYPEANNONCE);
+        
         // on change provisoirement d'utilisateur
         if (isset($GLOBALS['utilisateur_wikini'])) {
             $olduser = $this->authController->getLoggedUser();
@@ -531,7 +555,7 @@ class EntryManager
      *
      * @throws Exception
      */
-    public function formatDataBeforeSave($data, bool $isCreation = false): array
+    public function formatDataBeforeSave($data): array
     {
         // not possible to init the formManager in the constructor because of circular reference problem
         $form = $this->wiki->services->get(FormManager::class)->getOne($data['id_typeannonce']);
@@ -539,26 +563,64 @@ class EntryManager
             throw new Exception('No form with id: ' . $data['id_typeannonce']);
         }
 
-        // If there is a title field, compute the entry's title
-        if (is_array($form['prepared'])) {
-            foreach ($form['prepared'] as $field) {
-                if ($field instanceof TitleField) {
-                    $data = array_merge($data, $field->formatValuesBeforeSaveIfEditable($data, $isCreation));
+		// We first need to ensure default values for uneditable fields are set
+		// so we can use it later to build the automatic title if necessary
+
+		foreach ($form['prepared'] as $bazarField)
+		{
+            if ($bazarField instanceof BazarField && !($bazarField instanceof TitleField))
+            {
+                $tab = $bazarField->formatValuesBeforeSaveIfEditable($data);
+            }
+
+            if (is_array($tab))
+            {
+                if (isset($tab['fields-to-remove']) and is_array($tab['fields-to-remove']))
+                {
+                    foreach ($tab['fields-to-remove'] as $field)
+                    {
+                        if (isset($data[$field]))
+                        {
+                            unset($data[$field]);
+                        }
+                    }
+                    unset($tab['fields-to-remove']);
+                }
+                $data = array_merge($data, $tab);
+            }
+        }
+        
+        // We can now build the field title if there is one        
+        
+        if (is_array($form['prepared']))
+        {
+            foreach ($form['prepared'] as $field)
+            {
+                if ($field instanceof TitleField)
+                {
+                    $data = array_merge($data, $field->formatValuesBeforeSave($data));
                 }
             }
         }
 
-        // Entry ID
-        if (!isset($data['id_fiche'])) {
+        // Let's generate fiche id if necessary
+        
+        if (!isset($data['id_fiche']))
+        {
             // Generate the ID from the title
-            if (empty($data['id_fiche'] = genere_nom_wiki($data['bf_titre']))) {
+            if (empty($data['id_fiche'] = genere_nom_wiki($data['bf_titre'])))
+            {
                 throw new Exception('$data[\'id_fiche\'] can not be generated from $data[\'bf_titre\'] !');
             }
             // TODO see if we can remove this
-            $_POST['id_fiche'] = $data['id_fiche'];
-        } elseif (empty($data['id_fiche'])) {
+            //$_POST['id_fiche'] = $data['id_fiche'];
+        }
+        elseif (empty($data['id_fiche']))
+        {
             throw new Exception('$data[\'id_fiche\'] is set but with empty value !');
         }
+
+		// Let's set the value of id_typeannonce
 
         $data['id_typeannonce'] = isset($data['id_typeannonce']) ? $data['id_typeannonce'] : $_REQUEST['id_typeannonce'];
 
@@ -573,24 +635,7 @@ class EntryManager
             $data['statut_fiche'] = $this->params->get('BAZ_ETAT_VALIDATION');
         }
 
-        foreach ($form['prepared'] as $bazarField) {
-            if ($bazarField instanceof BazarField) {
-                $tab = $bazarField->formatValuesBeforeSaveIfEditable($data, $isCreation);
-            }
-
-            if (is_array($tab)) {
-                if (isset($tab['fields-to-remove']) and is_array($tab['fields-to-remove'])) {
-                    foreach ($tab['fields-to-remove'] as $field) {
-                        if (isset($data[$field])) {
-                            unset($data[$field]);
-                        }
-                    }
-                    unset($tab['fields-to-remove']);
-                }
-                $data = array_merge($data, $tab);
-            }
-        }
-        // $data['id_fiche'] can not be empty
+        // Let's ensure $data['id_fiche'] is not empty
         if (empty($data['id_fiche'])) {
             throw new Exception('$data[\'id_fiche\'] is empty !');
         }


### PR DESCRIPTION
Refonte de la gestion des méthodes formatValuesBeforeSave, formatValuesBeforeSaveIfEditable, canEdit :

Il y avait une mauvaise gestion des droits d'accès aux champs lors de la création. Les champs non éditables étaient masqués afin d'empecher que l'utilisateur puisse les spécifier. Cependant, il demeurait possible de les créer avec une valeur spécifiée sans avoir les droits d'écriture dessus en utilisant une requete API.

Lors de la création, si les droits d'accès ne permettent pas de modifier une valeur alors c'est la valeur par défaut qui est utilisée.

La méthode formatValuesBeforeSaveIfEditable appelle bien BazarField::canEdit 
Les méthodes formatValuesBeforeSave sont spécifiques à chaque sous classe
Les sous classes ne redéfinissent par la méthode : formatValuesBeforeSaveIfEditable


