### PR TITLE
fix(aceditor): make leaflet send HTTP Referer header that is required by OSM tile usage policy

### DIFF
--- a/tools/aceditor/presentation/javascripts/components/InputGeo.js
+++ b/tools/aceditor/presentation/javascripts/components/InputGeo.js
@@ -16,6 +16,7 @@ export default {
       zoom: this.defaultZoom,
       zoomControl: true,
       scrollWheelZoom: false,
+      referrerPolicy: 'strict-origin-when-cross-origin',
       layers: [L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors' })]
     })
 


### PR DESCRIPTION
## OSM tile provider requires a valid Referer header

See https://wiki.openstreetmap.org/wiki/Blocked_tiles


Cheers!