### PR TITLE
Remove unwanted fields in map popup

### DIFF
--- a/tools/bazar/templates/entries/index-dynamic-templates/_map_popup_from_data.twig
+++ b/tools/bazar/templates/entries/index-dynamic-templates/_map_popup_from_data.twig
@@ -1,7 +1,8 @@
 <template v-slot:popupentry ="{entry}">
   <div>
     <div class="popup-entry-content">
-      <template v-for="field in [{{ params.necessary_fields|filter(v => v not in ['url','bf_longitude','bf_latitude'])|map(p => "'#{p}'")|join(',')|raw }}]">
+	<div>
+      <template v-for="field in [{{ params.necessary_fields|filter(v => v not in ['url','bf_longitude','bf_latitude', 'geolocation', 'owner', 'date_creation_fiche', 'date_maj_fiche'])|map(p => "'#{p}'")|join(',')|raw }}]">
         {% set imWidth = 140 %}
         {% set imHeight = 140 %}
         {% set imagemethod = 'fit' %}


### PR DESCRIPTION
remove geolocation, owner, date_creation_fiche and date_maj_fiche from popup display

* remove geolocation as bf_latitude and bf_longitude were filtered
* remove fields that doesn't belong to form definition since it is displayed badly (without title) by the twig and that they are not useful.